### PR TITLE
data: collect stats on patent years from paroutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ data/models/**/*.md
 data/analysis/**/*.html
 data/analysis/**/*.json
 data/analysis/**/*.txt
+data/analysis/**/*.png
 _backups/
 # AI
 _prompts/


### PR DESCRIPTION
### TL;DR

Added patent year extraction and visualization for PaRoutes dataset analysis.

### What changed?

- Enhanced `PaRoutesAdapter` to extract and track publication years from patent IDs
- Added regex patterns to parse different patent ID formats (modern US patents, pre-2001 grants, special administrative patents)
- Implemented statistics reporting for patent year distribution
- Created a visualization of yearly distribution using Plotly
- Added unit tests for the patent year parsing functionality

### How to test?

1. Run the `scripts/PaRoutes/1-convert-test-sets.py` script
2. Verify that a yearly distribution chart is generated at `data/analysis/yearly_distribution.png`
3. Check the logs for patent year statistics
4. Run the new unit tests with `pytest tests/adapters/test_paroutes_adapter.py::TestPaRoutesYearParsing`

### Why make this change?

This change enables temporal analysis of the PaRoutes dataset by extracting publication years from patent IDs. Understanding the temporal distribution of routes helps assess dataset freshness and potential biases in the training data. The visualization provides an immediate overview of when the synthetic routes were published, which is valuable for dataset characterization and quality assessment.