### PR TITLE
patch: allow user to specify format of stock (smiles vs inchi) and update synplanner scripts

### DIFF
--- a/scripts/synplanner/2-run-synp-eval.py
+++ b/scripts/synplanner/2-run-synp-eval.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # 2. Load Stock
     stock_path = STOCKS_DIR / f"{benchmark.stock_name}.csv.gz"
-    building_blocks = load_stock_file(stock_path)
+    building_blocks = load_stock_file(stock_path, return_as="smiles")
 
     # 3. Setup Output
     folder_name = "synplanner-eval" if args.effort == "normal" else f"synplanner-{args.effort}"

--- a/scripts/synplanner/3-run-synp-rollout.py
+++ b/scripts/synplanner/3-run-synp-rollout.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # 2. Load Stock
     stock_path = STOCKS_DIR / f"{benchmark.stock_name}.csv.gz"
-    building_blocks = load_stock_file(stock_path)
+    building_blocks = load_stock_file(stock_path, return_as="smiles")
 
     # 3. Setup Output
     folder_name = "synplanner-mcts" if args.effort == "normal" else f"synplanner-mcts-{args.effort}"

--- a/src/retrocast/cli/handlers.py
+++ b/src/retrocast/cli/handlers.py
@@ -173,7 +173,7 @@ def _score_single(model_name: str, benchmark_name: str, paths: dict, args: Any) 
             logger.error(f"Stock file missing: {stock_path}")
             return
 
-        stock_set = load_stock_file(stock_path)
+        stock_set = load_stock_file(stock_path, return_as="inchikey")
         predictions = load_routes(routes_path)
 
         # Load execution stats if available


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR extends `load_stock_file()` to support returning molecules as either InChI keys (default) or SMILES strings via a new `return_as` parameter. This enables different tools with different input requirements to share the same stock loading infrastructure.

- Enhanced `load_stock_file()` with type-safe overloads for `return_as="inchikey"` (default) and `return_as="smiles"`
- Updated synplanner scripts to use SMILES format, which the synplanner library requires
- Made CLI handler explicit about using InChI keys for scoring
- Added comprehensive test coverage for the new SMILES return mode
- Refactored test imports to module level (cleaner code organization)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - backwards compatible enhancement with comprehensive test coverage.
- The change is backwards compatible (default behavior unchanged), properly typed with overloads, includes validation for invalid parameters, and has thorough test coverage for all new functionality.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/retrocast/io/data.py | 5/5 | Core enhancement: `load_stock_file` now supports `return_as` parameter ("inchikey" or "smiles") with proper type overloads, validation, and backwards-compatible default behavior. |
| src/retrocast/cli/handlers.py | 5/5 | Explicit `return_as="inchikey"` added to scoring handler for clarity, maintaining existing behavior. |
| scripts/synplanner/2-run-synp-eval.py | 5/5 | Now uses `return_as="smiles"` to load stock in SMILES format for synplanner compatibility. |
| scripts/synplanner/3-run-synp-rollout.py | 5/5 | Now uses `return_as="smiles"` to load stock in SMILES format for synplanner compatibility. |
| tests/io/test_roundtrip.py | 5/5 | Added comprehensive tests for SMILES return mode (whitespace stripping, empty handling, invalid parameter), plus import refactoring. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Script as synplanner scripts
    participant Handler as CLI handlers
    participant DataIO as load_stock_file()
    participant CSV as Stock CSV.GZ

    Note over Script,CSV: Synplanner workflow (SMILES)
    Script->>DataIO: load_stock_file(path, return_as="smiles")
    DataIO->>CSV: read SMILES column
    CSV-->>DataIO: SMILES values
    DataIO-->>Script: set[SmilesStr]
    Script->>Script: Pass to synplan.Tree(building_blocks)

    Note over Handler,CSV: Scoring workflow (InChI keys)
    Handler->>DataIO: load_stock_file(path, return_as="inchikey")
    DataIO->>CSV: read InChIKey column
    CSV-->>DataIO: InChIKey values
    DataIO-->>Handler: set[InchiKeyStr]
    Handler->>Handler: Pass to score.score_model(stock)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->