### PR TITLE
feat: add structured error taxonomy for adapter, io, and cli boundaries

### DIFF
--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -139,7 +139,13 @@ An adapter may raise these expected errors from `cast`:
 | --- | --- | --- | --- |
 | `AdapterSchemaError` | `adapter.schema_invalid` | the raw target payload does not match the adapter's declared input schema | workflow records the failure for that target and continues |
 | `AdapterLogicError` | `adapter.target_mismatch` | a transformed route root does not match the benchmark target | adapter logs/skips that route when other routes may still be usable |
-| `AdapterLogicError` | `adapter.route_transform_failed` | route topology is impossible, cyclic, malformed, or missing required nodes | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.cycle_detected` | route graph revisits the same molecule in one path | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.node_type_invalid` | a bipartite graph node has the wrong role, such as molecule where reaction is required | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.node_missing` | graph edges reference a node absent from the raw lookup tables | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.route_string_empty` | a string-based route payload is empty after parsing | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.route_string_invalid` | a string-based route payload has malformed step boundaries or missing reactants/products | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.route_metadata_missing` | a route node needs model metadata to describe a reaction but it is absent or empty | adapter logs/skips that route when the failure is route-local |
+| `AdapterLogicError` | `adapter.route_transform_failed` | fallback for route-local transform failures that do not fit a narrower code | adapter logs/skips that route when the failure is route-local |
 | `UnsupportedAdapterFeatureError` | `adapter.unsupported_feature` | a valid request asks for a feature the adapter does not support | caller should treat this as a fatal configuration/request failure |
 | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | raw route molecules cannot be canonicalized or processed by RDKit | adapter logs/skips that route when the failure is route-local |
 
@@ -171,7 +177,7 @@ RetroCast relies on exact SMILES matching.
 
 Retrosynthetic graphs must be acyclic trees.
 
-- The standard helpers include cycle detection (raising `AdapterLogicError` if a node appears twice in a path)
+- The standard helpers include cycle detection (raising `AdapterLogicError` with `adapter.cycle_detected` if a node appears twice in a path)
 - If writing a custom builder, maintain a `visited` set during recursion
 
 ### 4. Metadata

--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -153,6 +153,92 @@ Adapter resolution happens before `cast` and raises `AdapterResolutionError` (`a
 
 Use `retrocast.adapters.errors.adapter_schema_error()` and `adapter_target_mismatch()` where they fit; they keep messages, codes, and context consistent.
 
+### Adapter Error Examples
+
+These examples use tiny fake payloads to show what each route-local code means.
+
+`adapter.cycle_detected`: the route graph loops back to a molecule already in the same path.
+
+```json
+{
+    "smiles": "CCO",
+    "children": [
+        {
+            "smiles": "CC=O",
+            "children": [{"smiles": "CCO", "children": []}]
+        }
+    ]
+}
+```
+
+`adapter.node_type_invalid`: a graph slot contains the wrong kind of node. Bipartite adapters expect molecule -> reaction -> molecule.
+
+```json
+{
+    "type": "mol",
+    "smiles": "CCO",
+    "children": [{"type": "mol", "smiles": "CC=O", "children": []}]
+}
+```
+
+`adapter.node_missing`: an edge/reference points to an id or SMILES key that is absent from the raw lookup tables.
+
+```json
+{
+    "uuid2smiles": {"root": "CCO", "rxn1": "CC=O>>CCO"},
+    "node_dict": {"CCO": {"type": "chemical", "smiles": "CCO"}},
+    "pathways": [[{"source": "root", "target": "rxn1"}]]
+}
+```
+
+Here `rxn1` resolves to `CC=O>>CCO`, but `node_dict["CC=O>>CCO"]` is missing.
+
+`adapter.route_string_empty`: a string-based route field is empty after trimming/splitting.
+
+```json
+{"succ": true, "routes": ""}
+```
+
+`adapter.route_string_invalid`: the route string exists, but its grammar is malformed.
+
+```json
+{"succ": true, "routes": "CCO>CC=O"}
+```
+
+RetroStar and DreamRetro-style route steps need product, metadata/reagents, and reactants, e.g. `CCO>0.9>CC=O.[H][H]`.
+
+`adapter.route_metadata_missing`: a non-leaf node needs reaction metadata to describe how children form the parent, but that metadata is absent or empty.
+
+```json
+{
+    "smiles": "CCO",
+    "is_purchasable": false,
+    "children": [{"smiles": "CC=O", "is_purchasable": true, "children": []}]
+}
+```
+
+For MolBuilder, that missing metadata is `best_disconnection`.
+
+`adapter.target_mismatch`: the adapter produced a valid route, but the root is not the benchmark target.
+
+```json
+{
+    "target_id": "ethanol",
+    "expected_smiles": "CCO",
+    "actual_root_smiles": "CCC"
+}
+```
+
+`adapter.schema_invalid`: the raw payload does not match the adapter's top-level expected schema.
+
+```json
+{"succ": true, "routes": 123}
+```
+
+If `routes` must be a string, this is schema-invalid.
+
+`adapter.route_transform_failed`: fallback for route-local transformation failures that do not fit a sharper bucket. If this shows up often in manifests or logs, promote the recurring case to a dedicated code.
+
 ### 1. Define Pydantic Schemas
 
 Always define Pydantic models for the **raw** input format. This separates validation logic from transformation logic and ensures bad data is rejected early.

--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -73,7 +73,7 @@ class MyAdapter(BaseAdapter):
                     continue
 
                 yield Route(target=target_mol, rank=i+1, metadata={})
-            except Exception:
+            except RetroCastException:
                 continue
 ```
 
@@ -128,6 +128,24 @@ Some models have unique structures that don't fit the above patterns (e.g., grap
     1. **Canonicalization** - Use `retrocast.chem.canonicalize_smiles` for all SMILES
     2. **Cycle detection** - Ensure no molecule appears twice in a path
     3. **Target validation** - Verify the root matches `target.smiles`
+
+## Adaptation Errors
+
+Adapter error `code` values are lowercase machine contracts. Keep adapter names in `context["adapter"]` lowercase so callers can aggregate by `ADAPTER_MAP` key. Human-facing messages should use proper model capitalization, such as `DreamRetro`, `DMS`, or `MolBuilder`.
+
+An adapter may raise these expected errors from `cast`:
+
+| exception | code | when it is raised | caller policy |
+| --- | --- | --- | --- |
+| `AdapterSchemaError` | `adapter.schema_invalid` | the raw target payload does not match the adapter's declared input schema | workflow records the failure for that target and continues |
+| `AdapterLogicError` | `adapter.target_mismatch` | a transformed route root does not match the benchmark target | adapter logs/skips that route when other routes may still be usable |
+| `AdapterLogicError` | `adapter.route_transform_failed` | route topology is impossible, cyclic, malformed, or missing required nodes | adapter logs/skips that route when the failure is route-local |
+| `UnsupportedAdapterFeatureError` | `adapter.unsupported_feature` | a valid request asks for a feature the adapter does not support | caller should treat this as a fatal configuration/request failure |
+| `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | raw route molecules cannot be canonicalized or processed by RDKit | adapter logs/skips that route when the failure is route-local |
+
+Adapter resolution happens before `cast` and raises `AdapterResolutionError` (`adapter.unknown` or `adapter.resolution_missing`) when the CLI or manifest cannot select an adapter.
+
+Use `retrocast.adapters.errors.adapter_schema_error()` and `adapter_target_mismatch()` where they fit; they keep messages, codes, and context consistent.
 
 ### 1. Define Pydantic Schemas
 
@@ -235,6 +253,6 @@ pytest tests/adapters/test_my_adapter.py
     The `BaseAdapterTest` automatically verifies that your adapter:
     
     1. Correctly parses valid data
-    2. Rejects invalid schemas without crashing (returns empty generator)
+    2. Rejects invalid schemas with `AdapterSchemaError`
     3. Correctly identifies target mismatches
     4. Handles failed predictions gracefully

--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -144,7 +144,6 @@ An adapter may raise these expected errors from `cast`:
 | `AdapterLogicError` | `adapter.node_missing` | graph edges reference a node absent from the raw lookup tables | adapter logs/skips that route when the failure is route-local |
 | `AdapterLogicError` | `adapter.route_string_empty` | a string-based route payload is empty after parsing | adapter logs/skips that route when the failure is route-local |
 | `AdapterLogicError` | `adapter.route_string_invalid` | a string-based route payload has malformed step boundaries or missing reactants/products | adapter logs/skips that route when the failure is route-local |
-| `AdapterLogicError` | `adapter.route_metadata_missing` | a route node needs model metadata to describe a reaction but it is absent or empty | adapter logs/skips that route when the failure is route-local |
 | `AdapterLogicError` | `adapter.route_transform_failed` | fallback for route-local transform failures that do not fit a narrower code | adapter logs/skips that route when the failure is route-local |
 | `UnsupportedAdapterFeatureError` | `adapter.unsupported_feature` | a valid request asks for a feature the adapter does not support | caller should treat this as a fatal configuration/request failure |
 | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | raw route molecules cannot be canonicalized or processed by RDKit | adapter logs/skips that route when the failure is route-local |
@@ -206,18 +205,6 @@ Here `rxn1` resolves to `CC=O>>CCO`, but `node_dict["CC=O>>CCO"]` is missing.
 ```
 
 RetroStar and DreamRetro-style route steps need product, metadata/reagents, and reactants, e.g. `CCO>0.9>CC=O.[H][H]`.
-
-`adapter.route_metadata_missing`: a non-leaf node needs reaction metadata to describe how children form the parent, but that metadata is absent or empty.
-
-```json
-{
-    "smiles": "CCO",
-    "is_purchasable": false,
-    "children": [{"smiles": "CC=O", "is_purchasable": true, "children": []}]
-}
-```
-
-For MolBuilder, that missing metadata is `best_disconnection`.
 
 `adapter.target_mismatch`: the adapter produced a valid route, but the root is not the benchmark target.
 

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -18,7 +18,7 @@ all boundary-facing exceptions expose:
 ```json
 {
     "code": "adapter.schema_invalid",
-    "message": "raw data for target 'x' failed dms schema validation",
+    "message": "raw data for target 'x' failed DMS schema validation",
     "context": {"adapter": "dms", "target_id": "x"},
     "retryable": false
 }

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -1,0 +1,61 @@
+# error handling
+
+retrocast treats expected boundary failures as typed exceptions with stable codes.
+messages are for humans; codes and context are the contract.
+
+## rules
+
+- raise `RetroCastException` subclasses only at package, cli, io, adapter, workflow, and benchmark boundaries.
+- preserve causes with `raise ... from exc` when wrapping filesystem, json, gzip, pydantic, rdkit, or serializer failures.
+- let ordinary `ValueError`, `TypeError`, and `RuntimeError` represent local programmer errors.
+- library code raises; cli and workflow boundaries decide whether to abort, skip, count, or continue.
+- never branch on exception prose. branch on `error.code`.
+
+## shape
+
+all boundary-facing exceptions expose:
+
+```json
+{
+    "code": "adapter.schema_invalid",
+    "message": "raw data for target 'x' failed dms schema validation",
+    "context": {"adapter": "dms", "target_id": "x"},
+    "retryable": false,
+}
+```
+
+use `error.to_dict()` when persisting or reporting the structured form.
+
+## taxonomy
+
+| family | base class | examples | meaning |
+| --- | --- | --- | --- |
+| `input.*` | `InputError` | `security.path_invalid` | external cli/config/path input is invalid |
+| `config.*` | `ConfigurationError` | `config.invalid_color` | config values cannot be interpreted safely |
+| `chem.*` | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | chemistry parsing, identity, or backend failure |
+| `schema.*` | `SchemaLogicError` | `schema.logic_error` | data is structurally valid but logically impossible |
+| `benchmark.*` | `BenchmarkError` | `benchmark.validation_failed` | benchmark construction or uniqueness contract failed |
+| `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch` | raw model output failed adapter boundary contracts |
+| `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.write_failed` | artifact read, decode, shape, or write failure |
+| `serialization.*` | `RetroCastSerializationError` | `serialization.syntheseus_failed` | conversion to external route formats failed |
+| `workflow.*` | `WorkflowError` | `workflow.error` | orchestration failed at a workflow boundary |
+
+## adapter policy
+
+adapter schema errors are fatal for one target payload and counted by the workflow.
+individual route transform errors may be logged and skipped when the adapter can keep processing the rest of the target.
+route root mismatches should use `adapter.target_mismatch`; malformed raw payloads should use `adapter.schema_invalid`.
+
+## workflow accounting
+
+batch workflows that continue after expected failures must count them by stable code.
+ingestion persists `failures_by_code` in manifests so runs can be compared without log scraping.
+
+## cli policy
+
+the cli is the process boundary. it formats known `RetroCastException` instances with code and context, logs unexpected errors with tracebacks, and exits non-zero for fatal command failures.
+
+## tests
+
+test the exception class and `code`; assert exact message text only when copy itself is the public contract.
+when wrapping matters, assert `__cause__` is present.

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -36,7 +36,7 @@ use `error.to_dict()` when persisting or reporting the structured form.
 | `chem.*` | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | chemistry parsing, identity, or backend failure |
 | `schema.*` | `SchemaLogicError` | `schema.logic_error` | data is structurally valid but logically impossible |
 | `benchmark.*` | `BenchmarkError` | `benchmark.validation_failed` | benchmark construction or uniqueness contract failed |
-| `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch` | raw model output failed adapter boundary contracts |
+| `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch`, `adapter.cycle_detected`, `adapter.route_string_invalid` | raw model output failed adapter boundary contracts |
 | `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.unsupported_format`, `io.write_failed` | artifact read, decode, shape, format, or write failure |
 | `serialization.*` | `RetroCastSerializationError` | `serialization.syntheseus_failed` | conversion to external route formats failed |
 | `workflow.*` | `WorkflowError` | `workflow.error` | orchestration failed at a workflow boundary |

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -60,3 +60,5 @@ the cli is the process boundary. it formats known `RetroCastException` instances
 
 test the exception class and `code`; assert exact message text only when copy itself is the public contract.
 when wrapping matters, assert `__cause__` is present.
+
+See [adapter errors](adapters.md#adapter-error-examples) for concrete examples of route-local adapter failures.

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -20,7 +20,7 @@ all boundary-facing exceptions expose:
     "code": "adapter.schema_invalid",
     "message": "raw data for target 'x' failed dms schema validation",
     "context": {"adapter": "dms", "target_id": "x"},
-    "retryable": false,
+    "retryable": false
 }
 ```
 
@@ -30,13 +30,14 @@ use `error.to_dict()` when persisting or reporting the structured form.
 
 | family | base class | examples | meaning |
 | --- | --- | --- | --- |
-| `input.*` | `InputError` | `security.path_invalid` | external cli/config/path input is invalid |
+| `input.*` | `InputError` | `input.invalid` | external cli/config input is invalid |
+| `security.*` | `SecurityError` | `security.path_invalid`, `security.path_traversal` | path, filename, or filesystem boundary input is unsafe |
 | `config.*` | `ConfigurationError` | `config.invalid_color` | config values cannot be interpreted safely |
 | `chem.*` | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | chemistry parsing, identity, or backend failure |
 | `schema.*` | `SchemaLogicError` | `schema.logic_error` | data is structurally valid but logically impossible |
 | `benchmark.*` | `BenchmarkError` | `benchmark.validation_failed` | benchmark construction or uniqueness contract failed |
 | `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch` | raw model output failed adapter boundary contracts |
-| `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.write_failed` | artifact read, decode, shape, or write failure |
+| `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.unsupported_format`, `io.write_failed` | artifact read, decode, shape, format, or write failure |
 | `serialization.*` | `RetroCastSerializationError` | `serialization.syntheseus_failed` | conversion to external route formats failed |
 | `workflow.*` | `WorkflowError` | `workflow.error` | orchestration failed at a workflow boundary |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ New to RetroCast? Start here:
 - **[Concepts](concepts.md)** - Understand the architecture and philosophy
 - **[CLI Reference](guides/cli.md)** - Full command documentation
 - **[Python Library](guides/library.md)** - Integrate RetroCast into your research pipelines
+- **[Error Handling](developers/errors.md)** - Stable error codes and boundary contracts
 
 ## Benchmarks
 

--- a/src/retrocast/adapters/__init__.py
+++ b/src/retrocast/adapters/__init__.py
@@ -13,7 +13,7 @@ from retrocast.adapters.retrostar_adapter import RetroStarAdapter
 from retrocast.adapters.synllama_adapter import SynLlaMaAdapter
 from retrocast.adapters.synplanner_adapter import SynPlannerAdapter
 from retrocast.adapters.syntheseus_adapter import SyntheseusAdapter
-from retrocast.exceptions import RetroCastException
+from retrocast.exceptions import AdapterResolutionError
 from retrocast.models.chem import Route, TargetIdentity
 
 ADAPTER_MAP: dict[str, BaseAdapter] = {
@@ -42,8 +42,10 @@ def get_adapter(adapter_name: str) -> BaseAdapter:
     """
     adapter = ADAPTER_MAP.get(adapter_name)
     if adapter is None:
-        raise RetroCastException(
-            f"unknown adapter '{adapter_name}'. Check `retrocast.adapters.ADAPTER_MAP` for available adapters."
+        raise AdapterResolutionError(
+            f"unknown adapter '{adapter_name}'. Check `retrocast.adapters.ADAPTER_MAP` for available adapters.",
+            code="adapter.unknown",
+            context={"adapter": adapter_name, "available": sorted(ADAPTER_MAP.keys())},
         )
     return adapter
 

--- a/src/retrocast/adapters/aizynth_adapter.py
+++ b/src/retrocast/adapters/aizynth_adapter.py
@@ -8,8 +8,9 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import build_molecule_from_bipartite_node
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
 
 logger = logging.getLogger(__name__)
@@ -61,8 +62,7 @@ class AizynthAdapter(BaseAdapter):
         try:
             validated_routes = AizynthRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed aizynth schema validation. error: {e}")
-            return
+            raise adapter_schema_error("aizynth", target.id, "invalid route list") from e
 
         for rank, aizynth_tree_root in enumerate(validated_routes.root, start=1):
             try:
@@ -84,11 +84,11 @@ class AizynthAdapter(BaseAdapter):
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:
-            msg = (
-                f"mismatched smiles for target {target.id}. "
-                f"expected canonical: {expected_smiles}, but adapter produced: {target_molecule.smiles}"
+            raise adapter_target_mismatch(
+                "aizynth",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         return Route(target=target_molecule, rank=rank, metadata={})

--- a/src/retrocast/adapters/aizynth_adapter.py
+++ b/src/retrocast/adapters/aizynth_adapter.py
@@ -69,7 +69,7 @@ class AizynthAdapter(BaseAdapter):
                 route = self._transform(aizynth_tree_root, target, rank, ignore_stereo=ignore_stereo)
                 yield route
             except RetroCastException as e:
-                logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(

--- a/src/retrocast/adapters/askcos_adapter.py
+++ b/src/retrocast/adapters/askcos_adapter.py
@@ -8,9 +8,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_missing_node_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -129,7 +129,7 @@ class AskcosAdapter(BaseAdapter):
                 )
                 yield route
             except RetroCastException as e:
-                logger.warning(f"  - pathway {i} for target '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - pathway {i} for target '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform_pathway(
@@ -149,7 +149,7 @@ class AskcosAdapter(BaseAdapter):
 
         root_uuid = "00000000-0000-0000-0000-000000000000"
         if root_uuid not in uuid2smiles:
-            raise AdapterLogicError("root uuid not found in pathway data.")
+            raise adapter_missing_node_error("askcos", node_id=root_uuid, lookup="uuid2smiles", role="root chemical")
 
         target_molecule = self._build_molecule(
             chem_uuid=root_uuid,
@@ -183,11 +183,11 @@ class AskcosAdapter(BaseAdapter):
         """recursively builds a canonical molecule from a chemical uuid."""
         raw_smiles = uuid2smiles.get(chem_uuid)
         if not raw_smiles:
-            raise AdapterLogicError(f"uuid '{chem_uuid}' not found in uuid2smiles map.")
+            raise adapter_missing_node_error("askcos", node_id=chem_uuid, lookup="uuid2smiles", role="chemical")
 
         node_data = node_dict.get(raw_smiles)
         if not node_data or not isinstance(node_data, AskcosChemicalNode):
-            raise AdapterLogicError(f"node data for smiles '{raw_smiles}' not found or not a chemical node.")
+            raise adapter_missing_node_error("askcos", node_id=raw_smiles, lookup="node_dict", role="chemical")
 
         canon_smiles = canonicalize_smiles(node_data.smiles, ignore_stereo=ignore_stereo)
         is_leaf = node_data.terminal
@@ -228,11 +228,11 @@ class AskcosAdapter(BaseAdapter):
         """builds a canonical reaction step from a reaction uuid."""
         raw_smiles = uuid2smiles.get(rxn_uuid)
         if not raw_smiles:
-            raise AdapterLogicError(f"uuid '{rxn_uuid}' not found in uuid2smiles map.")
+            raise adapter_missing_node_error("askcos", node_id=rxn_uuid, lookup="uuid2smiles", role="reaction")
 
         node_data = node_dict.get(raw_smiles)
         if not node_data or not isinstance(node_data, AskcosReactionNode):
-            raise AdapterLogicError(f"node data for reaction '{raw_smiles}' not found or not a reaction node.")
+            raise adapter_missing_node_error("askcos", node_id=raw_smiles, lookup="node_dict", role="reaction")
 
         reactants: list[Molecule] = []
         reactant_smiles_list: list[SmilesStr] = []

--- a/src/retrocast/adapters/askcos_adapter.py
+++ b/src/retrocast/adapters/askcos_adapter.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -101,8 +101,11 @@ class AskcosAdapter(BaseAdapter):
         try:
             validated_output = AskcosOutput.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed askcos schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed askcos schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "askcos", "target_id": target.id},
+            ) from e
 
         uds = validated_output.results.uds
 

--- a/src/retrocast/adapters/askcos_adapter.py
+++ b/src/retrocast/adapters/askcos_adapter.py
@@ -8,8 +8,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -101,11 +102,7 @@ class AskcosAdapter(BaseAdapter):
         try:
             validated_output = AskcosOutput.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed askcos schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "askcos", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("askcos", target.id, "invalid output") from e
 
         uds = validated_output.results.uds
 
@@ -163,12 +160,14 @@ class AskcosAdapter(BaseAdapter):
             ignore_stereo=ignore_stereo,
         )
 
-        if target_molecule.smiles != target_input.smiles:
-            msg = (
-                f"mismatched smiles for target {target_input.id}. "
-                f"expected canonical: {target_input.smiles}, but adapter produced: {target_molecule.smiles}"
+        expected_smiles = canonicalize_smiles(target_input.smiles, ignore_stereo=ignore_stereo)
+        if target_molecule.smiles != expected_smiles:
+            raise adapter_target_mismatch(
+                "askcos",
+                target_input.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            raise AdapterLogicError(msg)
 
         return Route(target=target_molecule, rank=rank, metadata=metadata)
 

--- a/src/retrocast/adapters/common.py
+++ b/src/retrocast/adapters/common.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any, Protocol
 
+from retrocast.adapters.errors import adapter_node_type_error
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError
 from retrocast.models.chem import Molecule, ReactionStep
 from retrocast.typing import SmilesStr
 
@@ -147,7 +147,7 @@ def build_molecule_from_bipartite_node(raw_mol_node: BipartiteMolNode, ignore_st
         A Molecule object representing this node and its synthesis tree.
     """
     if raw_mol_node.type != "mol":
-        raise AdapterLogicError(f"Expected node type 'mol' but got '{raw_mol_node.type}'")
+        raise adapter_node_type_error("bipartite", expected="mol", actual=raw_mol_node.type, role="molecule")
 
     canon_smiles = canonicalize_smiles(raw_mol_node.smiles, ignore_stereo=ignore_stereo)
     is_leaf = raw_mol_node.in_stock or not bool(raw_mol_node.children)
@@ -168,7 +168,9 @@ def build_molecule_from_bipartite_node(raw_mol_node: BipartiteMolNode, ignore_st
 
     raw_reaction_node: BipartiteRxnNode = raw_mol_node.children[0]
     if raw_reaction_node.type != "reaction":
-        raise AdapterLogicError("Child of molecule node was not a reaction node")
+        raise adapter_node_type_error(
+            "bipartite", expected="reaction", actual=raw_reaction_node.type, role="molecule child"
+        )
 
     # Build reactants recursively
     reactant_molecules: list[Molecule] = []

--- a/src/retrocast/adapters/dms_adapter.py
+++ b/src/retrocast/adapters/dms_adapter.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
@@ -46,8 +47,7 @@ class DMSAdapter(BaseAdapter):
             # 1. Model-specific validation happens HERE, inside the adapter.
             validated_routes = DMSRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.debug(f"  - Raw data for target '{target.id}' failed DMS schema validation. Error: {e}")
-            return  # Stop processing this target
+            raise adapter_schema_error("dms", target.id, "invalid route list") from e
 
         # 2. Iterate and transform each valid route
         for rank, dms_tree_root in enumerate(validated_routes.root, start=1):
@@ -71,13 +71,12 @@ class DMSAdapter(BaseAdapter):
         # Final validation: does the transformed tree root match the canonical target smiles?
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:
-            # This is a logic error, not a parse error
-            msg = (
-                f"Mismatched SMILES for target {target.id}. "
-                f"Expected canonical: {expected_smiles}, but adapter produced: {target_molecule.smiles}"
+            raise adapter_target_mismatch(
+                "dms",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         return Route(target=target_molecule, rank=rank, metadata={})
 

--- a/src/retrocast/adapters/dms_adapter.py
+++ b/src/retrocast/adapters/dms_adapter.py
@@ -5,9 +5,9 @@ from typing import Any
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_cycle_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -57,7 +57,7 @@ class DMSAdapter(BaseAdapter):
                 yield route
             except RetroCastException as e:
                 # A single route failed, log it and continue with the next one.
-                logger.debug(f"  - Route for '{target.id}' failed transformation: {e}")
+                logger.debug(f"  - Route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(self, raw_data: DMSTree, target: TargetIdentity, rank: int, ignore_stereo: bool = False) -> Route:
@@ -93,7 +93,7 @@ class DMSAdapter(BaseAdapter):
         canon_smiles = canonicalize_smiles(dms_node.smiles, ignore_stereo=ignore_stereo)
 
         if canon_smiles in visited:
-            raise AdapterLogicError(f"cycle detected in route graph involving smiles: {canon_smiles}")
+            raise adapter_cycle_error("dms", canon_smiles)
 
         new_visited = visited | {canon_smiles}
         is_leaf = not bool(dms_node.children)

--- a/src/retrocast/adapters/dreamretro_adapter.py
+++ b/src/retrocast/adapters/dreamretro_adapter.py
@@ -6,9 +6,9 @@ from typing import Any
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import PrecursorMap, build_molecule_from_precursor_map
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -39,7 +39,7 @@ class DreamRetroAdapter(BaseAdapter):
             route = self._transform(route_str, target, raw_target_data, ignore_stereo=ignore_stereo)
             yield route
         except RetroCastException as e:
-            logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+            logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
             return
 
     def _parse_route_string(self, route_str: str, ignore_stereo: bool = False) -> tuple[SmilesStr, PrecursorMap]:
@@ -52,7 +52,7 @@ class DreamRetroAdapter(BaseAdapter):
         precursor_map: PrecursorMap = {}
         steps = route_str.split("|")
         if not steps or not steps[0]:
-            raise AdapterLogicError("route string is empty or invalid.")
+            raise adapter_route_string_error("dreamretro", "empty route string", empty=True)
 
         if len(steps) == 1 and ">" not in steps[0]:
             target_smiles = canonicalize_smiles(steps[0], ignore_stereo=ignore_stereo)
@@ -79,8 +79,10 @@ class DreamRetroAdapter(BaseAdapter):
 
             return target_smiles, precursor_map
         except (ValueError, IndexError) as e:
-            raise AdapterLogicError(
-                f"failed to parse route string step. invalid format near '{current_step_for_error_reporting[:70]}...'."
+            raise adapter_route_string_error(
+                "dreamretro",
+                "expected each reaction step to split into product, reagents, and reactants",
+                fragment=current_step_for_error_reporting[:70],
             ) from e
 
     def _transform(

--- a/src/retrocast/adapters/dreamretro_adapter.py
+++ b/src/retrocast/adapters/dreamretro_adapter.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import PrecursorMap, build_molecule_from_precursor_map
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
 from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
@@ -24,10 +25,7 @@ class DreamRetroAdapter(BaseAdapter):
         validates raw dreamretro data, transforms its single route string, and yields a route.
         """
         if not isinstance(raw_target_data, dict):
-            logger.warning(
-                f"  - raw data for target '{target.id}' failed validation: expected a dict, got {type(raw_target_data).__name__}."
-            )
-            return
+            raise adapter_schema_error("dreamretro", target.id, "expected a dict")
 
         if not raw_target_data.get("succ"):
             logger.debug(f"skipping raw data for '{target.id}': 'succ' is not true.")
@@ -35,8 +33,7 @@ class DreamRetroAdapter(BaseAdapter):
 
         route_str = raw_target_data.get("routes")
         if not isinstance(route_str, str) or not route_str:
-            logger.warning(f"  - raw data for target '{target.id}' failed validation: no valid 'routes' string found.")
-            return
+            raise adapter_schema_error("dreamretro", target.id, "no valid 'routes' string found")
 
         try:
             route = self._transform(route_str, target, raw_target_data, ignore_stereo=ignore_stereo)
@@ -94,16 +91,18 @@ class DreamRetroAdapter(BaseAdapter):
         """
         parsed_target_smiles, precursor_map = self._parse_route_string(route_str, ignore_stereo=ignore_stereo)
 
-        if parsed_target_smiles != target_input.smiles:
-            msg = (
-                f"mismatched smiles for target {target_input.id}. "
-                f"expected canonical: {target_input.smiles}, but adapter produced: {parsed_target_smiles}"
+        expected_smiles = canonicalize_smiles(target_input.smiles, ignore_stereo=ignore_stereo)
+        if parsed_target_smiles != expected_smiles:
+            raise adapter_target_mismatch(
+                "dreamretro",
+                target_input.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=parsed_target_smiles,
             )
-            raise AdapterLogicError(msg)
 
         # build molecule tree from precursor map
         molecule = build_molecule_from_precursor_map(
-            smiles=SmilesStr(target_input.smiles), precursor_map=precursor_map, ignore_stereo=ignore_stereo
+            smiles=expected_smiles, precursor_map=precursor_map, ignore_stereo=ignore_stereo
         )
 
         # extract metadata

--- a/src/retrocast/adapters/errors.py
+++ b/src/retrocast/adapters/errors.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+
+
+def adapter_schema_error(adapter: str, target_id: str, detail: str, **context: Any) -> AdapterSchemaError:
+    return AdapterSchemaError(
+        f"raw data for target '{target_id}' failed {adapter} schema validation: {detail}",
+        code="adapter.schema_invalid",
+        context={"adapter": adapter, "target_id": target_id, **context},
+    )
+
+
+def adapter_target_mismatch(
+    adapter: str,
+    target_id: str,
+    *,
+    expected_smiles: str,
+    actual_smiles: str,
+) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"mismatched smiles for target {target_id}. expected canonical: {expected_smiles}, "
+        f"but adapter produced: {actual_smiles}",
+        code="adapter.target_mismatch",
+        context={
+            "adapter": adapter,
+            "target_id": target_id,
+            "expected_smiles": expected_smiles,
+            "actual_smiles": actual_smiles,
+        },
+    )

--- a/src/retrocast/adapters/errors.py
+++ b/src/retrocast/adapters/errors.py
@@ -4,10 +4,29 @@ from typing import Any
 
 from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
 
+ADAPTER_DISPLAY_NAMES = {
+    "aizynth": "AiZynthFinder",
+    "askcos": "ASKCOS",
+    "dms": "DMS",
+    "dreamretro": "DreamRetro",
+    "molbuilder": "MolBuilder",
+    "multistepttl": "MultiStepTTL",
+    "paroutes": "PaRoutes",
+    "retrochimera": "RetroChimera",
+    "retrostar": "RetroStar",
+    "synllama": "SynLlama",
+    "synplanner": "SynPlanner",
+    "syntheseus": "Syntheseus",
+}
+
+
+def adapter_display_name(adapter: str) -> str:
+    return ADAPTER_DISPLAY_NAMES.get(adapter, adapter)
+
 
 def adapter_schema_error(adapter: str, target_id: str, detail: str, **context: Any) -> AdapterSchemaError:
     return AdapterSchemaError(
-        f"raw data for target '{target_id}' failed {adapter} schema validation: {detail}",
+        f"raw data for target '{target_id}' failed {adapter_display_name(adapter)} schema validation: {detail}",
         code="adapter.schema_invalid",
         context={"adapter": adapter, "target_id": target_id, **context},
     )
@@ -21,8 +40,8 @@ def adapter_target_mismatch(
     actual_smiles: str,
 ) -> AdapterLogicError:
     return AdapterLogicError(
-        f"mismatched smiles for target {target_id}. expected canonical: {expected_smiles}, "
-        f"but adapter produced: {actual_smiles}",
+        f"{adapter_display_name(adapter)} produced mismatched SMILES for target {target_id}. "
+        f"expected canonical: {expected_smiles}, but adapter produced: {actual_smiles}",
         code="adapter.target_mismatch",
         context={
             "adapter": adapter,

--- a/src/retrocast/adapters/errors.py
+++ b/src/retrocast/adapters/errors.py
@@ -94,11 +94,3 @@ def adapter_route_string_error(
         code=code,
         context=context,
     )
-
-
-def adapter_route_metadata_error(adapter: str, *, smiles: str, field: str) -> AdapterLogicError:
-    return AdapterLogicError(
-        f"{adapter_display_name(adapter)} non-leaf node for SMILES '{smiles}' is missing required route metadata field '{field}'",
-        code="adapter.route_metadata_missing",
-        context={"adapter": adapter, "smiles": smiles, "field": field},
-    )

--- a/src/retrocast/adapters/errors.py
+++ b/src/retrocast/adapters/errors.py
@@ -50,3 +50,55 @@ def adapter_target_mismatch(
             "actual_smiles": actual_smiles,
         },
     )
+
+
+def adapter_cycle_error(adapter: str, smiles: str) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} route contains a cycle involving SMILES: {smiles}",
+        code="adapter.cycle_detected",
+        context={"adapter": adapter, "smiles": smiles},
+    )
+
+
+def adapter_node_type_error(adapter: str, *, expected: str, actual: str, role: str) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} expected {role} node type '{expected}' but got '{actual}'",
+        code="adapter.node_type_invalid",
+        context={"adapter": adapter, "expected": expected, "actual": actual, "role": role},
+    )
+
+
+def adapter_missing_node_error(adapter: str, *, node_id: str, lookup: str, role: str) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} could not resolve {role} node '{node_id}' in {lookup}",
+        code="adapter.node_missing",
+        context={"adapter": adapter, "node_id": node_id, "lookup": lookup, "role": role},
+    )
+
+
+def adapter_route_string_error(
+    adapter: str,
+    detail: str,
+    *,
+    fragment: str | None = None,
+    empty: bool = False,
+) -> AdapterLogicError:
+    context: dict[str, Any] = {"adapter": adapter}
+    if fragment is not None:
+        context["fragment"] = fragment
+    code = "adapter.route_string_empty" if empty else "adapter.route_string_invalid"
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} route string is empty"
+        if empty
+        else f"{adapter_display_name(adapter)} route string is invalid: {detail}",
+        code=code,
+        context=context,
+    )
+
+
+def adapter_route_metadata_error(adapter: str, *, smiles: str, field: str) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} non-leaf node for SMILES '{smiles}' is missing required route metadata field '{field}'",
+        code="adapter.route_metadata_missing",
+        context={"adapter": adapter, "smiles": smiles, "field": field},
+    )

--- a/src/retrocast/adapters/molbuilder_adapter.py
+++ b/src/retrocast/adapters/molbuilder_adapter.py
@@ -36,8 +36,9 @@ from typing import Any
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -91,11 +92,7 @@ class MolBuilderAdapter(BaseAdapter):
         try:
             validated_routes = MolBuilderRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed molbuilder schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "molbuilder", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("molbuilder", target.id, "invalid route list") from e
 
         for rank, tree_root in enumerate(validated_routes.root, start=1):
             try:
@@ -117,12 +114,12 @@ class MolBuilderAdapter(BaseAdapter):
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:
-            msg = (
-                f"Mismatched SMILES for target {target.id}. "
-                f"Expected canonical: {expected_smiles}, but adapter produced: {target_molecule.smiles}"
+            raise adapter_target_mismatch(
+                "molbuilder",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         route_metadata: dict[str, Any] = {}
         if raw_root.best_disconnection is not None:

--- a/src/retrocast/adapters/molbuilder_adapter.py
+++ b/src/retrocast/adapters/molbuilder_adapter.py
@@ -36,9 +36,14 @@ from typing import Any
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_route_metadata_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -99,7 +104,7 @@ class MolBuilderAdapter(BaseAdapter):
                 route = self._transform(tree_root, target, rank, ignore_stereo=ignore_stereo)
                 yield route
             except RetroCastException as e:
-                logger.debug(f"  - Route for '{target.id}' failed transformation: {e}")
+                logger.debug(f"  - Route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(
@@ -140,7 +145,7 @@ class MolBuilderAdapter(BaseAdapter):
         canon_smiles = canonicalize_smiles(node.smiles, ignore_stereo=ignore_stereo)
 
         if canon_smiles in visited:
-            raise AdapterLogicError(f"cycle detected in route graph involving smiles: {canon_smiles}")
+            raise adapter_cycle_error("molbuilder", canon_smiles)
 
         visited.add(canon_smiles)
         is_leaf = node.is_purchasable or not bool(node.children)
@@ -158,11 +163,11 @@ class MolBuilderAdapter(BaseAdapter):
             )
 
         if node.best_disconnection is None:
-            raise AdapterLogicError(f"Non-leaf node for SMILES '{canon_smiles}' is missing 'best_disconnection' field.")
+            raise adapter_route_metadata_error("molbuilder", smiles=canon_smiles, field="best_disconnection")
 
         if not node.best_disconnection.reaction_name.strip():
-            raise AdapterLogicError(
-                f"Non-leaf node for SMILES '{canon_smiles}' has empty 'reaction_name' in 'best_disconnection'."
+            raise adapter_route_metadata_error(
+                "molbuilder", smiles=canon_smiles, field="best_disconnection.reaction_name"
             )
 
         reactant_molecules: list[Molecule] = []

--- a/src/retrocast/adapters/molbuilder_adapter.py
+++ b/src/retrocast/adapters/molbuilder_adapter.py
@@ -38,7 +38,6 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.errors import (
     adapter_cycle_error,
-    adapter_route_metadata_error,
     adapter_schema_error,
     adapter_target_mismatch,
 )
@@ -162,29 +161,24 @@ class MolBuilderAdapter(BaseAdapter):
                 metadata=mol_metadata,
             )
 
-        if node.best_disconnection is None:
-            raise adapter_route_metadata_error("molbuilder", smiles=canon_smiles, field="best_disconnection")
-
-        if not node.best_disconnection.reaction_name.strip():
-            raise adapter_route_metadata_error(
-                "molbuilder", smiles=canon_smiles, field="best_disconnection.reaction_name"
-            )
-
         reactant_molecules: list[Molecule] = []
         for child in node.children:
             reactant_mol = self._build_molecule(child, visited=set(visited), ignore_stereo=ignore_stereo)
             reactant_molecules.append(reactant_mol)
 
         disc = node.best_disconnection
-        step_metadata: dict[str, Any] = {
-            "reaction_name": disc.reaction_name,
-            "score": disc.score,
-        }
-        if disc.named_reaction:
-            step_metadata["named_reaction"] = disc.named_reaction
-        if disc.category:
-            step_metadata["category"] = disc.category
-        template = disc.reaction_name
+        step_metadata: dict[str, Any] = {}
+        template = None
+        if disc is not None:
+            reaction_name = disc.reaction_name.strip()
+            if reaction_name:
+                step_metadata["reaction_name"] = reaction_name
+                template = reaction_name
+            step_metadata["score"] = disc.score
+            if disc.named_reaction:
+                step_metadata["named_reaction"] = disc.named_reaction
+            if disc.category:
+                step_metadata["category"] = disc.category
 
         synthesis_step = ReactionStep(
             reactants=reactant_molecules,

--- a/src/retrocast/adapters/molbuilder_adapter.py
+++ b/src/retrocast/adapters/molbuilder_adapter.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -91,8 +91,11 @@ class MolBuilderAdapter(BaseAdapter):
         try:
             validated_routes = MolBuilderRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.debug(f"  - Raw data for target '{target.id}' failed MolBuilder schema validation. Error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed molbuilder schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "molbuilder", "target_id": target.id},
+            ) from e
 
         for rank, tree_root in enumerate(validated_routes.root, start=1):
             try:

--- a/src/retrocast/adapters/multistepttl_adapter.py
+++ b/src/retrocast/adapters/multistepttl_adapter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -41,8 +41,11 @@ class TtlRetroAdapter(BaseAdapter):
         try:
             validated_data = TtlRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - pre-processed data for target '{target.id}' failed schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"pre-processed data for target '{target.id}' failed multistepttl schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "multistepttl", "target_id": target.id},
+            ) from e
 
         for rank, route in enumerate(validated_data.root, start=1):
             try:

--- a/src/retrocast/adapters/multistepttl_adapter.py
+++ b/src/retrocast/adapters/multistepttl_adapter.py
@@ -7,9 +7,9 @@ from typing import Any
 from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error
+from retrocast.adapters.errors import adapter_cycle_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -49,7 +49,7 @@ class TtlRetroAdapter(BaseAdapter):
                 adapted_route = self._transform(route, target, rank, ignore_stereo=ignore_stereo)
                 yield adapted_route
             except RetroCastException as e:
-                logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(self, route: TtlRoute, target: TargetIdentity, rank: int, ignore_stereo: bool = False) -> Route:
@@ -70,8 +70,11 @@ class TtlRetroAdapter(BaseAdapter):
         root_smiles = canonicalize_smiles(route.reactions[0].product, ignore_stereo=ignore_stereo)
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if root_smiles != expected_smiles:
-            raise AdapterLogicError(
-                f"route's final product '{root_smiles}' does not match expected target '{expected_smiles}'."
+            raise adapter_target_mismatch(
+                "multistepttl",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=root_smiles,
             )
 
         # build precursor map for recursive traversal
@@ -102,7 +105,7 @@ class TtlRetroAdapter(BaseAdapter):
         canon_smiles = canonicalize_smiles(smiles, ignore_stereo=ignore_stereo)
 
         if canon_smiles in visited:
-            raise AdapterLogicError(f"cycle detected: molecule '{canon_smiles}' appears multiple times in route.")
+            raise adapter_cycle_error("multistepttl", canon_smiles)
 
         # if the molecule is not in the precursor map, it's a starting material
         if canon_smiles not in precursor_map:

--- a/src/retrocast/adapters/multistepttl_adapter.py
+++ b/src/retrocast/adapters/multistepttl_adapter.py
@@ -7,8 +7,9 @@ from typing import Any
 from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -41,11 +42,7 @@ class TtlRetroAdapter(BaseAdapter):
         try:
             validated_data = TtlRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"pre-processed data for target '{target.id}' failed multistepttl schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "multistepttl", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("multistepttl", target.id, "invalid pre-processed route list") from e
 
         for rank, route in enumerate(validated_data.root, start=1):
             try:

--- a/src/retrocast/adapters/paroutes_adapter.py
+++ b/src/retrocast/adapters/paroutes_adapter.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -129,8 +129,11 @@ class PaRoutesAdapter(BaseAdapter):
             # unlike other adapters, the raw data for one target is a single route object, not a list.
             validated_route_root = PaRoutesMoleculeInput.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed paroutes schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed paroutes schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "paroutes", "target_id": target.id},
+            ) from e
 
         # --- custom validation: ensure all reactions are from the same patent ---
         patent_ids = self._get_patent_ids(validated_route_root)

--- a/src/retrocast/adapters/paroutes_adapter.py
+++ b/src/retrocast/adapters/paroutes_adapter.py
@@ -9,9 +9,14 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_node_type_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -154,7 +159,7 @@ class PaRoutesAdapter(BaseAdapter):
             )
             yield route
         except RetroCastException as e:
-            logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+            logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
             return
 
     def _transform(
@@ -195,7 +200,7 @@ class PaRoutesAdapter(BaseAdapter):
             AdapterLogicError: If a cycle is detected in the route graph
         """
         if raw_mol_node.type != "mol":
-            raise AdapterLogicError(f"expected node type 'mol' but got '{raw_mol_node.type}'")
+            raise adapter_node_type_error("paroutes", expected="mol", actual=raw_mol_node.type, role="molecule")
 
         if visited is None:
             visited = set()
@@ -204,7 +209,7 @@ class PaRoutesAdapter(BaseAdapter):
 
         # Cycle detection: check if we've seen this molecule before in the current path
         if canon_smiles in visited:
-            raise AdapterLogicError(f"cycle detected in route graph involving smiles: {canon_smiles}")
+            raise adapter_cycle_error("paroutes", canon_smiles)
 
         # Create new visited set with current molecule added
         new_visited = visited | {canon_smiles}
@@ -227,7 +232,8 @@ class PaRoutesAdapter(BaseAdapter):
 
         first_child = raw_mol_node.children[0]
         if not isinstance(first_child, PaRoutesReactionInput):
-            raise AdapterLogicError("child of molecule node was not a reaction node")
+            actual = getattr(first_child, "type", type(first_child).__name__)
+            raise adapter_node_type_error("paroutes", expected="reaction", actual=actual, role="molecule child")
         raw_reaction_node: PaRoutesReactionInput = first_child
 
         # build reactants recursively with updated visited set

--- a/src/retrocast/adapters/paroutes_adapter.py
+++ b/src/retrocast/adapters/paroutes_adapter.py
@@ -9,8 +9,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -129,11 +130,7 @@ class PaRoutesAdapter(BaseAdapter):
             # unlike other adapters, the raw data for one target is a single route object, not a list.
             validated_route_root = PaRoutesMoleculeInput.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed paroutes schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "paroutes", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("paroutes", target.id, "invalid molecule route root") from e
 
         # --- custom validation: ensure all reactions are from the same patent ---
         patent_ids = self._get_patent_ids(validated_route_root)
@@ -171,12 +168,12 @@ class PaRoutesAdapter(BaseAdapter):
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:
-            msg = (
-                f"mismatched smiles for target {target.id}. "
-                f"expected canonical: {expected_smiles}, but adapter produced: {target_molecule.smiles}"
+            raise adapter_target_mismatch(
+                "paroutes",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         # add patent ID to route metadata (everything up to first semicolon)
         route_metadata = {"patent_id": patent_id}

--- a/src/retrocast/adapters/resolve.py
+++ b/src/retrocast/adapters/resolve.py
@@ -76,7 +76,9 @@ def resolve_adapter(
     if cli_adapter is not None:
         if cli_adapter not in ADAPTER_MAP:
             raise AdapterResolutionError(
-                f"CLI adapter '{cli_adapter}' is not a valid adapter. Available: {sorted(ADAPTER_MAP.keys())}"
+                f"CLI adapter '{cli_adapter}' is not a valid adapter. Available: {sorted(ADAPTER_MAP.keys())}",
+                code="adapter.unknown",
+                context={"source": "cli", "adapter": cli_adapter, "available": sorted(ADAPTER_MAP.keys())},
             )
         logger.info(f"Resolved adapter '{cli_adapter}' from cli")
         return get_adapter(cli_adapter), "cli"
@@ -89,7 +91,14 @@ def resolve_adapter(
         if manifest_adapter not in ADAPTER_MAP:
             raise AdapterResolutionError(
                 f"Manifest in {raw_dir} declares adapter '{manifest_adapter}', "
-                f"but it is not a valid adapter. Available: {sorted(ADAPTER_MAP.keys())}"
+                f"but it is not a valid adapter. Available: {sorted(ADAPTER_MAP.keys())}",
+                code="adapter.unknown",
+                context={
+                    "source": "manifest",
+                    "adapter": manifest_adapter,
+                    "raw_dir": str(raw_dir),
+                    "available": sorted(ADAPTER_MAP.keys()),
+                },
             )
         logger.info(f"Resolved adapter '{manifest_adapter}' from manifest")
         return get_adapter(manifest_adapter), "manifest"
@@ -99,7 +108,9 @@ def resolve_adapter(
         f"Cannot resolve adapter for model '{model_name}' in {raw_dir}. "
         f"No --adapter flag provided, and no manifest.json with directives.adapter found. "
         f"Either pass --adapter explicitly or ensure the raw data directory contains a "
-        f'manifest.json with \'"directives": {{"adapter": "<name>"}}\'.'
+        f'manifest.json with \'"directives": {{"adapter": "<name>"}}\'.',
+        code="adapter.resolution_missing",
+        context={"model": model_name, "raw_dir": str(raw_dir)},
     )
 
 

--- a/src/retrocast/adapters/retrochimera_adapter.py
+++ b/src/retrocast/adapters/retrochimera_adapter.py
@@ -7,8 +7,9 @@ from typing import Any
 from pydantic import BaseModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterSchemaError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -68,11 +69,7 @@ class RetrochimeraAdapter(BaseAdapter):
         try:
             validated_data = RetrochimeraData.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed retrochimera schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "retrochimera", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("retrochimera", target.id, "invalid output") from e
 
         if validated_data.result.error is not None:
             error_msg = validated_data.result.error.get("message", "unknown error")
@@ -83,7 +80,8 @@ class RetrochimeraAdapter(BaseAdapter):
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo) != expected_smiles:
             logger.warning(
-                f"  - mismatched smiles for target '{target.id}': expected {expected_smiles}, got {canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo)}"
+                f"  - RetroChimera produced mismatched SMILES for target '{target.id}': "
+                f"expected {expected_smiles}, got {canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo)}"
             )
             return
 

--- a/src/retrocast/adapters/retrochimera_adapter.py
+++ b/src/retrocast/adapters/retrochimera_adapter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import RetroCastException
+from retrocast.exceptions import AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -68,8 +68,11 @@ class RetrochimeraAdapter(BaseAdapter):
         try:
             validated_data = RetrochimeraData.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed retrochimera schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed retrochimera schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "retrochimera", "target_id": target.id},
+            ) from e
 
         if validated_data.result.error is not None:
             error_msg = validated_data.result.error.get("message", "unknown error")

--- a/src/retrocast/adapters/retrochimera_adapter.py
+++ b/src/retrocast/adapters/retrochimera_adapter.py
@@ -97,7 +97,7 @@ class RetrochimeraAdapter(BaseAdapter):
                     yield route_obj
                     rank += 1
                 except RetroCastException as e:
-                    logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                    logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                     continue
 
     def _transform(

--- a/src/retrocast/adapters/retrostar_adapter.py
+++ b/src/retrocast/adapters/retrostar_adapter.py
@@ -6,9 +6,9 @@ from typing import Any
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import PrecursorMap, build_molecule_from_precursor_map
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -42,7 +42,7 @@ class RetroStarAdapter(BaseAdapter):
             route = self._transform(route_str, target, route_cost=route_cost, ignore_stereo=ignore_stereo)
             yield route
         except RetroCastException as e:
-            logger.warning(f"  - Route for '{target.id}' failed transformation: {e}")
+            logger.warning(f"  - Route for '{target.id}' failed transformation: {e} [{e.code}]")
             return
 
     def _parse_route_string(self, route_str: str, ignore_stereo: bool = False) -> tuple[SmilesStr, PrecursorMap]:
@@ -55,7 +55,7 @@ class RetroStarAdapter(BaseAdapter):
         precursor_map: PrecursorMap = {}
         steps = route_str.split("|")
         if not steps or not steps[0]:
-            raise AdapterLogicError("Route string is empty or invalid.")
+            raise adapter_route_string_error("retrostar", "empty route string", empty=True)
 
         if len(steps) == 1 and ">" not in steps[0]:
             target_smiles = canonicalize_smiles(steps[0], ignore_stereo=ignore_stereo)
@@ -65,7 +65,7 @@ class RetroStarAdapter(BaseAdapter):
         try:
             current_step_for_error_reporting = steps[0]
             if len(current_step_for_error_reporting.split(">")) != 3:
-                raise ValueError("Invalid step format")
+                raise ValueError("invalid step format")
             first_product_smiles, _, _ = current_step_for_error_reporting.split(">")
             target_smiles = canonicalize_smiles(first_product_smiles, ignore_stereo=ignore_stereo)
 
@@ -73,7 +73,7 @@ class RetroStarAdapter(BaseAdapter):
                 current_step_for_error_reporting = step
                 parts = step.split(">")
                 if len(parts) != 3:
-                    raise ValueError("Invalid step format")
+                    raise ValueError("invalid step format")
                 product_smi, _, reactants_smi = parts
 
                 full_canonical_reactants = canonicalize_smiles(reactants_smi, ignore_stereo=ignore_stereo)
@@ -82,8 +82,10 @@ class RetroStarAdapter(BaseAdapter):
 
             return target_smiles, precursor_map
         except (ValueError, IndexError) as e:
-            raise AdapterLogicError(
-                f"Failed to parse route string step. Invalid format near '{current_step_for_error_reporting[:70]}...'."
+            raise adapter_route_string_error(
+                "retrostar",
+                "expected each reaction step to split into product, reagents, and reactants",
+                fragment=current_step_for_error_reporting[:70],
             ) from e
 
     def _transform(

--- a/src/retrocast/adapters/retrostar_adapter.py
+++ b/src/retrocast/adapters/retrostar_adapter.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import PrecursorMap, build_molecule_from_precursor_map
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
 from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
@@ -24,10 +25,7 @@ class RetroStarAdapter(BaseAdapter):
         Validates raw RetroStar data, transforms its single route string, and yields a Route.
         """
         if not isinstance(raw_target_data, dict):
-            logger.warning(
-                f"  - Raw data for target '{target.id}' failed validation: expected a dict, got {type(raw_target_data).__name__}."
-            )
-            return
+            raise adapter_schema_error("retrostar", target.id, "expected a dict")
 
         if not raw_target_data.get("succ"):
             logger.debug(f"Skipping raw data for '{target.id}': 'succ' is not true.")
@@ -35,8 +33,7 @@ class RetroStarAdapter(BaseAdapter):
 
         route_str = raw_target_data.get("routes")
         if not isinstance(route_str, str) or not route_str:
-            logger.warning(f"  - Raw data for target '{target.id}' failed validation: no valid 'routes' string found.")
-            return
+            raise adapter_schema_error("retrostar", target.id, "no valid 'routes' string found")
 
         # Extract route_cost if available
         route_cost = raw_target_data.get("route_cost")
@@ -100,11 +97,12 @@ class RetroStarAdapter(BaseAdapter):
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if parsed_target_smiles != expected_smiles:
-            msg = (
-                f"Mismatched SMILES for target {target.id}. "
-                f"Expected canonical: {expected_smiles}, but adapter produced: {parsed_target_smiles}"
+            raise adapter_target_mismatch(
+                "retrostar",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=parsed_target_smiles,
             )
-            raise AdapterLogicError(msg)
 
         # Build the molecule tree using the new schema helper
         target_molecule = build_molecule_from_precursor_map(

--- a/src/retrocast/adapters/synllama_adapter.py
+++ b/src/retrocast/adapters/synllama_adapter.py
@@ -7,8 +7,9 @@ from typing import Any
 from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -35,11 +36,7 @@ class SynLlaMaAdapter(BaseAdapter):
         try:
             validated_routes = SynLlamaRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"data for target '{target.id}' failed synllama schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "synllama", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("synllama", target.id, "invalid route list") from e
 
         for rank, route in enumerate(validated_routes.root, start=1):
             try:
@@ -63,11 +60,12 @@ class SynLlaMaAdapter(BaseAdapter):
         parsed_target_smiles = canonicalize_smiles(synthesis_parts[-1], ignore_stereo=ignore_stereo)
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if parsed_target_smiles != expected_smiles:
-            msg = (
-                f"mismatched smiles for target {target.id}. "
-                f"expected canonical: {expected_smiles}, but adapter produced: {parsed_target_smiles}"
+            raise adapter_target_mismatch(
+                "synllama",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=parsed_target_smiles,
             )
-            raise AdapterLogicError(msg)
 
         precursor_map = self._parse_synthesis_string(route.synthesis_string, ignore_stereo=ignore_stereo)
         target_molecule = self._build_molecule_from_precursor_map(

--- a/src/retrocast/adapters/synllama_adapter.py
+++ b/src/retrocast/adapters/synllama_adapter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -35,8 +35,11 @@ class SynLlaMaAdapter(BaseAdapter):
         try:
             validated_routes = SynLlamaRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - data for target '{target.id}' failed synllama schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"data for target '{target.id}' failed synllama schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "synllama", "target_id": target.id},
+            ) from e
 
         for rank, route in enumerate(validated_routes.root, start=1):
             try:

--- a/src/retrocast/adapters/synllama_adapter.py
+++ b/src/retrocast/adapters/synllama_adapter.py
@@ -7,9 +7,9 @@ from typing import Any
 from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
@@ -43,7 +43,7 @@ class SynLlaMaAdapter(BaseAdapter):
                 route_obj = self._transform(route, target, rank=rank, ignore_stereo=ignore_stereo)
                 yield route_obj
             except RetroCastException as e:
-                logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(
@@ -54,7 +54,7 @@ class SynLlaMaAdapter(BaseAdapter):
         # this is the most reliable way to identify it.
         synthesis_parts = [p.strip() for p in route.synthesis_string.split(";") if p.strip()]
         if not synthesis_parts:
-            raise AdapterLogicError("synthesis string is empty.")
+            raise adapter_route_string_error("synllama", "empty synthesis string", empty=True)
 
         # the final product is always the last element. this is the most reliable way to identify it.
         parsed_target_smiles = canonicalize_smiles(synthesis_parts[-1], ignore_stereo=ignore_stereo)
@@ -140,7 +140,7 @@ class SynLlaMaAdapter(BaseAdapter):
         parts = [p.strip() for p in synthesis_str.split(";") if p.strip()]
 
         if not parts:
-            raise AdapterLogicError("synthesis string is empty.")
+            raise adapter_route_string_error("synllama", "empty synthesis string", empty=True)
 
         template_indices = [i for i, p in enumerate(parts) if p.startswith("R") and p[1:].isdigit()]
 
@@ -153,7 +153,11 @@ class SynLlaMaAdapter(BaseAdapter):
         for template_idx in template_indices:
             product_idx = template_idx + 1
             if product_idx >= len(parts):
-                raise AdapterLogicError(f"malformed route: template '{parts[template_idx]}' has no product.")
+                raise adapter_route_string_error(
+                    "synllama",
+                    "template has no product",
+                    fragment=parts[template_idx],
+                )
 
             product_smiles = canonicalize_smiles(parts[product_idx], ignore_stereo=ignore_stereo)
             explicit_reactant_parts = parts[reactant_start_idx:template_idx]
@@ -162,7 +166,11 @@ class SynLlaMaAdapter(BaseAdapter):
                 all_reactants.append(last_product_smi)
 
             if not all_reactants:
-                raise AdapterLogicError(f"no reactants found for product '{parts[product_idx]}'")
+                raise adapter_route_string_error(
+                    "synllama",
+                    "no reactants found for product",
+                    fragment=parts[product_idx],
+                )
 
             precursor_map[product_smiles] = all_reactants
 

--- a/src/retrocast/adapters/synplanner_adapter.py
+++ b/src/retrocast/adapters/synplanner_adapter.py
@@ -7,9 +7,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import adapter_node_type_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr
 
@@ -70,7 +70,7 @@ class SynPlannerAdapter(BaseAdapter):
                 route = self._transform(synplanner_tree_root, target, rank, ignore_stereo=ignore_stereo)
                 yield route
             except RetroCastException as e:
-                logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(
@@ -113,7 +113,7 @@ class SynPlannerAdapter(BaseAdapter):
         synplanner has mapped_smiles in the 'smiles' field of reaction nodes.
         """
         if raw_mol_node.type != "mol":
-            raise AdapterLogicError(f"Expected node type 'mol' but got '{raw_mol_node.type}'")
+            raise adapter_node_type_error("synplanner", expected="mol", actual=raw_mol_node.type, role="molecule")
 
         canon_smiles = canonicalize_smiles(raw_mol_node.smiles, remove_mapping=True, ignore_stereo=ignore_stereo)
         is_leaf = raw_mol_node.in_stock or not bool(raw_mol_node.children)
@@ -134,7 +134,8 @@ class SynPlannerAdapter(BaseAdapter):
 
         first_child = raw_mol_node.children[0]
         if not isinstance(first_child, SynPlannerReactionInput):
-            raise AdapterLogicError("Child of molecule node was not a reaction node")
+            actual = getattr(first_child, "type", type(first_child).__name__)
+            raise adapter_node_type_error("synplanner", expected="reaction", actual=actual, role="molecule child")
         raw_reaction_node: SynPlannerReactionInput = first_child
 
         # Build reactants recursively
@@ -142,7 +143,8 @@ class SynPlannerAdapter(BaseAdapter):
         for reactant_mol_input in raw_reaction_node.children:
             # Type guard: children of reaction nodes should be molecule nodes
             if not isinstance(reactant_mol_input, SynPlannerMoleculeInput):
-                raise AdapterLogicError("Child of reaction node was not a molecule node")
+                actual = getattr(reactant_mol_input, "type", type(reactant_mol_input).__name__)
+                raise adapter_node_type_error("synplanner", expected="mol", actual=actual, role="reaction child")
             reactant_mol = self._build_molecule_from_synplanner_node(reactant_mol_input, ignore_stereo=ignore_stereo)
             reactant_molecules.append(reactant_mol)
 

--- a/src/retrocast/adapters/synplanner_adapter.py
+++ b/src/retrocast/adapters/synplanner_adapter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr
 
@@ -62,8 +62,11 @@ class SynPlannerAdapter(BaseAdapter):
         try:
             validated_routes = SynPlannerRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed synplanner schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed synplanner schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "synplanner", "target_id": target.id},
+            ) from e
 
         for rank, synplanner_tree_root in enumerate(validated_routes.root, start=1):
             try:

--- a/src/retrocast/adapters/synplanner_adapter.py
+++ b/src/retrocast/adapters/synplanner_adapter.py
@@ -7,8 +7,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr
 
@@ -62,11 +63,7 @@ class SynPlannerAdapter(BaseAdapter):
         try:
             validated_routes = SynPlannerRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed synplanner schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "synplanner", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("synplanner", target.id, "invalid route list") from e
 
         for rank, synplanner_tree_root in enumerate(validated_routes.root, start=1):
             try:
@@ -91,12 +88,12 @@ class SynPlannerAdapter(BaseAdapter):
         expected = canonicalize_smiles(target.smiles, remove_mapping=True, ignore_stereo=ignore_stereo)
 
         if produced != expected:
-            msg = (
-                f"mismatched smiles for target {target.id}. "
-                f"expected canonical: {expected}, but adapter produced: {produced}"
+            raise adapter_target_mismatch(
+                "synplanner",
+                target.id,
+                expected_smiles=expected,
+                actual_smiles=produced,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         # ensure target molecule uses the rdkit-canonicalized form
         target_molecule = Molecule(

--- a/src/retrocast/adapters/syntheseus_adapter.py
+++ b/src/retrocast/adapters/syntheseus_adapter.py
@@ -70,7 +70,7 @@ class SyntheseusAdapter(BaseAdapter):
                 route = self._transform(syntheseus_tree_root, target, rank, ignore_stereo=ignore_stereo)
                 yield route
             except RetroCastException as e:
-                logger.warning(f"  - route for '{target.id}' failed transformation: {e}")
+                logger.warning(f"  - route for '{target.id}' failed transformation: {e} [{e.code}]")
                 continue
 
     def _transform(

--- a/src/retrocast/adapters/syntheseus_adapter.py
+++ b/src/retrocast/adapters/syntheseus_adapter.py
@@ -8,8 +8,9 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import build_molecule_from_bipartite_node
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
+from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
 
 logger = logging.getLogger(__name__)
@@ -62,11 +63,7 @@ class SyntheseusAdapter(BaseAdapter):
         try:
             validated_routes = SyntheseusRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            raise AdapterSchemaError(
-                f"raw data for target '{target.id}' failed syntheseus schema validation",
-                code="adapter.schema_invalid",
-                context={"adapter": "syntheseus", "target_id": target.id},
-            ) from e
+            raise adapter_schema_error("syntheseus", target.id, "invalid route list") from e
 
         for rank, syntheseus_tree_root in enumerate(validated_routes.root, start=1):
             try:
@@ -88,11 +85,11 @@ class SyntheseusAdapter(BaseAdapter):
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:
-            msg = (
-                f"mismatched smiles for target {target.id}. "
-                f"expected canonical: {expected_smiles}, but adapter produced: {target_molecule.smiles}"
+            raise adapter_target_mismatch(
+                "syntheseus",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=target_molecule.smiles,
             )
-            logger.error(msg)
-            raise AdapterLogicError(msg)
 
         return Route(target=target_molecule, rank=rank, metadata={})

--- a/src/retrocast/adapters/syntheseus_adapter.py
+++ b/src/retrocast/adapters/syntheseus_adapter.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.adapters.common import build_molecule_from_bipartite_node
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError, RetroCastException
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, RetroCastException
 from retrocast.models.chem import Route, TargetIdentity
 
 logger = logging.getLogger(__name__)
@@ -62,8 +62,11 @@ class SyntheseusAdapter(BaseAdapter):
         try:
             validated_routes = SyntheseusRouteList.model_validate(raw_target_data)
         except ValidationError as e:
-            logger.warning(f"  - raw data for target '{target.id}' failed syntheseus schema validation. error: {e}")
-            return
+            raise AdapterSchemaError(
+                f"raw data for target '{target.id}' failed syntheseus schema validation",
+                code="adapter.schema_invalid",
+                context={"adapter": "syntheseus", "target_id": target.id},
+            ) from e
 
         for rank, syntheseus_tree_root in enumerate(validated_routes.root, start=1):
             try:

--- a/src/retrocast/chem.py
+++ b/src/retrocast/chem.py
@@ -4,7 +4,7 @@ from enum import Enum
 from rdkit import Chem, rdBase
 from rdkit.Chem import rdinchi, rdMolDescriptors
 
-from retrocast.exceptions import InvalidSmilesError, RetroCastException
+from retrocast.exceptions import ChemRuntimeError, InvalidInchiKeyError, InvalidSmilesError, RetroCastException
 from retrocast.typing import InchiKeyStr, SmilesStr
 
 logger = logging.getLogger(__name__)
@@ -49,18 +49,29 @@ def _get_mol(smiles: str, func_name: str) -> Chem.Mol:
     """
     if not isinstance(smiles, str) or not smiles:
         msg = f"SMILES input must be a non-empty string in {func_name}"
-        logger.error(msg)
-        raise InvalidSmilesError(msg)
+        raise InvalidSmilesError(
+            msg,
+            code="chem.invalid_smiles",
+            context={"operation": func_name, "value": smiles},
+        )
 
     # rdkit handles exceptions poorly, usually just returns None or segfaults (rarely now)
     try:
         mol = Chem.MolFromSmiles(smiles)
     except Exception as e:
         # rare edge case where rdkit raises instead of returning None
-        raise RetroCastException(f"RDKit raised error parsing '{smiles}': {e}") from e
+        raise ChemRuntimeError(
+            f"RDKit raised error parsing '{smiles}': {e}",
+            code="chem.rdkit_parse_failed",
+            context={"operation": func_name, "smiles": smiles},
+        ) from e
 
     if mol is None:
-        raise InvalidSmilesError(f"Invalid SMILES string: {smiles}")
+        raise InvalidSmilesError(
+            f"Invalid SMILES string: {smiles}",
+            code="chem.invalid_smiles",
+            context={"operation": func_name, "smiles": smiles},
+        )
 
     return mol
 
@@ -94,7 +105,11 @@ def canonicalize_smiles(smiles: str, remove_mapping: bool = False, ignore_stereo
     except (InvalidSmilesError, RetroCastException):
         raise
     except Exception as e:
-        raise RetroCastException(f"Unexpected RDKit error canonicalizing '{smiles}': {e}") from e
+        raise ChemRuntimeError(
+            f"Unexpected RDKit error canonicalizing '{smiles}': {e}",
+            code="chem.rdkit_canonicalize_failed",
+            context={"operation": "canonicalize_smiles", "smiles": smiles},
+        ) from e
 
 
 def get_inchi_key(smiles: str, level: InchiKeyLevel = InchiKeyLevel.FULL) -> InchiKeyStr:
@@ -135,13 +150,21 @@ def get_inchi_key(smiles: str, level: InchiKeyLevel = InchiKeyLevel.FULL) -> Inc
             # MolToInchi returns (inchi, ret_code, message, log, aux_info)
             inchi, ret_code, _, _, _ = rdinchi.MolToInchi(mol, options="-SNon")
             if ret_code != 0:
-                raise RetroCastException(f"rdkit failed to generate inchi (code {ret_code})")
+                raise ChemRuntimeError(
+                    f"rdkit failed to generate inchi (code {ret_code})",
+                    code="chem.inchi_generation_failed",
+                    context={"smiles": smiles, "ret_code": ret_code, "level": level.value},
+                )
             key = rdinchi.InchiToInchiKey(inchi)
         else:
             key = Chem.MolToInchiKey(mol)
 
         if not key:
-            raise RetroCastException(f"Empty InchiKey generated for '{smiles}'")
+            raise ChemRuntimeError(
+                f"Empty InchiKey generated for '{smiles}'",
+                code="chem.inchikey_empty",
+                context={"smiles": smiles, "level": level.value},
+            )
 
         if level == InchiKeyLevel.CONNECTIVITY:
             return InchiKeyStr(key.split("-")[0])
@@ -151,7 +174,11 @@ def get_inchi_key(smiles: str, level: InchiKeyLevel = InchiKeyLevel.FULL) -> Inc
     except (InvalidSmilesError, RetroCastException):
         raise
     except Exception as e:
-        raise RetroCastException(f"unexpected error generating inchikey: {e}") from e
+        raise ChemRuntimeError(
+            f"unexpected error generating inchikey: {e}",
+            code="chem.inchikey_generation_failed",
+            context={"smiles": smiles, "level": level.value},
+        ) from e
 
 
 def reduce_inchikey(inchikey: str, level: InchiKeyLevel) -> InchiKeyStr:
@@ -186,19 +213,29 @@ def reduce_inchikey(inchikey: str, level: InchiKeyLevel) -> InchiKeyStr:
 
     # basic validation: 14 chars (1 part) or 27 chars (3 parts)
     if len(parts) not in (1, 3):
-        raise ValueError(f"malformed inchikey structure: {inchikey}")
+        raise InvalidInchiKeyError(
+            f"malformed inchikey structure: {inchikey}",
+            code="chem.invalid_inchikey",
+            context={"inchikey": inchikey, "target_level": level.value},
+        )
 
     # validate connectivity block is exactly 14 chars
     if len(parts[0]) != 14:
-        raise ValueError(f"invalid connectivity block length (expected 14, got {len(parts[0])}): {inchikey}")
+        raise InvalidInchiKeyError(
+            f"invalid connectivity block length (expected 14, got {len(parts[0])}): {inchikey}",
+            code="chem.invalid_inchikey",
+            context={"inchikey": inchikey, "target_level": level.value, "connectivity_length": len(parts[0])},
+        )
 
     current_is_partial = len(parts) == 1
     target_is_full = level in (InchiKeyLevel.FULL, InchiKeyLevel.NO_STEREO)
 
     # prevent upscaling (14 -> 25)
     if current_is_partial and target_is_full:
-        raise RetroCastException(
-            f"cannot upscale connectivity key '{inchikey}' to level '{level}'. information has been lost."
+        raise InvalidInchiKeyError(
+            f"cannot upscale connectivity key '{inchikey}' to level '{level}'. information has been lost.",
+            code="chem.inchikey_upscale",
+            context={"inchikey": inchikey, "target_level": level.value},
         )
 
     if level == InchiKeyLevel.FULL:
@@ -230,22 +267,31 @@ def get_heavy_atom_count(smiles: str) -> int:
         RetroCastException: For any other unexpected errors during processing.
     """
     if not isinstance(smiles, str) or not smiles:
-        logger.error("Provided SMILES for HAC calculation is not a valid string or is empty.")
-        raise InvalidSmilesError("SMILES input must be a non-empty string.")
+        raise InvalidSmilesError(
+            "SMILES input must be a non-empty string.",
+            code="chem.invalid_smiles",
+            context={"operation": "get_heavy_atom_count", "value": smiles},
+        )
 
     try:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
-            logger.debug(f"RDKit failed to parse SMILES for HAC calculation: '{smiles}'")
-            raise InvalidSmilesError(f"Invalid SMILES string: {smiles}")
+            raise InvalidSmilesError(
+                f"Invalid SMILES string: {smiles}",
+                code="chem.invalid_smiles",
+                context={"operation": "get_heavy_atom_count", "smiles": smiles},
+            )
 
         return mol.GetNumAtoms()
 
     except InvalidSmilesError:
         raise
     except Exception as e:
-        logger.error(f"An unexpected RDKit error occurred during HAC calculation for SMILES '{smiles}': {e}")
-        raise RetroCastException(f"An unexpected error occurred during HAC calculation: {e}") from e
+        raise ChemRuntimeError(
+            f"An unexpected error occurred during HAC calculation: {e}",
+            code="chem.descriptor_failed",
+            context={"operation": "get_heavy_atom_count", "smiles": smiles},
+        ) from e
 
 
 def get_molecular_weight(smiles: str) -> float:
@@ -263,22 +309,31 @@ def get_molecular_weight(smiles: str) -> float:
         RetroCastException: For any other unexpected errors during processing.
     """
     if not isinstance(smiles, str) or not smiles:
-        logger.error("Provided SMILES for MW calculation is not a valid string or is empty.")
-        raise InvalidSmilesError("SMILES input must be a non-empty string.")
+        raise InvalidSmilesError(
+            "SMILES input must be a non-empty string.",
+            code="chem.invalid_smiles",
+            context={"operation": "get_molecular_weight", "value": smiles},
+        )
 
     try:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
-            logger.warning(f"RDKit failed to parse SMILES for MW calculation: '{smiles}'")
-            raise InvalidSmilesError(f"Invalid SMILES string: {smiles}")
+            raise InvalidSmilesError(
+                f"Invalid SMILES string: {smiles}",
+                code="chem.invalid_smiles",
+                context={"operation": "get_molecular_weight", "smiles": smiles},
+            )
 
         return rdMolDescriptors.CalcExactMolWt(mol)
 
     except InvalidSmilesError:
         raise
     except Exception as e:
-        logger.error(f"An unexpected RDKit error occurred during MW calculation for SMILES '{smiles}': {e}")
-        raise RetroCastException(f"An unexpected error occurred during MW calculation: {e}") from e
+        raise ChemRuntimeError(
+            f"An unexpected error occurred during MW calculation: {e}",
+            code="chem.descriptor_failed",
+            context={"operation": "get_molecular_weight", "smiles": smiles},
+        ) from e
 
 
 def get_chiral_center_count(smiles: str) -> int:
@@ -296,14 +351,20 @@ def get_chiral_center_count(smiles: str) -> int:
         RetroCastException: For any other unexpected errors during processing.
     """
     if not isinstance(smiles, str) or not smiles:
-        logger.error("Provided SMILES for chiral center count is not a valid string or is empty.")
-        raise InvalidSmilesError("SMILES input must be a non-empty string.")
+        raise InvalidSmilesError(
+            "SMILES input must be a non-empty string.",
+            code="chem.invalid_smiles",
+            context={"operation": "get_chiral_center_count", "value": smiles},
+        )
 
     try:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
-            logger.warning(f"RDKit failed to parse SMILES for chiral center count: '{smiles}'")
-            raise InvalidSmilesError(f"Invalid SMILES string: {smiles}")
+            raise InvalidSmilesError(
+                f"Invalid SMILES string: {smiles}",
+                code="chem.invalid_smiles",
+                context={"operation": "get_chiral_center_count", "smiles": smiles},
+            )
 
         chiral_centers = Chem.FindMolChiralCenters(mol)
         return len(chiral_centers)
@@ -311,5 +372,8 @@ def get_chiral_center_count(smiles: str) -> int:
     except InvalidSmilesError:
         raise
     except Exception as e:
-        logger.error(f"An unexpected RDKit error occurred during chiral center count for SMILES '{smiles}': {e}")
-        raise RetroCastException(f"An unexpected error occurred during chiral center count: {e}") from e
+        raise ChemRuntimeError(
+            f"An unexpected error occurred during chiral center count: {e}",
+            code="chem.descriptor_failed",
+            context={"operation": "get_chiral_center_count", "smiles": smiles},
+        ) from e

--- a/src/retrocast/cli/adhoc.py
+++ b/src/retrocast/cli/adhoc.py
@@ -11,7 +11,7 @@ from retrocast.adapters import ADAPTER_MAP, get_adapter
 from retrocast.api import score_predictions
 from retrocast.cli.errors import log_expected_error
 from retrocast.curation.filtering import deduplicate_routes
-from retrocast.exceptions import AdapterError, RetroCastException
+from retrocast.exceptions import AdapterError, ChemError, RetroCastException
 from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.io.data import load_benchmark, load_routes, save_routes
 from retrocast.io.provenance import create_manifest
@@ -318,7 +318,7 @@ def handle_adapt(args: Any) -> None:
                     success_count += 1
                 else:
                     processed_routes[target_input.id] = []
-            except AdapterError as e:
+            except (AdapterError, ChemError) as e:
                 logger.debug(f"Failed to adapt {target_input.id}: {e}")
                 processed_routes[target_input.id] = []
 

--- a/src/retrocast/cli/adhoc.py
+++ b/src/retrocast/cli/adhoc.py
@@ -9,7 +9,9 @@ from tqdm import tqdm
 
 from retrocast.adapters import ADAPTER_MAP, get_adapter
 from retrocast.api import score_predictions
+from retrocast.cli.errors import log_expected_error
 from retrocast.curation.filtering import deduplicate_routes
+from retrocast.exceptions import AdapterError, RetroCastException
 from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.io.data import load_benchmark, load_routes, save_routes
 from retrocast.io.provenance import create_manifest
@@ -197,6 +199,9 @@ def handle_create_benchmark(args: Any) -> None:
 
         logger.info(f"Created manifest at {manifest_path}")
 
+    except RetroCastException as e:
+        log_expected_error(logger, "Failed to create benchmark", e, exc_info=True)
+        sys.exit(1)
     except Exception as e:
         logger.critical(f"Failed to create benchmark: {e}", exc_info=True)
         sys.exit(1)
@@ -239,6 +244,9 @@ def handle_score_file(args: Any) -> None:
         save_json_gz(results, output_path)
         logger.info(f"Scoring complete. Results saved to {output_path}")
 
+    except RetroCastException as e:
+        log_expected_error(logger, "Scoring failed", e, exc_info=True)
+        sys.exit(1)
     except Exception as e:
         logger.critical(f"Scoring failed: {e}", exc_info=True)
         sys.exit(1)
@@ -310,7 +318,7 @@ def handle_adapt(args: Any) -> None:
                     success_count += 1
                 else:
                     processed_routes[target_input.id] = []
-            except Exception as e:
+            except AdapterError as e:
                 logger.debug(f"Failed to adapt {target_input.id}: {e}")
                 processed_routes[target_input.id] = []
 
@@ -331,6 +339,9 @@ def handle_adapt(args: Any) -> None:
         with open(manifest_path, "w") as f:
             f.write(manifest.model_dump_json(indent=2))
 
+    except RetroCastException as e:
+        log_expected_error(logger, "Adaptation failed", e, exc_info=True)
+        sys.exit(1)
     except Exception as e:
         logger.critical(f"Adaptation failed: {e}", exc_info=True)
         sys.exit(1)

--- a/src/retrocast/cli/compare.py
+++ b/src/retrocast/cli/compare.py
@@ -45,7 +45,8 @@ from pathlib import Path
 
 import yaml
 
-from retrocast.exceptions import ConfigurationError
+from retrocast.cli.errors import log_expected_error
+from retrocast.exceptions import ConfigurationError, RetroCastException
 from retrocast.io.blob import load_json_gz
 from retrocast.models.stats import ModelStatistics
 from retrocast.utils.logging import logger
@@ -105,6 +106,9 @@ def _load_sources(
             try:
                 stats = ModelStatistics.model_validate(load_json_gz(stats_path))
                 stats_list.append(stats)
+            except RetroCastException as e:
+                log_expected_error(logger, f"[red]Failed to load {name}[/]", e)
+                continue
             except Exception as e:
                 logger.error(f"[red]Failed to load {name}[/]: {e}")
                 continue
@@ -195,7 +199,11 @@ def handle_pareto_frontier(args: argparse.Namespace) -> None:
             try:
                 r, g, b = int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)
             except ValueError as e:
-                raise ConfigurationError(f"Group color must be in #RRGGBB hex format, got: {color!r}") from e
+                raise ConfigurationError(
+                    f"Group color must be in #RRGGBB hex format, got: {color!r}",
+                    code="config.invalid_color",
+                    context={"group": group_id, "color": color},
+                ) from e
             fig.add_trace(
                 go.Scatter(
                     x=[p[0] for p in points],

--- a/src/retrocast/cli/errors.py
+++ b/src/retrocast/cli/errors.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+from retrocast.exceptions import RetroCastException
+
+
+def format_cli_error(error: RetroCastException) -> str:
+    """Format an expected RetroCast failure for a CLI boundary."""
+    bits = [f"{error.message} [{error.code}]"]
+    if error.context:
+        safe_context = ", ".join(f"{key}={value}" for key, value in sorted(error.context.items()))
+        bits.append(f"({safe_context})")
+    return " ".join(bits)
+
+
+def log_expected_error(
+    logger: logging.Logger, message: str, error: RetroCastException, *, exc_info: bool = False
+) -> None:
+    logger.error(f"{message}: {format_cli_error(error)}", exc_info=exc_info)

--- a/src/retrocast/cli/errors.py
+++ b/src/retrocast/cli/errors.py
@@ -9,7 +9,10 @@ def format_cli_error(error: RetroCastException) -> str:
     """Format an expected RetroCast failure for a CLI boundary."""
     bits = [f"{error.message} [{error.code}]"]
     if error.context:
-        safe_context = ", ".join(f"{key}={value}" for key, value in sorted(error.context.items()))
+        safe_context = ", ".join(
+            f"{key}={str(value).replace(chr(10), ' ').replace(chr(13), ' ')}"
+            for key, value in sorted(error.context.items())
+        )
         bits.append(f"({safe_context})")
     return " ".join(bits)
 

--- a/src/retrocast/cli/handlers.py
+++ b/src/retrocast/cli/handlers.py
@@ -11,8 +11,9 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 
 from retrocast.adapters.resolve import resolve_adapter, resolve_raw_results_filename
 from retrocast.chem import InchiKeyLevel
+from retrocast.cli.errors import log_expected_error
 from retrocast.curation.sampling import SAMPLING_STRATEGIES
-from retrocast.exceptions import SecurityError
+from retrocast.exceptions import AdapterResolutionError, RetroCastException, SecurityError
 from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.io.data import load_benchmark, load_execution_stats, load_routes, load_stock_file
 from retrocast.io.provenance import create_manifest
@@ -150,7 +151,7 @@ def _ingest_single(model_name: str, benchmark_name: str, paths: dict, args: Any)
     # Security: Ensure raw_dir is within the raw directory bounds
     try:
         raw_dir = ensure_path_within_root(raw_dir, paths["raw"], "raw data directory")
-    except Exception as e:
+    except SecurityError as e:
         logger.error(f"Security violation for {model_name}/{benchmark_name}: {e}")
         return
 
@@ -166,12 +167,16 @@ def _ingest_single(model_name: str, benchmark_name: str, paths: dict, args: Any)
             model_name=model_name,
         )
         logger.info(f"Resolved adapter from {source} for {model_name}/{benchmark_name}")
-    except Exception as e:
-        logger.error(f"Skipping {model_name}/{benchmark_name}: {e}")
+    except AdapterResolutionError as e:
+        logger.error(f"Skipping {model_name}/{benchmark_name}: {e} [{e.code}]")
         return
 
     # Resolve raw results filename from manifest directives
-    raw_filename = resolve_raw_results_filename(raw_dir=raw_dir)
+    try:
+        raw_filename = resolve_raw_results_filename(raw_dir=raw_dir)
+    except SecurityError as e:
+        logger.error(f"Security violation for {model_name}/{benchmark_name}: {e}")
+        return
     raw_path = raw_dir / raw_filename
 
     # Security: Ensure raw_path is within the raw directory bounds
@@ -228,6 +233,8 @@ def _ingest_single(model_name: str, benchmark_name: str, paths: dict, args: Any)
         with open(manifest_path, "w") as f:
             f.write(manifest.model_dump_json(indent=2))
 
+    except RetroCastException as e:
+        log_expected_error(logger, f"Failed to ingest {model_name} on {benchmark_name}", e, exc_info=True)
     except Exception as e:
         logger.error(f"Failed to ingest {model_name} on {benchmark_name}: {e}", exc_info=True)
 
@@ -254,7 +261,7 @@ def _score_single(model_name: str, benchmark_name: str, paths: dict, args: Any) 
     # Security: Ensure paths are within bounds
     try:
         routes_path = ensure_path_within_root(routes_path, paths["processed"], "routes path")
-    except Exception as e:
+    except SecurityError as e:
         logger.error(f"Security violation for {model_name}/{benchmark_name}: {e}")
         return
 
@@ -289,7 +296,7 @@ def _score_single(model_name: str, benchmark_name: str, paths: dict, args: Any) 
         # Security: Ensure exec_stats_path is within bounds
         try:
             exec_stats_path = ensure_path_within_root(exec_stats_path, paths["raw"], "execution stats path")
-        except Exception as e:
+        except SecurityError as e:
             logger.warning(f"Security violation for execution stats: {e}")
             exec_stats_path = None
 
@@ -297,6 +304,8 @@ def _score_single(model_name: str, benchmark_name: str, paths: dict, args: Any) 
             try:
                 execution_stats = load_execution_stats(exec_stats_path)
                 logger.info(f"Loaded execution stats from {exec_stats_path}")
+            except RetroCastException as e:
+                logger.warning(f"Failed to load execution stats from {exec_stats_path}: {e} [{e.code}]")
             except Exception as e:
                 logger.warning(f"Failed to load execution stats from {exec_stats_path}: {e}")
 
@@ -335,6 +344,8 @@ def _score_single(model_name: str, benchmark_name: str, paths: dict, args: Any) 
 
         logger.info(f"Scored {model_name} on {benchmark_name} (Stock: {stock_name}). Saved to {out_path}")
 
+    except RetroCastException as e:
+        log_expected_error(logger, f"Failed to score {model_name} on {benchmark_name}", e, exc_info=True)
     except Exception as e:
         logger.error(f"Failed to score {model_name} on {benchmark_name}: {e}", exc_info=True)
 
@@ -363,7 +374,7 @@ def _analyze_single(model_name: str, benchmark_name: str, paths: dict, args: Any
     # Security: Ensure scored_base is within the scored directory bounds
     try:
         scored_base = ensure_path_within_root(scored_base, paths["scored"], "scored base directory")
-    except Exception as e:
+    except SecurityError as e:
         logger.error(f"Security violation for {model_name}/{benchmark_name}: {e}")
         return
 
@@ -385,7 +396,7 @@ def _analyze_single(model_name: str, benchmark_name: str, paths: dict, args: Any
         # Security: Ensure score_path is within bounds
         try:
             score_path = ensure_path_within_root(score_path, paths["scored"], "score file path")
-        except Exception as e:
+        except SecurityError as e:
             logger.error(f"Security violation for {model_name}/{benchmark_name}/{stock_name}: {e}")
             continue
         if not score_path.exists():
@@ -423,6 +434,8 @@ def _analyze_single(model_name: str, benchmark_name: str, paths: dict, args: Any
             console.print(create_single_model_summary_table(final_stats, visible_k=args.top_k))
             console.print(f"\n[dim]Full report saved to: {output_dir}[/]\n")
 
+        except RetroCastException as e:
+            log_expected_error(logger, f"Failed analysis for {model_name} ({stock_name})", e, exc_info=True)
         except Exception as e:
             logger.error(f"Failed analysis for {model_name} ({stock_name}): {e}", exc_info=True)
 
@@ -538,6 +551,9 @@ def handle_verify(args: Any, config: dict[str, Any]) -> None:
                 )
                 all_reports.append(report)
                 _render_report(report)
+            except RetroCastException as e:
+                console.print(f"[red]Failed to verify {manifest_path}: {e}[/]")
+                logger.error(f"Verification error for {manifest_path}: {e.code}", exc_info=True)
             except Exception as e:
                 console.print(f"[red]Failed to verify {manifest_path}: {e}[/]")
                 logger.error(f"Verification error for {manifest_path}", exc_info=True)

--- a/src/retrocast/cli/main.py
+++ b/src/retrocast/cli/main.py
@@ -7,6 +7,8 @@ import yaml
 
 from retrocast import __version__
 from retrocast.cli import adhoc, compare, handlers
+from retrocast.cli.errors import format_cli_error
+from retrocast.exceptions import RetroCastException
 from retrocast.paths import ENV_VAR_NAME, check_migration_needed, get_data_dir_source, resolve_data_dir
 from retrocast.utils.logging import configure_script_logging, logger
 
@@ -228,6 +230,9 @@ def main() -> None:
         elif args.command == "verify":
             handlers.handle_verify(args, config)
 
+    except RetroCastException as e:
+        logger.critical(f"Command failed: {format_cli_error(e)}", exc_info=True)
+        sys.exit(1)
     except Exception as e:
         logger.critical(f"Command failed: {e}", exc_info=True)
         sys.exit(1)

--- a/src/retrocast/exceptions.py
+++ b/src/retrocast/exceptions.py
@@ -1,70 +1,185 @@
+from __future__ import annotations
+
+from typing import Any
+
+
 class RetroCastException(Exception):
-    """Base exception for all errors raised by the retrocast package."""
+    """Base exception for boundary-facing errors raised by retrocast."""
 
-    pass
+    default_code = "retrocast.error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        context: dict[str, Any] | None = None,
+        retryable: bool = False,
+    ) -> None:
+        self.code = code or self.default_code
+        self.message = message
+        self.context = context or {}
+        self.retryable = retryable
+        Exception.__init__(self, message)
+
+    def __str__(self) -> str:
+        return self.message
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable boundary shape used by logs, manifests, and tests."""
+        return {
+            "code": self.code,
+            "message": self.message,
+            "context": self.context,
+            "retryable": self.retryable,
+        }
 
 
-class SecurityError(RetroCastException):
-    """Raised when security validation fails (path traversal, unsafe filenames, etc.)."""
+class InputError(RetroCastException, ValueError):
+    """Raised when external input is invalid at a package, cli, or workflow boundary."""
 
-    pass
-
-
-class InvalidSmilesError(RetroCastException):
-    """Raised when a SMILES string is malformed or cannot be processed."""
-
-    pass
+    default_code = "input.invalid"
 
 
-class SchemaLogicError(RetroCastException, ValueError):
-    """Raised when data violates the logical rules of a schema, beyond basic type validation."""
+class ChemError(RetroCastException):
+    """Raised for chemistry parsing, normalization, or identity failures."""
 
-    pass
+    default_code = "chem.error"
 
 
-class BenchmarkValidationError(RetroCastException, ValueError):
+class DataIOError(RetroCastException):
+    """Raised for expected artifact read, write, decode, or format failures."""
+
+    default_code = "io.error"
+
+
+class AdapterError(RetroCastException):
+    """Raised for expected adapter resolution, schema, or route contract failures."""
+
+    default_code = "adapter.error"
+
+
+class WorkflowError(RetroCastException):
+    """Raised when a workflow cannot complete an expected operation."""
+
+    default_code = "workflow.error"
+
+
+class BenchmarkError(RetroCastException, ValueError):
+    """Raised when benchmark construction or validation fails."""
+
+    default_code = "benchmark.error"
+
+
+class SecurityError(InputError):
+    """Raised when security validation fails, such as path traversal or unsafe filenames."""
+
+    default_code = "security.path_invalid"
+
+
+class InvalidSmilesError(ChemError, ValueError):
+    """Raised when a smiles string is malformed or cannot be processed."""
+
+    default_code = "chem.invalid_smiles"
+
+
+class ChemRuntimeError(ChemError):
+    """Raised when rdkit or a chemistry backend fails unexpectedly."""
+
+    default_code = "chem.runtime_error"
+
+
+class InvalidInchiKeyError(ChemError, ValueError):
+    """Raised when an inchikey is malformed or cannot be transformed as requested."""
+
+    default_code = "chem.invalid_inchikey"
+
+
+class SchemaLogicError(InputError):
+    """Raised when data violates logical schema rules beyond basic type validation."""
+
+    default_code = "schema.logic_error"
+
+
+class BenchmarkValidationError(BenchmarkError):
     """Raised when benchmark data violates uniqueness or validation constraints."""
 
-    pass
+    default_code = "benchmark.validation_failed"
 
 
-class AdapterLogicError(RetroCastException):
-    """Raised when an adapter fails to correctly fulfill its transformation contract."""
+class AdapterLogicError(AdapterError):
+    """Raised when an adapter cannot fulfill its route transformation contract."""
 
-    pass
-
-
-class AdapterResolutionError(RetroCastException):
-    """Raised when no adapter can be resolved from any source in the resolution hierarchy."""
-
-    pass
+    default_code = "adapter.route_transform_failed"
 
 
-class RetroCastIOError(RetroCastException):
+class AdapterResolutionError(AdapterError):
+    """Raised when no adapter can be resolved from the resolution hierarchy."""
+
+    default_code = "adapter.resolution_failed"
+
+
+class AdapterSchemaError(AdapterError):
+    """Raised when raw adapter input fails expected schema validation."""
+
+    default_code = "adapter.schema_invalid"
+
+
+class UnsupportedAdapterFeatureError(AdapterError, NotImplementedError):
+    """Raised when an adapter receives a valid request for an unsupported feature."""
+
+    default_code = "adapter.unsupported_feature"
+
+
+class RetroCastIOError(DataIOError):
     """Raised for file system or I/O related errors during processing."""
 
-    pass
+    default_code = "io.error"
 
 
-class ConfigurationError(RetroCastException, ValueError):
-    """Raised when a YAML configuration value is invalid or malformed."""
+class ArtifactNotFoundError(RetroCastIOError):
+    """Raised when a required artifact is missing."""
 
-    pass
+    default_code = "io.not_found"
+
+
+class ArtifactFormatError(RetroCastIOError, ValueError):
+    """Raised when an artifact has an unsupported or invalid format."""
+
+    default_code = "io.unsupported_format"
+
+
+class ArtifactDecodeError(RetroCastIOError):
+    """Raised when an artifact cannot be decoded or parsed."""
+
+    default_code = "io.decode_failed"
+
+
+class ArtifactWriteError(RetroCastIOError):
+    """Raised when an artifact cannot be written."""
+
+    default_code = "io.write_failed"
+
+
+class ConfigurationError(InputError):
+    """Raised when a configuration value is invalid or malformed."""
+
+    default_code = "config.invalid_value"
 
 
 class RetroCastSerializationError(RetroCastException):
-    """Raised when data cannot be serialized to the desired format (e.g., JSON)."""
+    """Raised when data cannot be serialized to the desired format."""
 
-    pass
+    default_code = "serialization.failed"
 
 
 class TtlRetroSerializationError(RetroCastSerializationError):
-    """custom exception for errors during ttlretro route serialization."""
+    """Raised for errors during ttlretro route serialization."""
 
-    pass
+    default_code = "serialization.ttlretro_failed"
 
 
 class SyntheseusSerializationError(RetroCastSerializationError):
-    """Custom exception for errors during syntheseus route serialization."""
+    """Raised for errors during syntheseus route serialization."""
 
-    pass
+    default_code = "serialization.syntheseus_failed"

--- a/src/retrocast/exceptions.py
+++ b/src/retrocast/exceptions.py
@@ -146,7 +146,7 @@ class ArtifactNotFoundError(RetroCastIOError):
 class ArtifactFormatError(RetroCastIOError, ValueError):
     """Raised when an artifact has an unsupported or invalid format."""
 
-    default_code = "io.unsupported_format"
+    default_code = "io.invalid_artifact_shape"
 
 
 class ArtifactDecodeError(RetroCastIOError):

--- a/src/retrocast/io/blob.py
+++ b/src/retrocast/io/blob.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from retrocast.exceptions import ArtifactDecodeError, ArtifactNotFoundError, ArtifactWriteError
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,29 +17,40 @@ def save_json_gz(data: Any, path: Path) -> None:
     If data is a Pydantic model, dumps it first.
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    if isinstance(data, BaseModel):
-        json_obj = data.model_dump(mode="json")
-    else:
-        json_obj = data
-
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(data, BaseModel):
+            json_obj = data.model_dump(mode="json")
+        else:
+            json_obj = data
         json_str = json.dumps(json_obj, indent=2)
         with gzip.open(path, "wt", encoding="utf-8") as f:
             f.write(json_str)
         logger.debug(f"Saved {path}")
-    except Exception as e:
-        logger.error(f"Failed to save {path}: {e}")
-        raise
+    except (OSError, TypeError, ValueError) as e:
+        raise ArtifactWriteError(
+            f"Failed to save {path}: {e}",
+            code="io.write_failed",
+            context={"path": str(path)},
+        ) from e
 
 
 def load_json_gz(path: Path) -> Any:
     """Loads a gzipped JSON file."""
     path = Path(path)
+    if not path.exists():
+        raise ArtifactNotFoundError(
+            f"File not found: {path}",
+            code="io.not_found",
+            context={"path": str(path)},
+        )
+
     try:
         with gzip.open(path, "rt", encoding="utf-8") as f:
             return json.load(f)
-    except Exception as e:
-        logger.error(f"Failed to load {path}: {e}")
-        raise
+    except (OSError, json.JSONDecodeError) as e:
+        raise ArtifactDecodeError(
+            f"Failed to load {path}: {e}",
+            code="io.decode_failed",
+            context={"path": str(path)},
+        ) from e

--- a/src/retrocast/io/data.py
+++ b/src/retrocast/io/data.py
@@ -12,7 +12,6 @@ from retrocast.exceptions import (
     ArtifactFormatError,
     ArtifactNotFoundError,
     ArtifactWriteError,
-    RetroCastIOError,
 )
 from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.io.provenance import create_manifest
@@ -146,16 +145,13 @@ def load_stock_file(
         Set of InChI keys or SMILES representing available stock molecules
 
     Raises:
-        RetroCastIOError: If file cannot be read, format is invalid, or return_as is invalid
+        RetroCastIOError: If file cannot be read or the artifact format is invalid.
+        ValueError: If return_as is not "inchikey" or "smiles".
     """
     path = Path(path)
 
     if return_as not in ("inchikey", "smiles"):
-        raise ArtifactFormatError(
-            f"Invalid return_as parameter: '{return_as}'. Must be 'inchikey' or 'smiles'.",
-            code="io.invalid_return_format",
-            context={"path": str(path), "return_as": return_as},
-        )
+        raise ValueError(f"Invalid return_as parameter: '{return_as}'. Must be 'inchikey' or 'smiles'.")
 
     if not path.exists():
         raise ArtifactNotFoundError(
@@ -185,7 +181,7 @@ def load_stock_file(
             if reader.fieldnames is None or required_col not in reader.fieldnames:
                 raise ArtifactFormatError(
                     f"Invalid stock CSV format. Expected header with '{required_col}' column. Got: {reader.fieldnames}",
-                    code="io.invalid_header",
+                    code="io.invalid_artifact_shape",
                     context={"path": str(path), "required_column": required_col, "columns": reader.fieldnames},
                 )
 
@@ -203,9 +199,9 @@ def load_stock_file(
         return molecules
 
     except OSError as e:
-        raise RetroCastIOError(
+        raise ArtifactDecodeError(
             f"Failed to read stock file {path}: {e}",
-            code="io.read_failed",
+            code="io.decode_failed",
             context={"path": str(path), "artifact": "stock"},
         ) from e
 

--- a/src/retrocast/io/data.py
+++ b/src/retrocast/io/data.py
@@ -5,9 +5,15 @@ import logging
 from pathlib import Path
 from typing import Literal, overload
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
-from retrocast.exceptions import RetroCastIOError
+from retrocast.exceptions import (
+    ArtifactDecodeError,
+    ArtifactFormatError,
+    ArtifactNotFoundError,
+    ArtifactWriteError,
+    RetroCastIOError,
+)
 from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.io.provenance import create_manifest
 from retrocast.models.benchmark import BenchmarkSet, ExecutionStats
@@ -32,12 +38,19 @@ def save_routes(routes: RoutesDict, path: Path) -> None:
         path: output path (usually .json.gz)
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
 
-    # dump_json returns bytes, so we use "wb"
-    json_bytes = _ROUTES_ADAPTER.dump_json(routes, indent=2)
-    with gzip.open(path, "wb") as f:
-        f.write(json_bytes)
+        # dump_json returns bytes, so we use "wb"
+        json_bytes = _ROUTES_ADAPTER.dump_json(routes, indent=2)
+        with gzip.open(path, "wb") as f:
+            f.write(json_bytes)
+    except (OSError, TypeError, ValueError) as e:
+        raise ArtifactWriteError(
+            f"Failed to save routes to {path}: {e}",
+            code="io.write_failed",
+            context={"path": str(path), "artifact": "routes"},
+        ) from e
     logger.debug(f"Saved {sum(len(r) for r in routes.values())} routes to {path}")
 
 
@@ -50,11 +63,31 @@ def load_routes(path: Path) -> RoutesDict:
     """
     path = Path(path)
     logger.debug(f"Loading routes from {path}...")
+    if not path.exists():
+        raise ArtifactNotFoundError(
+            f"Routes file not found: {path}",
+            code="io.not_found",
+            context={"path": str(path), "artifact": "routes"},
+        )
 
-    with gzip.open(path, "rb") as f:
-        json_bytes = f.read()
+    try:
+        with gzip.open(path, "rb") as f:
+            json_bytes = f.read()
+    except OSError as e:
+        raise ArtifactDecodeError(
+            f"Failed to load routes from {path}: {e}",
+            code="io.decode_failed",
+            context={"path": str(path), "artifact": "routes"},
+        ) from e
 
-    routes = _ROUTES_ADAPTER.validate_json(json_bytes)
+    try:
+        routes = _ROUTES_ADAPTER.validate_json(json_bytes)
+    except ValidationError as e:
+        raise ArtifactFormatError(
+            f"Invalid routes JSON format in {path}: {e}",
+            code="io.invalid_artifact_shape",
+            context={"path": str(path), "artifact": "routes"},
+        ) from e
     logger.debug(f"Loaded {sum(len(r) for r in routes.values())} routes for {len(routes)} targets.")
     return routes
 
@@ -65,7 +98,14 @@ def load_benchmark(path: Path) -> BenchmarkSet:
     """
     logger.info(f"Loading benchmark from {path}...")
     data = load_json_gz(path)
-    benchmark = BenchmarkSet.model_validate(data)
+    try:
+        benchmark = BenchmarkSet.model_validate(data)
+    except ValidationError as e:
+        raise ArtifactFormatError(
+            f"Invalid benchmark JSON format in {path}: {e}",
+            code="io.invalid_artifact_shape",
+            context={"path": str(path), "artifact": "benchmark"},
+        ) from e
     logger.info(f"Loaded benchmark '{benchmark.name}' with {len(benchmark.targets)} targets.")
     return benchmark
 
@@ -78,7 +118,11 @@ def load_raw_paroutes_list(path: Path) -> list[dict]:
     logger.info(f"Loading raw PaRoutes data from {path}...")
     data = load_json_gz(path)
     if not isinstance(data, list):
-        raise ValueError(f"Expected list, got {type(data)}")
+        raise ArtifactFormatError(
+            f"Expected list, got {type(data)}",
+            code="io.invalid_artifact_shape",
+            context={"path": str(path), "expected": "list", "actual": type(data).__name__},
+        )
     return data
 
 
@@ -107,18 +151,26 @@ def load_stock_file(
     path = Path(path)
 
     if return_as not in ("inchikey", "smiles"):
-        raise RetroCastIOError(f"Invalid return_as parameter: '{return_as}'. Must be 'inchikey' or 'smiles'.")
+        raise ArtifactFormatError(
+            f"Invalid return_as parameter: '{return_as}'. Must be 'inchikey' or 'smiles'.",
+            code="io.invalid_return_format",
+            context={"path": str(path), "return_as": return_as},
+        )
 
     if not path.exists():
-        raise RetroCastIOError(
+        raise ArtifactNotFoundError(
             f"Stock file not found: {path}. "
-            f"Expected .csv.gz format. Run scripts/1-canonicalize-stock.py to generate stock files."
+            f"Expected .csv.gz format. Run scripts/1-canonicalize-stock.py to generate stock files.",
+            code="io.not_found",
+            context={"path": str(path), "artifact": "stock"},
         )
 
     if not path.name.endswith(".csv.gz"):
-        raise RetroCastIOError(
+        raise ArtifactFormatError(
             f"Invalid stock file format: {path}. "
-            f"Only .csv.gz format is supported. Run scripts/1-canonicalize-stock.py to convert."
+            f"Only .csv.gz format is supported. Run scripts/1-canonicalize-stock.py to convert.",
+            code="io.unsupported_format",
+            context={"path": str(path), "expected_suffix": ".csv.gz"},
         )
 
     logger.debug(f"Loading stock from {path}...")
@@ -131,8 +183,10 @@ def load_stock_file(
             # Validate header
             required_col = "InChIKey" if return_as == "inchikey" else "SMILES"
             if reader.fieldnames is None or required_col not in reader.fieldnames:
-                raise RetroCastIOError(
-                    f"Invalid stock CSV format. Expected header with '{required_col}' column. Got: {reader.fieldnames}"
+                raise ArtifactFormatError(
+                    f"Invalid stock CSV format. Expected header with '{required_col}' column. Got: {reader.fieldnames}",
+                    code="io.invalid_header",
+                    context={"path": str(path), "required_column": required_col, "columns": reader.fieldnames},
                 )
 
             for row in reader:
@@ -149,7 +203,11 @@ def load_stock_file(
         return molecules
 
     except OSError as e:
-        raise RetroCastIOError(f"Failed to read stock file {path}: {e}") from e
+        raise RetroCastIOError(
+            f"Failed to read stock file {path}: {e}",
+            code="io.read_failed",
+            context={"path": str(path), "artifact": "stock"},
+        ) from e
 
 
 def load_execution_stats(path: Path) -> ExecutionStats:
@@ -158,7 +216,14 @@ def load_execution_stats(path: Path) -> ExecutionStats:
     """
     logger.info(f"Loading execution stats from {path}...")
     data = load_json_gz(path)
-    stats = ExecutionStats.model_validate(data)
+    try:
+        stats = ExecutionStats.model_validate(data)
+    except ValidationError as e:
+        raise ArtifactFormatError(
+            f"Invalid execution stats JSON format in {path}: {e}",
+            code="io.invalid_artifact_shape",
+            context={"path": str(path), "artifact": "execution_stats"},
+        ) from e
     logger.info(
         f"Loaded execution stats with {len(stats.wall_time)} wall_time and {len(stats.cpu_time)} cpu_time entries."
     )
@@ -213,7 +278,6 @@ def save_stock_files(
     """
 
     output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Define output paths (gzipped)
     csv_path = output_dir / f"{stock_name}.csv.gz"
@@ -221,6 +285,14 @@ def save_stock_files(
     manifest_path = output_dir / f"{stock_name}.manifest.json"
 
     logger.info(f"Saving stock files for '{stock_name}'...")
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise ArtifactWriteError(
+            f"Failed to create stock output directory {output_dir}: {e}",
+            code="io.write_failed",
+            context={"path": str(output_dir), "artifact": "stock"},
+        ) from e
 
     # Sort by InChI key for deterministic output
     sorted_items = sorted(stock.items(), key=lambda x: x[0])
@@ -234,7 +306,11 @@ def save_stock_files(
             for inchi_key, smiles in sorted_items:
                 writer.writerow([smiles, inchi_key])
     except OSError as e:
-        raise RetroCastIOError(f"Failed to write CSV file {csv_path}: {e}") from e
+        raise ArtifactWriteError(
+            f"Failed to write CSV file {csv_path}: {e}",
+            code="io.write_failed",
+            context={"path": str(csv_path), "artifact": "stock_csv"},
+        ) from e
 
     # Save TXT (SMILES only, for models that need plain text) - gzipped
     logger.debug(f"Writing TXT to {txt_path}...")
@@ -243,7 +319,11 @@ def save_stock_files(
             for _, smiles in sorted_items:
                 f.write(f"{smiles}\n")
     except OSError as e:
-        raise RetroCastIOError(f"Failed to write TXT file {txt_path}: {e}") from e
+        raise ArtifactWriteError(
+            f"Failed to write TXT file {txt_path}: {e}",
+            code="io.write_failed",
+            context={"path": str(txt_path), "artifact": "stock_txt"},
+        ) from e
 
     # Create manifest
     logger.debug(f"Creating manifest at {manifest_path}...")
@@ -263,8 +343,15 @@ def save_stock_files(
     )
 
     manifest_json = manifest.model_dump(mode="json")
-    with manifest_path.open("w", encoding="utf-8") as f:
-        json.dump(manifest_json, f, indent=2, sort_keys=False)
+    try:
+        with manifest_path.open("w", encoding="utf-8") as f:
+            json.dump(manifest_json, f, indent=2, sort_keys=False)
+    except (OSError, TypeError, ValueError) as e:
+        raise ArtifactWriteError(
+            f"Failed to write stock manifest {manifest_path}: {e}",
+            code="io.write_failed",
+            context={"path": str(manifest_path), "artifact": "stock_manifest"},
+        ) from e
 
     logger.info(f"✓ Saved {len(stock):,} molecules")
     logger.debug(f"  CSV: {csv_path}")

--- a/src/retrocast/models/benchmark.py
+++ b/src/retrocast/models/benchmark.py
@@ -151,7 +151,12 @@ def validate_benchmark_targets(targets: dict[str, BenchmarkTarget]) -> None:
 
     if errors:
         raise BenchmarkValidationError(
-            "Benchmark contains duplicate molecules:\n" + "\n".join(f"  - {e}" for e in errors)
+            "Benchmark contains duplicate molecules:\n" + "\n".join(f"  - {e}" for e in errors),
+            code="benchmark.duplicate_molecule",
+            context={
+                "smiles_duplicate_count": len(smiles_duplicates),
+                "inchikey_duplicate_count": len(inchikey_duplicates),
+            },
         )
 
 
@@ -186,7 +191,9 @@ def validate_acceptable_routes_solvable(benchmark: BenchmarkSet, stock: set[Inch
             error_summary.append(f"... and {len(errors) - 10} more unsolvable routes")
 
         raise BenchmarkValidationError(
-            f"Found {len(errors)} unsolvable acceptable routes:\n" + "\n".join(f"  - {e}" for e in error_summary)
+            f"Found {len(errors)} unsolvable acceptable routes:\n" + "\n".join(f"  - {e}" for e in error_summary),
+            code="benchmark.unsolvable_route",
+            context={"benchmark": benchmark.name, "unsolvable_route_count": len(errors)},
         )
 
 

--- a/src/retrocast/models/chem.py
+++ b/src/retrocast/models/chem.py
@@ -346,6 +346,16 @@ class RunStatistics(BaseModel):
     final_unique_routes_saved: int = 0
     targets_with_at_least_one_route: set[str] = Field(default_factory=set)
     routes_per_target: dict[str, int] = Field(default_factory=dict)
+    failures_by_code: dict[str, int] = Field(default_factory=dict)
+    failures_by_target: dict[str, dict[str, int]] = Field(default_factory=dict)
+
+    def record_failure(self, code: str, *, target_id: str | None = None) -> None:
+        """Record a workflow-classified target failure."""
+        self.routes_failed_transformation += 1
+        self.failures_by_code[code] = self.failures_by_code.get(code, 0) + 1
+        if target_id is not None:
+            target_failures = self.failures_by_target.setdefault(target_id, {})
+            target_failures[code] = target_failures.get(code, 0) + 1
 
     @property
     def total_failures(self) -> int:
@@ -393,7 +403,7 @@ class RunStatistics(BaseModel):
             return 0.0
         return round(statistics.median(self.routes_per_target.values()), 2)
 
-    def to_manifest_dict(self) -> dict[str, int | float]:
+    def to_manifest_dict(self) -> dict[str, int | float | dict[str, int]]:
         """Generates a dictionary suitable for including in the final manifest."""
         return {
             "total_routes_in_raw_files": self.total_routes_in_raw_files,
@@ -406,4 +416,5 @@ class RunStatistics(BaseModel):
             "max_routes_per_target": self.max_routes_per_target,
             "avg_routes_per_target": self.avg_routes_per_target,
             "median_routes_per_target": self.median_routes_per_target,
+            "failures_by_code": dict(sorted(self.failures_by_code.items())),
         }

--- a/src/retrocast/paths.py
+++ b/src/retrocast/paths.py
@@ -30,21 +30,35 @@ def validate_filename(filename: str, param_name: str = "filename") -> str:
     """
     # Check for null bytes
     if "\x00" in filename:
-        raise SecurityError(f"{param_name} contains null bytes: {filename!r}")
+        raise SecurityError(
+            f"{param_name} contains null bytes: {filename!r}",
+            code="security.path_null_byte",
+            context={"param": param_name, "value": filename},
+        )
 
     # Check for path separators (both Unix and Windows)
     if "/" in filename or "\\" in filename:
         raise SecurityError(
-            f"{param_name} contains path separator: {filename!r}. Filenames cannot contain '/' or '\\'."
+            f"{param_name} contains path separator: {filename!r}. Filenames cannot contain '/' or '\\'.",
+            code="security.path_separator",
+            context={"param": param_name, "value": filename},
         )
 
     # Check for parent directory traversal
     if filename == ".." or filename.startswith("../") or filename.endswith("/.."):
-        raise SecurityError(f"{param_name} contains parent directory reference: {filename!r}")
+        raise SecurityError(
+            f"{param_name} contains parent directory reference: {filename!r}",
+            code="security.path_traversal",
+            context={"param": param_name, "value": filename},
+        )
 
     # Check for current directory reference at problematic positions
     if filename == "." or filename.startswith("./") or filename.endswith("/."):
-        raise SecurityError(f"{param_name} contains current directory reference: {filename!r}")
+        raise SecurityError(
+            f"{param_name} contains current directory reference: {filename!r}",
+            code="security.current_directory",
+            context={"param": param_name, "value": filename},
+        )
 
     return filename
 
@@ -92,7 +106,14 @@ def ensure_path_within_root(path: Path, root: Path, description: str = "path") -
         resolved_path.relative_to(resolved_root)
     except ValueError as exc:
         raise SecurityError(
-            f"{description} escapes root directory: {path} (resolved: {resolved_path}, root: {resolved_root})"
+            f"{description} escapes root directory: {path} (resolved: {resolved_path}, root: {resolved_root})",
+            code="security.path_traversal",
+            context={
+                "description": description,
+                "path": str(path),
+                "resolved_path": str(resolved_path),
+                "root": str(resolved_root),
+            },
         ) from exc
 
     return resolved_path

--- a/src/retrocast/workflow/ingest.py
+++ b/src/retrocast/workflow/ingest.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.curation.filtering import deduplicate_routes
 from retrocast.curation.sampling import sample_k_by_length, sample_random_k, sample_top_k
+from retrocast.exceptions import AdapterError
 from retrocast.io.data import save_routes
 from retrocast.io.provenance import generate_model_hash
 from retrocast.models.benchmark import BenchmarkSet
@@ -77,10 +78,10 @@ def ingest_model_predictions(
         try:
             # Adapter returns an iterator of Routes
             routes = list(adapter.cast(raw_payload, target=target, ignore_stereo=ignore_stereo))
-        except Exception as e:
-            logger.warning(f"Adapter failed for {target_id}: {e}")
+        except AdapterError as e:
+            logger.warning(f"Adapter failed for {target_id}: {e} [{e.code}]")
             routes = []
-            stats.routes_failed_transformation += 1
+            stats.record_failure(e.code, target_id=target_id)
             processed_routes[target_id] = []
             continue
 

--- a/src/retrocast/workflow/ingest.py
+++ b/src/retrocast/workflow/ingest.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.curation.filtering import deduplicate_routes
 from retrocast.curation.sampling import sample_k_by_length, sample_random_k, sample_top_k
-from retrocast.exceptions import AdapterError
+from retrocast.exceptions import AdapterError, ChemError
 from retrocast.io.data import save_routes
 from retrocast.io.provenance import generate_model_hash
 from retrocast.models.benchmark import BenchmarkSet
@@ -78,7 +78,7 @@ def ingest_model_predictions(
         try:
             # Adapter returns an iterator of Routes
             routes = list(adapter.cast(raw_payload, target=target, ignore_stereo=ignore_stereo))
-        except AdapterError as e:
+        except (AdapterError, ChemError) as e:
             logger.warning(f"Adapter failed for {target_id}: {e} [{e.code}]")
             routes = []
             stats.record_failure(e.code, target_id=target_id)

--- a/tests/adapters/test_askcos_adapter.py
+++ b/tests/adapters/test_askcos_adapter.py
@@ -224,18 +224,14 @@ class TestAskcosAdapterErrorHandling:
     """Tests for error handling and edge cases."""
 
     @pytest.mark.parametrize(
-        "key_to_remove, error_match",
+        "key_to_remove, role",
         [
-            pytest.param("COC(C)=O", "node data for smiles 'COC(C)=O' not found", id="chemical_smiles_missing"),
-            pytest.param(
-                "CC(=O)Cl.CO>>COC(C)=O",
-                "node data for reaction 'CC(=O)Cl.CO>>COC(C)=O' not found",
-                id="reaction_smiles_missing",
-            ),
+            pytest.param("COC(C)=O", "chemical", id="chemical_smiles_missing"),
+            pytest.param("CC(=O)Cl.CO>>COC(C)=O", "reaction", id="reaction_smiles_missing"),
         ],
     )
     def test_logs_warning_on_inconsistent_nodedict(
-        self, raw_askcos_data, methylacetate_target_input, key_to_remove, error_match, caplog
+        self, raw_askcos_data, methylacetate_target_input, key_to_remove, role, caplog
     ):
         """Tests resilience to inconsistencies in the node_dict mapping."""
         adapter = AskcosAdapter()
@@ -249,4 +245,5 @@ class TestAskcosAdapterErrorHandling:
         # The key assertion: we produced FEWER routes than total pathways.
         total_pathways = len(raw_target_data["results"]["uds"]["pathways"])
         assert len(routes) < total_pathways
-        assert error_match in caplog.text
+        assert "adapter.node_missing" in caplog.text
+        assert role in caplog.text

--- a/tests/adapters/test_base_adapter.py
+++ b/tests/adapters/test_base_adapter.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from retrocast.exceptions import AdapterSchemaError
 from retrocast.models.chem import Route
 
 logger = logging.getLogger(__name__)
@@ -75,15 +76,20 @@ class BaseAdapterTest(ABC):
         assert route.rank >= 1
 
     def test_adapt_handles_unsuccessful_run(self, adapter_instance, raw_unsuccessful_run_data, target_input):
-        """Tests that data for an unsuccessful run yields no routes."""
-        routes = list(adapter_instance.cast(raw_unsuccessful_run_data, target_input))
-        assert len(routes) == 0
+        """Tests that data for an unsuccessful run yields no routes or a typed schema error."""
+        try:
+            routes = list(adapter_instance.cast(raw_unsuccessful_run_data, target_input))
+        except AdapterSchemaError as exc:
+            assert exc.code == "adapter.schema_invalid"
+        else:
+            assert len(routes) == 0
 
     def test_adapt_handles_invalid_schema(self, adapter_instance, raw_invalid_schema_data, target_input, caplog):
-        """Tests that data failing schema validation yields no routes and logs a warning."""
-        routes = list(adapter_instance.cast(raw_invalid_schema_data, target_input))
-        assert len(routes) == 0
-        assert "failed" in caplog.text and "validation" in caplog.text
+        """Tests that data failing schema validation raises a typed adapter schema error."""
+        with pytest.raises(AdapterSchemaError) as exc_info:
+            list(adapter_instance.cast(raw_invalid_schema_data, target_input))
+        assert exc_info.value.code == "adapter.schema_invalid"
+        assert exc_info.value.context["target_id"] == target_input.id
 
     def test_adapt_handles_mismatched_smiles(
         self, adapter_instance, raw_valid_route_data, mismatched_target_input, caplog

--- a/tests/adapters/test_common.py
+++ b/tests/adapters/test_common.py
@@ -46,8 +46,10 @@ class TestBipartiteBuilder:
             in_stock=False,
             children=[SimpleNamespace(smiles="CC=O", type="mol", in_stock=True, children=[])],
         )
-        with pytest.raises(AdapterLogicError, match="Child of molecule node was not a reaction node"):
+        with pytest.raises(AdapterLogicError) as exc_info:
             build_molecule_from_bipartite_node(raw_data)
+        assert exc_info.value.code == "adapter.node_type_invalid"
+        assert exc_info.value.context["expected"] == "reaction"
 
 
 class TestPrecursorMapBuilder:

--- a/tests/adapters/test_dms_adapter.py
+++ b/tests/adapters/test_dms_adapter.py
@@ -66,7 +66,7 @@ class TestDMSAdapterUnit(BaseAdapterTest):
         target_input = TargetInput(id="ibuprofen_cycle_test", smiles=canonicalize_smiles(target_smiles))
         routes = list(adapter_instance.cast(cyclic_route_data, target_input))
         assert len(routes) == 0
-        assert "cycle detected" in caplog.text
+        assert "adapter.cycle_detected" in caplog.text
 
 
 @pytest.mark.integration

--- a/tests/adapters/test_dreamretro_adapter.py
+++ b/tests/adapters/test_dreamretro_adapter.py
@@ -42,8 +42,9 @@ class TestDreamRetroAdapterUnit(BaseAdapterTest):
     def test_parser_raises_on_invalid_step_format(self, adapter_instance):
         """the private parser method should raise an error for malformed steps."""
         bad_route_str = "CCO>CC=O.O"  # missing a ">"
-        with pytest.raises(AdapterLogicError, match="invalid format near"):
+        with pytest.raises(AdapterLogicError) as exc_info:
             adapter_instance._parse_route_string(bad_route_str)
+        assert exc_info.value.code == "adapter.route_string_invalid"
 
 
 # ============================================================================

--- a/tests/adapters/test_factory.py
+++ b/tests/adapters/test_factory.py
@@ -23,8 +23,10 @@ def test_get_adapter_unknown_adapter_raises_exception():
     with a helpful error message.
     """
     unknown_name = "this-adapter-does-not-exist"
-    with pytest.raises(RetroCastException, match=f"unknown adapter '{unknown_name}'"):
+    with pytest.raises(RetroCastException, match=f"unknown adapter '{unknown_name}'") as exc_info:
         get_adapter(unknown_name)
+    assert exc_info.value.code == "adapter.unknown"
+    assert exc_info.value.context["adapter"] == unknown_name
 
 
 @pytest.mark.parametrize("adapter_name, adapter_instance", ADAPTER_MAP.items())

--- a/tests/adapters/test_molbuilder_adapter.py
+++ b/tests/adapters/test_molbuilder_adapter.py
@@ -11,6 +11,7 @@ import pytest
 
 from retrocast.adapters.molbuilder_adapter import MolBuilderAdapter
 from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterSchemaError
 from retrocast.models.chem import TargetInput
 from tests.adapters.test_base_adapter import BaseAdapterTest
 
@@ -281,16 +282,17 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         assert len(routes) == 0
         assert "empty 'reaction_name'" in caplog.text
 
-    def test_invalid_top_level_payload_is_ignored(self, adapter_instance, target_input):
+    def test_invalid_top_level_payload_raises_schema_error(self, adapter_instance, target_input):
         raw_payload = {
             "smiles": "CCO",
             "is_purchasable": False,
             "children": [],
         }
 
-        routes = list(adapter_instance.cast(raw_payload, target_input))
-
-        assert routes == []
+        with pytest.raises(AdapterSchemaError) as exc_info:
+            list(adapter_instance.cast(raw_payload, target_input))
+        assert exc_info.value.code == "adapter.schema_invalid"
+        assert exc_info.value.context == {"adapter": "molbuilder", "target_id": target_input.id}
 
     def test_mismatched_target_smiles_route_is_discarded(self, adapter_instance):
         raw_routes = [

--- a/tests/adapters/test_molbuilder_adapter.py
+++ b/tests/adapters/test_molbuilder_adapter.py
@@ -173,7 +173,7 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         target = TargetInput(id="ibuprofen_cycle", smiles=canonicalize_smiles(target_smiles))
         routes = list(adapter_instance.cast(raw_routes, target))
         assert len(routes) == 0
-        assert "cycle detected" in caplog.text
+        assert "adapter.cycle_detected" in caplog.text
 
     def test_multi_step_tree(self, adapter_instance):
         """Two-step tree: target -> intermediate -> leaf."""
@@ -259,7 +259,8 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         routes = list(adapter_instance.cast(raw_routes, target))
         # Route should be discarded due to AdapterLogicError
         assert len(routes) == 0
-        assert "missing 'best_disconnection'" in caplog.text
+        assert "adapter.route_metadata_missing" in caplog.text
+        assert "best_disconnection" in caplog.text
 
     def test_non_leaf_with_empty_reaction_name_is_discarded(self, adapter_instance, caplog):
         raw_routes = [
@@ -280,7 +281,8 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         routes = list(adapter_instance.cast(raw_routes, target))
 
         assert len(routes) == 0
-        assert "empty 'reaction_name'" in caplog.text
+        assert "adapter.route_metadata_missing" in caplog.text
+        assert "best_disconnection.reaction_name" in caplog.text
 
     def test_invalid_top_level_payload_raises_schema_error(self, adapter_instance, target_input):
         raw_payload = {

--- a/tests/adapters/test_molbuilder_adapter.py
+++ b/tests/adapters/test_molbuilder_adapter.py
@@ -243,13 +243,12 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         assert len(routes) == 1
         assert routes[0].target.is_leaf
 
-    def test_non_leaf_without_disconnection_raises(self, adapter_instance, caplog):
-        """A non-leaf node (has children, not purchasable) without best_disconnection is an error."""
+    def test_non_leaf_without_disconnection_preserves_topology(self, adapter_instance):
+        """A non-leaf node without best_disconnection still carries valid topology."""
         raw_routes = [
             {
                 "smiles": "CCO",
                 "is_purchasable": False,
-                # No best_disconnection, but has children -> should raise
                 "children": [
                     {"smiles": "CC=O", "is_purchasable": True, "children": []},
                 ],
@@ -257,12 +256,14 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
         ]
         target = TargetInput(id="ethanol", smiles="CCO")
         routes = list(adapter_instance.cast(raw_routes, target))
-        # Route should be discarded due to AdapterLogicError
-        assert len(routes) == 0
-        assert "adapter.route_metadata_missing" in caplog.text
-        assert "best_disconnection" in caplog.text
+        assert len(routes) == 1
+        step = routes[0].target.synthesis_step
+        assert step is not None
+        assert step.template is None
+        assert step.metadata == {}
+        assert [mol.smiles for mol in step.reactants] == ["CC=O"]
 
-    def test_non_leaf_with_empty_reaction_name_is_discarded(self, adapter_instance, caplog):
+    def test_non_leaf_with_empty_reaction_name_preserves_topology(self, adapter_instance):
         raw_routes = [
             {
                 "smiles": "CCO",
@@ -280,9 +281,11 @@ class TestMolBuilderAdapterUnit(BaseAdapterTest):
 
         routes = list(adapter_instance.cast(raw_routes, target))
 
-        assert len(routes) == 0
-        assert "adapter.route_metadata_missing" in caplog.text
-        assert "best_disconnection.reaction_name" in caplog.text
+        assert len(routes) == 1
+        step = routes[0].target.synthesis_step
+        assert step is not None
+        assert step.template is None
+        assert step.metadata == {"score": 0.5}
 
     def test_invalid_top_level_payload_raises_schema_error(self, adapter_instance, target_input):
         raw_payload = {

--- a/tests/adapters/test_retrostar_adapter.py
+++ b/tests/adapters/test_retrostar_adapter.py
@@ -46,8 +46,9 @@ class TestRetroStarAdapterUnit(BaseAdapterTest):
     def test_parser_raises_on_invalid_step_format(self, adapter_instance):
         """The private parser method should raise an error for malformed steps."""
         bad_route_str = "CCO>CC=O"  # Missing the score part
-        with pytest.raises(AdapterLogicError, match="Invalid format near"):
+        with pytest.raises(AdapterLogicError) as exc_info:
             adapter_instance._parse_route_string(bad_route_str)
+        assert exc_info.value.code == "adapter.route_string_invalid"
 
 
 # ============================================================================

--- a/tests/adapters/test_synllama_adapter.py
+++ b/tests/adapters/test_synllama_adapter.py
@@ -72,17 +72,18 @@ class TestSynLlamaAdapterUnit(BaseAdapterTest):
         assert all(r.is_leaf for r in synthesis_step2.reactants)
 
     @pytest.mark.parametrize(
-        "bad_string, error_match",
+        "bad_string, expected_code",
         [
-            ("C;R1", "malformed route: template 'R1' has no product"),
-            ("R1;C", "no reactants found for product 'C'"),
-            ("", "synthesis string is empty."),
+            ("C;R1", "adapter.route_string_invalid"),
+            ("R1;C", "adapter.route_string_invalid"),
+            ("", "adapter.route_string_empty"),
         ],
     )
-    def test_parser_raises_on_invalid_string_format(self, adapter_instance, bad_string, error_match):
+    def test_parser_raises_on_invalid_string_format(self, adapter_instance, bad_string, expected_code):
         """tests that the private parser method raises specific logic errors."""
-        with pytest.raises(AdapterLogicError, match=error_match):
+        with pytest.raises(AdapterLogicError) as exc_info:
             adapter_instance._parse_synthesis_string(bad_string)
+        assert exc_info.value.code == expected_code
 
 
 @pytest.mark.integration

--- a/tests/cli/test_adhoc.py
+++ b/tests/cli/test_adhoc.py
@@ -8,12 +8,24 @@ Tests follow the testing framework philosophy:
 """
 
 from argparse import Namespace
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 
-from retrocast.cli.adhoc import handle_create_benchmark
-from retrocast.io.blob import load_json_gz
+from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.cli.adhoc import handle_adapt, handle_create_benchmark
+from retrocast.exceptions import ChemRuntimeError
+from retrocast.io.blob import load_json_gz, save_json_gz
 from retrocast.models.benchmark import BenchmarkSet
+from retrocast.models.chem import Route, TargetIdentity
+
+
+class ChemFailingAdapter(BaseAdapter):
+    def cast(
+        self, raw_target_data: Any, target: TargetIdentity, ignore_stereo: bool = False
+    ) -> Generator[Route, None, None]:
+        raise ChemRuntimeError("synthetic chemistry failure", context={"target_id": target.id})
 
 
 @pytest.mark.integration
@@ -378,6 +390,26 @@ class TestHandleCreateBenchmark:
         assert manifest["statistics"]["n_targets"] == 2
         assert len(manifest["source_files"]) == 1
         assert len(manifest["output_files"]) == 1
+
+
+@pytest.mark.integration
+class TestHandleAdapt:
+    def test_adapt_skips_target_local_chem_failures(self, tmp_path, monkeypatch):
+        input_path = tmp_path / "raw.json.gz"
+        output_path = tmp_path / "routes.json.gz"
+        save_json_gz({"CCO": {"bad": "payload"}}, input_path)
+        monkeypatch.setattr("retrocast.cli.adhoc.get_adapter", lambda name: ChemFailingAdapter())
+
+        args = Namespace(
+            input=str(input_path),
+            output=str(output_path),
+            adapter="synthetic",
+            benchmark=None,
+        )
+
+        handle_adapt(args)
+
+        assert load_json_gz(output_path) == {"CCO": []}
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_handlers.py
+++ b/tests/cli/test_handlers.py
@@ -575,6 +575,33 @@ class TestSecurityAndErrorHandling:
         # Verify security error was logged
         assert "Security violation" in caplog.text
 
+    def test_ingest_single_rejects_unsafe_manifest_results_filename(self, tmp_path, caplog):
+        """Manifest raw_results_filename traversal should be logged and skipped."""
+        data_dir = tmp_path / "data"
+        raw_dir = data_dir / "2-raw" / "test-model" / "test-benchmark"
+        raw_dir.mkdir(parents=True)
+
+        manifest = {"directives": {"adapter": "syntheseus", "raw_results_filename": "../escape.json.gz"}}
+        with open(raw_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        from retrocast.cli.handlers import _ingest_single
+        from retrocast.paths import get_paths
+
+        args = Namespace(
+            adapter=None,
+            sampling_strategy=None,
+            k=None,
+            ignore_stereo=False,
+            anonymize=False,
+        )
+
+        with caplog.at_level("ERROR"):
+            _ingest_single("test-model", "test-benchmark", get_paths(data_dir), args)
+
+        assert "Security violation" in caplog.text
+        assert "raw_results_filename" in caplog.text
+
     def test_resolve_models_handles_security_error(self, tmp_path):
         """Test that _resolve_models catches SecurityError from malformed model names."""
         # Setup: Create a directory with path traversal attempt

--- a/tests/io/test_roundtrip.py
+++ b/tests/io/test_roundtrip.py
@@ -451,6 +451,27 @@ class TestRouteRoundtrip:
 
         assert [r.rank for r in loaded["target"]] == [1, 2, 3]
 
+    def test_load_routes_missing_file_raises_not_found_code(self, tmp_path):
+        """Missing routes files should be typed as missing artifacts."""
+        path = tmp_path / "missing-routes.json.gz"
+
+        with pytest.raises(RetroCastIOError) as exc_info:
+            load_routes(path)
+
+        assert exc_info.value.code == "io.not_found"
+        assert exc_info.value.context == {"path": str(path), "artifact": "routes"}
+
+    def test_load_routes_invalid_json_shape_raises_format_code(self, tmp_path):
+        """Route files with valid JSON but invalid route shape should be typed as format errors."""
+        path = tmp_path / "routes.json.gz"
+        save_json_gz({"target": [{"not": "a route"}]}, path)
+
+        with pytest.raises(RetroCastIOError) as exc_info:
+            load_routes(path)
+
+        assert exc_info.value.code == "io.invalid_artifact_shape"
+        assert exc_info.value.context == {"path": str(path), "artifact": "routes"}
+
 
 # =============================================================================
 # Tests for benchmark save/load roundtrip
@@ -561,8 +582,10 @@ class TestStockFile:
         stock_file = tmp_path / "stock.txt"
         stock_file.write_text("C\nCC\n")
 
-        with pytest.raises(RetroCastIOError, match="Only .csv.gz format is supported"):
+        with pytest.raises(RetroCastIOError, match="Only .csv.gz format is supported") as exc_info:
             load_stock_file(stock_file)
+        assert exc_info.value.code == "io.unsupported_format"
+        assert exc_info.value.context["expected_suffix"] == ".csv.gz"
 
     def test_load_stock_csv_invalid_header_raises(self, tmp_path):
         """Invalid CSV.GZ header should raise RetroCastIOError."""
@@ -571,16 +594,20 @@ class TestStockFile:
         with gzip.open(stock_file, "wt") as f:
             f.write("WrongHeader1,WrongHeader2\nC,VNWKTOKETHGBQD-UHFFFAOYSA-N\n")
 
-        with pytest.raises(RetroCastIOError, match="Invalid stock CSV format"):
+        with pytest.raises(RetroCastIOError, match="Invalid stock CSV format") as exc_info:
             load_stock_file(stock_file)
+        assert exc_info.value.code == "io.invalid_header"
+        assert exc_info.value.context["required_column"] == "InChIKey"
 
     def test_load_stock_missing_file_raises(self, tmp_path):
         """Missing file should raise RetroCastIOError."""
 
         stock_file = tmp_path / "nonexistent.csv.gz"
 
-        with pytest.raises(RetroCastIOError, match="Stock file not found"):
+        with pytest.raises(RetroCastIOError, match="Stock file not found") as exc_info:
             load_stock_file(stock_file)
+        assert exc_info.value.code == "io.not_found"
+        assert exc_info.value.context["artifact"] == "stock"
 
     def test_load_stock_as_smiles_returns_smiles(self, tmp_path):
         """Stock CSV.GZ with return_as='smiles' should return SMILES set."""
@@ -635,8 +662,10 @@ class TestStockFile:
             writer.writerow(["SMILES", "InChIKey"])
             writer.writerow(["C", "VNWKTOKETHGBQD-UHFFFAOYSA-N"])
 
-        with pytest.raises(RetroCastIOError, match="Invalid return_as parameter"):
+        with pytest.raises(RetroCastIOError, match="Invalid return_as parameter") as exc_info:
             load_stock_file(stock_file, return_as="invalid")
+        assert exc_info.value.code == "io.invalid_return_format"
+        assert exc_info.value.context["return_as"] == "invalid"
 
     def test_load_stock_as_smiles_missing_smiles_column_raises(self, tmp_path):
         """Missing SMILES column should raise when return_as='smiles'."""
@@ -692,6 +721,18 @@ def test_json_gz_roundtrip_arbitrary_dict(data):
         save_json_gz(data, path)
         loaded = load_json_gz(path)
         assert loaded == data
+
+
+@pytest.mark.unit
+def test_load_json_gz_missing_file_raises_not_found_code(tmp_path):
+    """Missing JSON artifacts should not be reported as decode failures."""
+    path = tmp_path / "missing.json.gz"
+
+    with pytest.raises(RetroCastIOError) as exc_info:
+        load_json_gz(path)
+
+    assert exc_info.value.code == "io.not_found"
+    assert exc_info.value.context == {"path": str(path)}
 
 
 # =============================================================================

--- a/tests/io/test_roundtrip.py
+++ b/tests/io/test_roundtrip.py
@@ -596,7 +596,7 @@ class TestStockFile:
 
         with pytest.raises(RetroCastIOError, match="Invalid stock CSV format") as exc_info:
             load_stock_file(stock_file)
-        assert exc_info.value.code == "io.invalid_header"
+        assert exc_info.value.code == "io.invalid_artifact_shape"
         assert exc_info.value.context["required_column"] == "InChIKey"
 
     def test_load_stock_missing_file_raises(self, tmp_path):
@@ -662,10 +662,8 @@ class TestStockFile:
             writer.writerow(["SMILES", "InChIKey"])
             writer.writerow(["C", "VNWKTOKETHGBQD-UHFFFAOYSA-N"])
 
-        with pytest.raises(RetroCastIOError, match="Invalid return_as parameter") as exc_info:
+        with pytest.raises(ValueError, match="Invalid return_as parameter"):
             load_stock_file(stock_file, return_as="invalid")
-        assert exc_info.value.code == "io.invalid_return_format"
-        assert exc_info.value.context["return_as"] == "invalid"
 
     def test_load_stock_as_smiles_missing_smiles_column_raises(self, tmp_path):
         """Missing SMILES column should raise when return_as='smiles'."""

--- a/tests/test_chem_descriptors.py
+++ b/tests/test_chem_descriptors.py
@@ -47,6 +47,8 @@ def test_get_heavy_atom_count_raises_exception_on_generic_error(mock_molfromsmil
     with pytest.raises(RetroCastException) as exc_info:
         get_heavy_atom_count("CCO")
     assert "An unexpected error occurred during HAC calculation" in str(exc_info.value)
+    assert exc_info.value.code == "chem.descriptor_failed"
+    assert exc_info.value.context == {"operation": "get_heavy_atom_count", "smiles": "CCO"}
 
 
 # ============================================================================
@@ -86,6 +88,8 @@ def test_get_molecular_weight_raises_exception_on_generic_error(mock_calc) -> No
     with pytest.raises(RetroCastException) as exc_info:
         get_molecular_weight("CCO")
     assert "An unexpected error occurred during MW calculation" in str(exc_info.value)
+    assert exc_info.value.code == "chem.descriptor_failed"
+    assert exc_info.value.context == {"operation": "get_molecular_weight", "smiles": "CCO"}
 
 
 # ============================================================================
@@ -125,6 +129,8 @@ def test_get_chiral_center_count_raises_exception_on_generic_error(mock_find) ->
     with pytest.raises(RetroCastException) as exc_info:
         get_chiral_center_count("CCO")
     assert "An unexpected error occurred during chiral center count" in str(exc_info.value)
+    assert exc_info.value.code == "chem.descriptor_failed"
+    assert exc_info.value.context == {"operation": "get_chiral_center_count", "smiles": "CCO"}
 
 
 # ============================================================================
@@ -148,3 +154,4 @@ def test_all_functions_reject_bad_input(func, bad_input) -> None:
     with pytest.raises(InvalidSmilesError) as exc_info:
         func(bad_input)
     assert "SMILES input must be a non-empty string" in str(exc_info.value)
+    assert exc_info.value.code == "chem.invalid_smiles"

--- a/tests/test_chem_identifiers.py
+++ b/tests/test_chem_identifiers.py
@@ -14,7 +14,7 @@ from retrocast.chem import (
     get_molecular_weight,
     reduce_inchikey,
 )
-from retrocast.exceptions import InvalidSmilesError, RetroCastException
+from retrocast.exceptions import InvalidInchiKeyError, InvalidSmilesError, RetroCastException
 
 # ============================================================================
 # canonicalization
@@ -207,11 +207,15 @@ def test_reduce_inchikey_prevent_upscaling() -> None:
     conn_key = "UHOVQNZJYSORNB"
 
     # prevent 14 -> 27
-    with pytest.raises(RetroCastException, match="cannot upscale"):
+    with pytest.raises(InvalidInchiKeyError, match="cannot upscale") as exc_info:
         reduce_inchikey(conn_key, InchiKeyLevel.FULL)
+    assert exc_info.value.code == "chem.inchikey_upscale"
+    assert exc_info.value.context == {"inchikey": conn_key, "target_level": "full"}
 
-    with pytest.raises(RetroCastException, match="cannot upscale"):
+    with pytest.raises(InvalidInchiKeyError, match="cannot upscale") as exc_info:
         reduce_inchikey(conn_key, InchiKeyLevel.NO_STEREO)
+    assert exc_info.value.code == "chem.inchikey_upscale"
+    assert exc_info.value.context == {"inchikey": conn_key, "target_level": "no_stereo"}
 
 
 @pytest.mark.unit
@@ -352,8 +356,9 @@ def test_stereo_round_trip_invariant() -> None:
 
 @pytest.mark.unit
 def test_invalid_smiles_raises() -> None:
-    with pytest.raises(InvalidSmilesError):
+    with pytest.raises(InvalidSmilesError) as exc_info:
         get_inchi_key("not a smile")
+    assert exc_info.value.code == "chem.invalid_smiles"
 
 
 @pytest.mark.unit
@@ -371,16 +376,18 @@ def test_reduce_inchikey_rejects_malformed_input(bad_key: str) -> None:
     guard test: reduce_inchikey should reject malformed keys.
     only 14-char (connectivity) or 27-char (full) keys are valid.
     """
-    with pytest.raises((ValueError, RetroCastException)):
+    with pytest.raises(InvalidInchiKeyError) as exc_info:
         reduce_inchikey(bad_key, InchiKeyLevel.CONNECTIVITY)
+    assert exc_info.value.code == "chem.invalid_inchikey"
 
 
 @pytest.mark.unit
 @patch("retrocast.chem.Chem.MolToInchiKey")
 def test_rdkit_empty_result_guarded(mock_inchi) -> None:
     mock_inchi.return_value = ""
-    with pytest.raises(RetroCastException, match="Empty InchiKey"):
+    with pytest.raises(RetroCastException, match="Empty InchiKey") as exc_info:
         get_inchi_key("C")
+    assert exc_info.value.code == "chem.inchikey_empty"
 
 
 @pytest.mark.unit

--- a/tests/test_error_contracts.py
+++ b/tests/test_error_contracts.py
@@ -48,6 +48,26 @@ def test_cli_error_formatter_includes_code_and_context():
     assert "path=../x" in rendered
 
 
+def test_cli_error_formatter_flattens_multiline_context():
+    error = RetroCastException(
+        "bad input",
+        code="schema.invalid",
+        context={"detail": "line one\nline two\rline three"},
+    )
+
+    rendered = format_cli_error(error)
+
+    assert "detail=line one line two line three" in rendered
+    assert "\n" not in rendered
+    assert "\r" not in rendered
+
+
+def test_artifact_format_error_defaults_to_invalid_shape():
+    error = ArtifactFormatError("bad artifact")
+
+    assert error.code == "io.invalid_artifact_shape"
+
+
 def test_json_gz_decode_errors_preserve_cause(tmp_path):
     path = tmp_path / "bad.json.gz"
     path.write_bytes(b"not gzip")

--- a/tests/test_error_contracts.py
+++ b/tests/test_error_contracts.py
@@ -1,0 +1,133 @@
+import ast
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from retrocast.cli.errors import format_cli_error
+from retrocast.exceptions import ArtifactDecodeError, ArtifactFormatError, RetroCastException
+from retrocast.io.blob import load_json_gz
+from retrocast.io.data import load_benchmark
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "retrocast"
+
+
+def _python_files() -> list[Path]:
+    return sorted(SRC.rglob("*.py"))
+
+
+def test_retrocast_exception_serializes_stable_contract():
+    error = RetroCastException(
+        "boom",
+        code="test.failure",
+        context={"target_id": "t1"},
+        retryable=True,
+    )
+
+    assert error.to_dict() == {
+        "code": "test.failure",
+        "message": "boom",
+        "context": {"target_id": "t1"},
+        "retryable": True,
+    }
+
+
+def test_cli_error_formatter_includes_code_and_context():
+    error = RetroCastException(
+        "bad input",
+        code="security.path_invalid",
+        context={"path": "../x"},
+    )
+
+    rendered = format_cli_error(error)
+
+    assert "bad input" in rendered
+    assert "[security.path_invalid]" in rendered
+    assert "path=../x" in rendered
+
+
+def test_json_gz_decode_errors_preserve_cause(tmp_path):
+    path = tmp_path / "bad.json.gz"
+    path.write_bytes(b"not gzip")
+
+    with pytest.raises(ArtifactDecodeError) as exc_info:
+        load_json_gz(path)
+
+    assert exc_info.value.code == "io.decode_failed"
+    assert exc_info.value.__cause__ is not None
+
+
+def test_benchmark_schema_errors_preserve_cause(tmp_path):
+    path = tmp_path / "benchmark.json.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump({"name": "broken", "targets": {"x": {"id": "x"}}}, f)
+
+    with pytest.raises(ArtifactFormatError) as exc_info:
+        load_benchmark(path)
+
+    assert exc_info.value.code == "io.invalid_artifact_shape"
+    assert exc_info.value.context["artifact"] == "benchmark"
+    assert exc_info.value.__cause__ is not None
+
+
+def test_no_direct_retrocast_exception_raises_outside_exceptions_module():
+    offenders = []
+    for path in _python_files():
+        if path.name == "exceptions.py":
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+                func = node.exc.func
+                if isinstance(func, ast.Name) and func.id == "RetroCastException":
+                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_broad_exception_catches_stay_at_boundaries():
+    allowed = {
+        Path("src/retrocast/chem.py"),
+        Path("src/retrocast/cli/adhoc.py"),
+        Path("src/retrocast/cli/compare.py"),
+        Path("src/retrocast/cli/handlers.py"),
+        Path("src/retrocast/cli/main.py"),
+        Path("src/retrocast/io/data.py"),
+        Path("src/retrocast/utils/serializers.py"),
+        Path("src/retrocast/workflow/verify.py"),
+    }
+    offenders = []
+    for path in _python_files():
+        rel = path.relative_to(ROOT)
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            broad = node.type is None or (
+                isinstance(node.type, ast.Name) and node.type.id in {"Exception", "BaseException"}
+            )
+            if broad and rel not in allowed:
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_sys_exit_is_cli_only():
+    offenders = []
+    for path in _python_files():
+        rel = path.relative_to(ROOT)
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "exit"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "sys"
+                and (rel.parts[:2] != ("src", "retrocast") or rel.parts[2] != "cli")
+            ):
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert offenders == []

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -217,8 +217,10 @@ class TestValidateFilename:
 
     def test_rejects_forward_slash(self):
         """Should reject forward slashes."""
-        with pytest.raises(SecurityError, match="path separator"):
+        with pytest.raises(SecurityError, match="path separator") as exc_info:
             validate_filename("path/to/file.json")
+        assert exc_info.value.code == "security.path_separator"
+        assert exc_info.value.context == {"param": "filename", "value": "path/to/file.json"}
 
     def test_rejects_backslash(self):
         """Should reject backslashes."""
@@ -262,8 +264,9 @@ class TestValidateFilename:
 
     def test_rejects_null_bytes(self):
         """Should reject null bytes."""
-        with pytest.raises(SecurityError, match="null bytes"):
+        with pytest.raises(SecurityError, match="null bytes") as exc_info:
             validate_filename("file\x00.txt")
+        assert exc_info.value.code == "security.path_null_byte"
 
     def test_includes_param_name_in_error(self):
         """Error message should include parameter name."""
@@ -343,8 +346,10 @@ class TestEnsurePathWithinRoot:
 
         path = root / ".." / "outside" / "secret.txt"
 
-        with pytest.raises(SecurityError, match="escapes root directory"):
+        with pytest.raises(SecurityError, match="escapes root directory") as exc_info:
             ensure_path_within_root(path, root)
+        assert exc_info.value.code == "security.path_traversal"
+        assert exc_info.value.context["description"] == "path"
 
     def test_rejects_absolute_path_outside_root(self, tmp_path):
         """Should reject absolute paths outside root."""

--- a/tests/workflow/test_pipeline.py
+++ b/tests/workflow/test_pipeline.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.exceptions import AdapterSchemaError
+from retrocast.exceptions import AdapterSchemaError, ChemRuntimeError
 from retrocast.io.data import load_routes
 from retrocast.models.benchmark import BenchmarkSet, BenchmarkTarget
 from retrocast.models.chem import Route, TargetIdentity
@@ -60,6 +60,18 @@ class FailingAdapter(BaseAdapter):
             "synthetic adapter schema failure",
             code="adapter.schema_invalid",
             context={"adapter": "synthetic", "target_id": target.id},
+        )
+
+
+class ChemFailingAdapter(BaseAdapter):
+    """Adapter that raises a chemistry failure after target-local processing begins."""
+
+    def cast(
+        self, raw_target_data: Any, target: TargetIdentity, ignore_stereo: bool = False
+    ) -> Generator[Route, None, None]:
+        raise ChemRuntimeError(
+            "synthetic chemistry failure",
+            context={"target_id": target.id},
         )
 
 
@@ -355,6 +367,32 @@ class TestIngestModelPredictions:
             "target_2": {"adapter.schema_invalid": 1},
         }
         assert stats.to_manifest_dict()["failures_by_code"] == {"adapter.schema_invalid": 2}
+
+    @pytest.mark.integration
+    def test_ingest_records_chem_failures_per_target(self, tmp_path, synthetic_benchmark):
+        adapter = ChemFailingAdapter()
+        raw_data = {
+            "target_1": [{"bad": "payload"}],
+            "target_2": [{"bad": "payload"}],
+        }
+
+        processed, _, stats = ingest_model_predictions(
+            model_name="failing-model",
+            benchmark=synthetic_benchmark,
+            raw_data=raw_data,
+            adapter=adapter,
+            output_dir=tmp_path,
+        )
+
+        assert processed["target_1"] == []
+        assert processed["target_2"] == []
+        assert processed["target_3"] == []
+        assert stats.routes_failed_transformation == 2
+        assert stats.failures_by_code == {"chem.runtime_error": 2}
+        assert stats.failures_by_target == {
+            "target_1": {"chem.runtime_error": 1},
+            "target_2": {"chem.runtime_error": 1},
+        }
 
 
 # =============================================================================

--- a/tests/workflow/test_pipeline.py
+++ b/tests/workflow/test_pipeline.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.exceptions import AdapterSchemaError
 from retrocast.io.data import load_routes
 from retrocast.models.benchmark import BenchmarkSet, BenchmarkTarget
 from retrocast.models.chem import Route, TargetIdentity
@@ -47,6 +48,19 @@ class SyntheticAdapter(BaseAdapter):
                     yield route
                 except Exception:
                     continue
+
+
+class FailingAdapter(BaseAdapter):
+    """Adapter that raises a structured schema failure for accounting tests."""
+
+    def cast(
+        self, raw_target_data: Any, target: TargetIdentity, ignore_stereo: bool = False
+    ) -> Generator[Route, None, None]:
+        raise AdapterSchemaError(
+            "synthetic adapter schema failure",
+            code="adapter.schema_invalid",
+            context={"adapter": "synthetic", "target_id": target.id},
+        )
 
 
 # =============================================================================
@@ -315,6 +329,32 @@ class TestIngestModelPredictions:
                 sampling_strategy="top-k",
                 sample_k=None,
             )
+
+    @pytest.mark.integration
+    def test_ingest_records_structured_adapter_failures(self, tmp_path, synthetic_benchmark):
+        adapter = FailingAdapter()
+        raw_data = {
+            "target_1": [{"bad": "payload"}],
+            "target_2": [{"bad": "payload"}],
+        }
+
+        processed, _, stats = ingest_model_predictions(
+            model_name="failing-model",
+            benchmark=synthetic_benchmark,
+            raw_data=raw_data,
+            adapter=adapter,
+            output_dir=tmp_path,
+        )
+
+        assert processed["target_1"] == []
+        assert processed["target_2"] == []
+        assert stats.routes_failed_transformation == 2
+        assert stats.failures_by_code == {"adapter.schema_invalid": 2}
+        assert stats.failures_by_target == {
+            "target_1": {"adapter.schema_invalid": 1},
+            "target_2": {"adapter.schema_invalid": 1},
+        }
+        assert stats.to_manifest_dict()["failures_by_code"] == {"adapter.schema_invalid": 2}
 
 
 # =============================================================================


### PR DESCRIPTION
problem: expected adapter, io, chemistry, security, and cli boundary failures were not consistently typed, counted, or documented. malformed manifests, missing artifacts, route decode/schema failures, and adapter schema failures could escape as prose-only or broad exceptions.

approach: introduced a stable RetroCastException contract with codes, context, retryability, and serialization; documented the taxonomy in docs/developers/errors.md; migrated core chem/path/io/adapter/cli/workflow callsites; added adapter and cli error helpers; and made ingestion count adapter failures by stable code.

review fixes: addressed follow-up comments by fixing the docs json example, adding a security.* taxonomy row, documenting io.unsupported_format, restoring invalid return_as to ValueError, and consolidating stock header/read failures under documented io codes.

risk: adapter schema failures now raise AdapterSchemaError instead of being silently logged inside adapters; ingestion owns the skip/count policy. artifact loaders now distinguish not-found, decode, invalid-shape, unsupported-format, and write failures.

verification:
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run --extra viz ty check
- uv run pytest -q: 749 passed
- pre-commit hooks on commits: ruff, ruff-format, ty

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error taxonomy with codes and context across adapter, IO, and CLI boundaries
> - Introduces a richer `RetroCastException` base class in [exceptions.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-9e63e1ca044315ec0b6162674c05a00496d67c379d60b17a8d82b88da81d048e) carrying `code`, `context`, `retryable`, and `to_dict()`, plus a full hierarchy of typed subclasses (`AdapterError`, `ChemError`, `DataIOError`, `AdapterSchemaError`, `ArtifactNotFoundError`, etc.).
> - Replaces generic `AdapterLogicError` and silent warning-and-return patterns across all adapters with typed raises (`adapter_schema_error`, `adapter_target_mismatch`, `adapter_cycle_error`, etc.) defined in the new [adapters/errors.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-0f50d0893b1aff6e2d33bde2a71e3340aed9580344ee0e267ac970c594e3f4d5) helper module.
> - IO functions in [io/blob.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-08924509c966fdade4b372aee35154d1900c4c3d10a3af00ec7454b2fcf4a840) and [io/data.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-b65a47b1ad42395f89adb585f3b6994bb31d9bb93c6d070cfafc67c34356aea6) now raise `ArtifactNotFoundError`, `ArtifactDecodeError`, `ArtifactFormatError`, or `ArtifactWriteError` with structured codes and context instead of logging and re-raising generic exceptions.
> - CLI error handling in [cli/handlers.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-90ea286376ddce8de663f02b851c5db52afcfececee06f2ef5eb547b5fb4fe7d), [cli/adhoc.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-12cdf8e97e55642944e39cfcf4d6e638796db51b62d2f76267bf3a476e70560e), and [cli/main.py](https://github.com/ischemist/project-procrustes/pull/67/files#diff-35da0f22064cecd83ace145130cdf4bce8bd244cbea3be764b3fd4beb1ee7cbc) now distinguishes `RetroCastException` from unexpected errors, logging structured messages via the new `log_expected_error` helper.
> - `ingest_model_predictions` narrows its exception catch to `(AdapterError, ChemError)` and records failures by stable code and per-target via `stats.record_failure`, surfacing counts in the manifest under `failures_by_code`.
> - Risk: adapters that previously returned zero routes on schema validation failure now raise `AdapterSchemaError`, which propagates to callers; any code that expected silent empty results will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6a1a94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a stable `RetroCastException` contract (codes, context, retryability, `to_dict()`) and migrates all adapter, IO, chem, path, and CLI raise-sites to the new typed subclasses. A companion error-taxonomy document and 153-line contract test suite are added.

- **New exception hierarchy** in `exceptions.py` adds 19 subclasses organised under `ChemError`, `DataIOError`, `AdapterError`, `InputError`, `BenchmarkError`, and `WorkflowError`, each with a `default_code`; `to_dict()` gives a stable shape for manifests and logs.
- **IO layer** (`blob.py`, `data.py`) wraps all file operations in `ArtifactNotFoundError`, `ArtifactDecodeError`, `ArtifactFormatError`, and `ArtifactWriteError`; `load_stock_file`'s invalid `return_as` reverts to plain `ValueError` (programmer error, not IO error).
- **Ingestion loop** (`ingest.py`) narrows its catch to `(AdapterError, ChemError)`, records failures by stable code and target via `RunStatistics.record_failure`, and lets non-adapter/non-chem exceptions propagate; the per-target handler in `adhoc.py` mirrors this pattern so chemistry failures inside adapters no longer abort the entire adapt run.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the refactoring is thorough, all callers have been updated, and every narrowed catch retains an outer Exception fallback so the changed paths fail gracefully.

The exception taxonomy migration is systematic and well-tested (153 contract tests + new pipeline integration tests). The only gaps are in gzip error coverage — truncated files raise EOFError instead of ArtifactDecodeError — but every affected call-site already has an outer except Exception guard, so the control flow is unaffected.

src/retrocast/io/blob.py and src/retrocast/io/data.py have a narrow EOFError gap in their gzip read paths, but callers are all guarded by broader exception handlers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/exceptions.py | New two-level exception hierarchy with stable codes, context dicts, retryability, and to_dict() serialization; clean and internally consistent |
| src/retrocast/io/blob.py | Wraps IO operations in structured exceptions; EOFError (truncated gzip) and UnicodeDecodeError escape the except clause in load_json_gz |
| src/retrocast/io/data.py | Comprehensive structured wrapping for routes/benchmark/stock loading and writing; same EOFError gap present in load_routes gzip read |
| src/retrocast/workflow/ingest.py | Narrowed catch to (AdapterError, ChemError) so non-adapter/chem exceptions propagate; record_failure now tracks by code and target |
| src/retrocast/adapters/errors.py | New factory module for consistent adapter error construction; well-structured with stable codes and context fields |
| src/retrocast/cli/errors.py | format_cli_error sanitizes newlines/CR in context values before printing; log_expected_error provides a consistent CLI logging boundary |
| src/retrocast/cli/handlers.py | Exception catches narrowed from Exception to specific types (SecurityError, AdapterResolutionError) with RetroCastException fallback before catch-all; structured error logging added throughout |
| src/retrocast/cli/adhoc.py | Per-target handler now catches (AdapterError, ChemError), outer handlers catch RetroCastException; ChemError coverage prevents chemistry failures from aborting entire adapt run |
| src/retrocast/models/chem.py | RunStatistics gains record_failure() tracking failures by code and target, and failures_by_code is surfaced in to_manifest_dict() |
| src/retrocast/chem.py | All raise sites migrated to InvalidSmilesError, ChemRuntimeError, or InvalidInchiKeyError with stable codes and operation context |
| tests/test_error_contracts.py | New test file verifying to_dict() shape, default_code inheritance, and code stability across exception classes |
| tests/workflow/test_pipeline.py | New integration tests verify per-target failure accounting for both AdapterSchemaError and ChemRuntimeError paths through ingest_model_predictions |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class RetroCastException {
        +code: str
        +message: str
        +context: dict
        +retryable: bool
        +to_dict() dict
    }
    class ChemError { default_code = chem.error }
    class DataIOError { default_code = io.error }
    class AdapterError { default_code = adapter.error }
    class InputError { default_code = input.invalid }
    class WorkflowError { default_code = workflow.error }
    class BenchmarkError { default_code = benchmark.error }

    RetroCastException <|-- ChemError
    RetroCastException <|-- DataIOError
    RetroCastException <|-- AdapterError
    RetroCastException <|-- InputError
    RetroCastException <|-- WorkflowError
    RetroCastException <|-- BenchmarkError

    ChemError <|-- InvalidSmilesError
    ChemError <|-- ChemRuntimeError
    ChemError <|-- InvalidInchiKeyError

    DataIOError <|-- RetroCastIOError
    RetroCastIOError <|-- ArtifactNotFoundError
    RetroCastIOError <|-- ArtifactFormatError
    RetroCastIOError <|-- ArtifactDecodeError
    RetroCastIOError <|-- ArtifactWriteError

    AdapterError <|-- AdapterLogicError
    AdapterError <|-- AdapterResolutionError
    AdapterError <|-- AdapterSchemaError
    AdapterError <|-- UnsupportedAdapterFeatureError

    InputError <|-- SecurityError
    InputError <|-- SchemaLogicError
    InputError <|-- ConfigurationError

    BenchmarkError <|-- BenchmarkValidationError
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/retrocast/io/blob.py:51-56
Reading a truncated `.gz` file causes Python's gzip module to raise `EOFError` from `f.read()`, not `OSError`. Similarly, a valid gzip file with non-UTF-8 content raises `UnicodeDecodeError`. Neither is caught here, so both propagate as raw Python exceptions instead of `ArtifactDecodeError`, breaking the structured error contract for callers that rely on catching `RetroCastException`.

```suggestion
    except (OSError, EOFError, UnicodeDecodeError, json.JSONDecodeError) as e:
        raise ArtifactDecodeError(
            f"Failed to load {path}: {e}",
            code="io.decode_failed",
            context={"path": str(path)},
        ) from e
```

### Issue 2 of 2
src/retrocast/io/data.py:72-80
Same gap as in `blob.py`: `gzip.open()` in binary read mode raises `EOFError` (not `OSError`) when the file is truncated mid-stream. That exception escapes the handler and surfaces as a raw `EOFError` rather than `ArtifactDecodeError`, so any `except RetroCastException` guard higher up the call stack won't catch it.

```suggestion
    try:
        with gzip.open(path, "rb") as f:
            json_bytes = f.read()
    except (OSError, EOFError) as e:
        raise ArtifactDecodeError(
            f"Failed to load routes from {path}: {e}",
            code="io.decode_failed",
            context={"path": str(path), "artifact": "routes"},
        ) from e
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: keep chemistry failures target loca..."](https://github.com/ischemist/project-procrustes/commit/c6a1a9489308bad4b52a753a03b34e6ebfcb35a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30920028)</sub>

<!-- /greptile_comment -->