### PR TITLE
add a 7-day uv release cooling-off window

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,22 +5,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7
     labels:
-      - "type/security"
+      - "scope/ci-cd"
 
   - package-ecosystem: "uv"
     directory: "/scripts/planning/run-synplanner"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7
     labels:
-      - "type/security"
+      - "scope/ci-cd"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
     labels:
-      - "type/security"
+      - "scope/ci-cd"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "type/security"
+
+  - package-ecosystem: "uv"
+    directory: "/scripts/planning/run-synplanner"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "type/security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "type/security"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,15 @@ aizyn = [
 dms = ["directmultistep"]
 retro-star = ["retro-star>=0.1.0", "torch"]
 syntheseus = [
-  "syntheseus[local-retro]>=0.5.0",
-  "numpy<2",
-  "pandas<2.2",
-  "dgl",
-  "torch<=2.1",
-  "torchdata<=0.7.0",
-  "faiss-cpu",
-  "torch-scatter"
+  # dgl does not publish compatible macOS Python 3.12 wheels for this stack yet.
+  "syntheseus[local-retro]>=0.5.0; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "numpy<2; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "pandas<2.2; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "dgl; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "torch<=2.1; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "torchdata<=0.7.0; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "faiss-cpu; sys_platform != 'darwin' or python_full_version < '3.12'",
+  "torch-scatter; sys_platform != 'darwin' or python_full_version < '3.12'"
 ]
 viz = [
   "ischemist>=0.2.0",
@@ -122,6 +123,8 @@ local_scheme = "no-local-version"
 exclude = ["tests", "scripts"]
 
 [tool.uv]
+# Require a short cooling-off window before newly uploaded artifacts are eligible.
+exclude-newer = "7 days"
 conflicts = [
   [
     { extra = "dms" },
@@ -143,7 +146,7 @@ explicit = true
 
 [tool.uv.sources]
 dgl = [
-  { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin'" },
+  { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin' and python_full_version < '3.12'" },
 ]
 retro_star = { git = "https://github.com/anmorgunov/retro_star", branch = "master" }
 torch = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ exclude = ["tests", "scripts"]
 
 [tool.uv]
 # Require a short cooling-off window before newly uploaded artifacts are eligible.
+required-version = ">=0.9.17"
 exclude-newer = "7 days"
 conflicts = [
   [
@@ -146,7 +147,7 @@ explicit = true
 
 [tool.uv.sources]
 dgl = [
-  { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin' and python_full_version < '3.12'" },
+  { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin' and platform_machine == 'arm64' and python_version == '3.11'" },
 ]
 retro_star = { git = "https://github.com/anmorgunov/retro_star", branch = "master" }
 torch = [

--- a/scripts/planning/run-synplanner/pyproject.toml
+++ b/scripts/planning/run-synplanner/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
 
 [tool.uv]
 # Require a short cooling-off window before newly uploaded artifacts are eligible.
+required-version = ">=0.9.17"
 exclude-newer = "7 days"

--- a/scripts/planning/run-synplanner/pyproject.toml
+++ b/scripts/planning/run-synplanner/pyproject.toml
@@ -8,3 +8,7 @@ dependencies = [
   "retrocast>=0.5.2",
   "synplanner>=1.3.2",
 ]
+
+[tool.uv]
+# Require a short cooling-off window before newly uploaded artifacts are eligible.
+exclude-newer = "7 days"

--- a/scripts/planning/run-synplanner/uv.lock
+++ b/scripts/planning/run-synplanner/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "adabelief-pytorch"
 version = "0.2.1"
@@ -1949,8 +1953,8 @@ wheels = [
 
 [[package]]
 name = "retrocast"
-version = "0.5.3.dev9"
-source = { git = "https://github.com/ischemist/project-procrustes?branch=idk%2Freally#ee70bc66741bc85c46fcd08666c9b5a0c6d656db" }
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
@@ -1958,6 +1962,10 @@ dependencies = [
     { name = "rdkit" },
     { name = "rich" },
     { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/59/20b428897743baa817a608565923846771ef67a11cb4e6f1fe4a2a49cf4f/retrocast-0.5.3.tar.gz", hash = "sha256:8fe4a65c43b29f64c89ef58ee06100b741d86274bb931bfe80343a361ff5a8ba", size = 800724, upload-time = "2026-01-17T03:35:08.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/26/22298ec5a26f557ff8f23228581c0a26064a7ea38c22f8822cc2adff118c/retrocast-0.5.3-py3-none-any.whl", hash = "sha256:9c25eb3edd56978fcd5bc1389e01fcb451353d76f3a8bcb61e5925adea149454", size = 122170, upload-time = "2026-01-17T03:35:06.888Z" },
 ]
 
 [[package]]
@@ -2198,7 +2206,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "retrocast", git = "https://github.com/ischemist/project-procrustes?branch=idk%2Freally" },
+    { name = "retrocast", specifier = ">=0.5.2" },
     { name = "synplanner", specifier = ">=1.3.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,10 @@ conflicts = [[
     { package = "retrocast", extra = "syntheseus" },
 ]]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -563,6 +567,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },
@@ -1160,18 +1169,17 @@ name = "dgl"
 version = "2.2.1"
 source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pandas", marker = "sys_platform == 'darwin'" },
-    { name = "psutil", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "scipy", marker = "sys_platform == 'darwin'" },
-    { name = "torchdata", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "pandas", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "psutil", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "torchdata", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cb5a2a5645ea36e7c25d69976a2ea95d2fe404499cbad7c30fdd4ef978b5156" },
@@ -1194,15 +1202,15 @@ name = "dgllife"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "hyperopt" },
-    { name = "joblib" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "requests" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "tqdm" },
+    { name = "hyperopt", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "joblib", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "pandas", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "requests", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "scikit-learn", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/84/5b2b0c5529a08ac547c743152354c6e02047874bdc81fab72c94780c21b5/dgllife-0.3.2.tar.gz", hash = "sha256:6a0baf112e5d89b0ced2d459872750540517eb03ae0a8cf71576c4b69fc6b553", size = 146565, upload-time = "2023-02-13T08:43:11.8Z" }
 wheels = [
@@ -1249,8 +1257,8 @@ name = "faiss-cpu"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "packaging", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/92/c4f30580aee11fda3f424f8509d9b5ad96b9f44409f52a7ceb6b42880e50/faiss_cpu-1.13.1-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:2967def7aa2da8efbf6a5da81138780aa17a9970ca666417cb632a00a593423d", size = 3418004, upload-time = "2025-12-05T01:01:51.955Z" },
@@ -1545,14 +1553,14 @@ name = "hyperopt"
 version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle" },
-    { name = "future" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "py4j" },
-    { name = "scipy" },
-    { name = "six" },
-    { name = "tqdm" },
+    { name = "cloudpickle", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "future", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "py4j", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "six", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/75/0c4712e3f3a21c910778b8f9f4622601a823cefcae24181467674a0352f9/hyperopt-0.2.7.tar.gz", hash = "sha256:1bf89ae58050bbd32c7307199046117feee245c2fd9ab6255c7308522b7ca149", size = 1308240, upload-time = "2021-11-17T10:05:51.386Z" }
 wheels = [
@@ -1781,7 +1789,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "extra == 'extra-9-retrocast-aizyn' or extra == 'extra-9-retrocast-dms' or extra == 'extra-9-retrocast-retro-star' or extra == 'extra-9-retrocast-syntheseus'" },
+    { name = "markupsafe", marker = "(python_full_version < '3.12' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-syntheseus') or extra == 'extra-9-retrocast-aizyn' or extra == 'extra-9-retrocast-dms' or extra == 'extra-9-retrocast-retro-star'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -2881,7 +2889,6 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
@@ -3051,75 +3058,220 @@ wheels = [
 name = "nvidia-cublas-cu12"
 version = "12.1.3.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/6d/121efd7382d5b0284239f4ab1fc1590d86d34ed4a4a2fdb13b30ca8e5740/nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728", size = 410594774, upload-time = "2023-04-19T15:50:03.519Z" },
     { url = "https://files.pythonhosted.org/packages/c5/ef/32a375b74bea706c93deea5613552f7c9104f961b21df423f5887eca713b/nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906", size = 439918445, upload-time = "2023-04-19T15:56:13.346Z" },
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti-cu12"
 version = "12.1.105"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/00/6b218edd739ecfc60524e585ba8e6b00554dd908de2c9c66c1af3e44e18d/nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e", size = 14109015, upload-time = "2023-04-19T15:47:32.502Z" },
     { url = "https://files.pythonhosted.org/packages/d0/56/0021e32ea2848c24242f6b56790bd0ccc8bf99f973ca790569c6ca028107/nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4", size = 10154340, upload-time = "2023-04-19T15:53:33.563Z" },
 ]
 
 [[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.1.105"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/9f/c64c03f49d6fbc56196664d05dba14e3a561038a81a638eeb47f4d4cfd48/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2", size = 23671734, upload-time = "2023-04-19T15:48:32.42Z" },
     { url = "https://files.pythonhosted.org/packages/ad/1d/f76987c4f454eb86e0b9a0e4f57c3bf1ac1d13ad13cd1a4da4eb0e0c0ce9/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed", size = 19331863, upload-time = "2023-04-19T15:54:34.603Z" },
 ]
 
 [[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-runtime-cu12"
 version = "12.1.105"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/d5/c68b1d2cdfcc59e72e8a5949a37ddb22ae6cade80cd4a57a84d4c8b55472/nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40", size = 823596, upload-time = "2023-04-19T15:47:22.471Z" },
     { url = "https://files.pythonhosted.org/packages/9f/e2/7a2b4b5064af56ea8ea2d8b2776c0f2960d95c88716138806121ae52a9c9/nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344", size = 821226, upload-time = "2023-04-19T15:53:23.082Z" },
 ]
 
 [[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
+]
+
+[[package]]
 name = "nvidia-cudnn-cu12"
 version = "8.9.2.26"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/74/a2e2be7fb83aaedec84f391f082cf765dfb635e7caa9b49065f73e4835d8/nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9", size = 731725872, upload-time = "2023-06-01T19:24:57.328Z" },
 ]
 
 [[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "nvidia-cublas-cu12", version = "12.8.4.1", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
+]
+
+[[package]]
 name = "nvidia-cufft-cu12"
 version = "11.0.2.54"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/94/eb540db023ce1d162e7bea9f8f5aa781d57c65aed513c33ee9a5123ead4d/nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56", size = 121635161, upload-time = "2023-04-19T15:50:46Z" },
     { url = "https://files.pythonhosted.org/packages/f7/57/7927a3aa0e19927dfed30256d1c854caf991655d847a4e7c01fe87e3d4ac/nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253", size = 121344196, upload-time = "2023-04-19T15:56:59.562Z" },
 ]
 
 [[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
+]
+
+[[package]]
 name = "nvidia-curand-cu12"
 version = "10.3.2.106"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/31/4890b1c9abc496303412947fc7dcea3d14861720642b49e8ceed89636705/nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0", size = 56467784, upload-time = "2023-04-19T15:51:04.804Z" },
     { url = "https://files.pythonhosted.org/packages/5c/97/4c9c7c79efcdf5b70374241d48cf03b94ef6707fd18ea0c0f53684931d0b/nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a", size = 55995813, upload-time = "2023-04-19T15:57:16.676Z" },
 ]
 
 [[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
+]
+
+[[package]]
 name = "nvidia-cusolver-cu12"
 version = "11.4.5.107"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse-cu12", version = "12.1.0.106", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1d/8de1e5c67099015c834315e333911273a8c6aaba78923dd1d1e25fc5f217/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd", size = 124161928, upload-time = "2023-04-19T15:51:25.781Z" },
@@ -3127,11 +3279,34 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "nvidia-cublas-cu12", version = "12.8.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cusparse-cu12", version = "12.5.8.93", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
+]
+
+[[package]]
 name = "nvidia-cusparse-cu12"
 version = "12.1.0.106"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/5b/cfaeebf25cd9fdec14338ccb16f6b2c4c7fa9163aefcf057d86b9cc248bb/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c", size = 195958278, upload-time = "2023-04-19T15:51:49.939Z" },
@@ -3139,17 +3314,79 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.18.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/05/23f8f38eec3d28e4915725b233c24d8f1a33cb6540a882f7b54be1befa02/nvidia_nccl_cu12-2.18.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:1a6c4acefcbebfa6de320f412bf7866de856e786e0462326ba1bac40de0b5e71", size = 209797524, upload-time = "2023-05-04T23:15:49.653Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
     { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
@@ -3157,12 +3394,39 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.3.20"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/9d/3dd98852568fb845ec1f7902c90a22b240fe1cbabda411ccedf2fd737b7b/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0", size = 124484616, upload-time = "2025-08-04T20:24:59.172Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+]
+
+[[package]]
 name = "nvidia-nvtx-cu12"
 version = "12.1.105"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/d3/8057f0587683ed2fcd4dbfbdfdfa807b9160b809976099d36b8f60d08f03/nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5", size = 99138, upload-time = "2023-04-19T15:48:43.556Z" },
     { url = "https://files.pythonhosted.org/packages/b8/d7/bd7cb2d95ac6ac6e8d05bfa96cdce69619f1ef2808e072919044c2d47a8c/nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82", size = 66307, upload-time = "2023-04-19T15:54:45.736Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -3170,8 +3434,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "pyyaml" },
+    { name = "antlr4-python3-runtime", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -3361,7 +3625,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32' or extra != 'extra-9-retrocast-aizyn' or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4527,14 +4791,14 @@ retro-star = [
 ]
 syntheseus = [
     { name = "dgl", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
-    { name = "dgl", version = "2.2.1", source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }, marker = "(sys_platform == 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus')" },
-    { name = "faiss-cpu" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "syntheseus", extra = ["local-retro"], marker = "(extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus')" },
-    { name = "torch", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch-scatter" },
-    { name = "torchdata" },
+    { name = "dgl", version = "2.2.1", source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }, marker = "(python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (python_full_version >= '3.12' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus')" },
+    { name = "faiss-cpu", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "pandas", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "syntheseus", extra = ["local-retro"], marker = "(python_full_version < '3.12' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
+    { name = "torch", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "torch-scatter", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "torchdata", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 viz = [
     { name = "ischemist" },
@@ -4563,27 +4827,27 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aizynthfinder", marker = "extra == 'aizyn'", specifier = "==4.4.0" },
-    { name = "dgl", marker = "sys_platform == 'darwin' and extra == 'syntheseus'", url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" },
+    { name = "dgl", marker = "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'syntheseus'", url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" },
     { name = "dgl", marker = "sys_platform != 'darwin' and extra == 'syntheseus'" },
     { name = "directmultistep", marker = "extra == 'dms'" },
-    { name = "faiss-cpu", marker = "extra == 'syntheseus'" },
+    { name = "faiss-cpu", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')" },
     { name = "ischemist", marker = "extra == 'viz'", specifier = ">=0.2.0" },
     { name = "kaleido", marker = "extra == 'viz'", specifier = ">=1.1.0" },
+    { name = "numpy", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')", specifier = "<2" },
     { name = "numpy", marker = "extra == 'aizyn'", specifier = "<=2.2" },
-    { name = "numpy", marker = "extra == 'syntheseus'", specifier = "<2" },
     { name = "packaging", specifier = ">=25.0" },
-    { name = "pandas", marker = "extra == 'syntheseus'", specifier = "<2.2" },
+    { name = "pandas", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')", specifier = "<2.2" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=6.3.0" },
     { name = "pydantic" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rdkit" },
     { name = "retro-star", marker = "extra == 'retro-star'", git = "https://github.com/anmorgunov/retro_star?branch=master" },
     { name = "rich", specifier = ">=14.2.0" },
-    { name = "syntheseus", extras = ["local-retro"], marker = "extra == 'syntheseus'", specifier = ">=0.5.0" },
+    { name = "syntheseus", extras = ["local-retro"], marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')", specifier = ">=0.5.0" },
+    { name = "torch", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')", specifier = "<=2.1" },
     { name = "torch", marker = "extra == 'retro-star'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "retrocast", extra = "retro-star" } },
-    { name = "torch", marker = "extra == 'syntheseus'", specifier = "<=2.1" },
-    { name = "torch-scatter", marker = "extra == 'syntheseus'" },
-    { name = "torchdata", marker = "extra == 'syntheseus'", specifier = "<=0.7.0" },
+    { name = "torch-scatter", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')" },
+    { name = "torchdata", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')", specifier = "<=0.7.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
 provides-extras = ["aizyn", "dms", "retro-star", "syntheseus", "viz"]
@@ -4817,10 +5081,10 @@ name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -4867,7 +5131,7 @@ name = "scipy"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "(python_full_version < '3.12' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-syntheseus') or extra == 'extra-9-retrocast-aizyn' or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -5071,7 +5335,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "extra == 'extra-9-retrocast-aizyn' or extra == 'extra-9-retrocast-dms' or extra == 'extra-9-retrocast-retro-star' or extra == 'extra-9-retrocast-syntheseus'" },
+    { name = "mpmath", marker = "(python_full_version < '3.12' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-syntheseus') or extra == 'extra-9-retrocast-aizyn' or extra == 'extra-9-retrocast-dms' or extra == 'extra-9-retrocast-retro-star'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -5083,12 +5347,12 @@ name = "syntheseus"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "omegaconf" },
-    { name = "rdkit", version = "2025.9.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "more-itertools", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "omegaconf", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "rdkit", version = "2025.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/e2/d80c6785df97ced7dc24fac3b0d8a9c174c594a6e2f5aaa7dedfcf631cc8/syntheseus-0.7.0.tar.gz", hash = "sha256:2484ded58c6bc932ac5bef59972c5d85dc20c3436883d91a2b44f5e90e6f95b5", size = 264873, upload-time = "2025-11-06T16:07:51.146Z" }
 wheels = [
@@ -5097,7 +5361,7 @@ wheels = [
 
 [package.optional-dependencies]
 local-retro = [
-    { name = "syntheseus-local-retro" },
+    { name = "syntheseus-local-retro", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -5105,9 +5369,9 @@ name = "syntheseus-local-retro"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "chardet" },
-    { name = "dgllife" },
-    { name = "pandas" },
+    { name = "chardet", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "dgllife", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "pandas", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/3d/b6f3d1bf556abcfc02e958d32e8c72a766e902cddf0680c88a32919c3cc3/syntheseus_local_retro-0.5.0.tar.gz", hash = "sha256:f7009d7cfde7411e3ecc8d33556603053cd96efa1ccab79f6e6e2b4392f2ee84", size = 31211, upload-time = "2024-06-06T16:28:41.448Z" }
 wheels = [
@@ -5261,30 +5525,29 @@ name = "torch"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
     "python_full_version < '3.12' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", version = "8.9.2.26", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", version = "11.0.2.54", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", version = "10.3.2.106", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", version = "11.4.5.107", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", version = "12.1.0.106", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", version = "2.18.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sympy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "triton", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/13/fcabc86948f9e89b62a538670720f8589d63f93d3f4f3d172236a98e70f8/torch-2.1.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:2224622407ca52611cbc5b628106fde22ed8e679031f5a99ce286629fc696128", size = 670193698, upload-time = "2023-10-04T16:47:38.255Z" },
@@ -5312,12 +5575,12 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:a52952a8c90a422c14627ea99b9826b7557203b46b4d0772d3ca5c7699692425", upload-time = "2026-01-23T15:12:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:287242dd1f830846098b5eca847f817aa5c6015ea57ab4c1287809efea7b77eb", upload-time = "2026-01-23T15:12:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8924d10d36eac8fe0652a060a03fc2ae52980841850b9a1a2ddb0f27a4f181cd", upload-time = "2026-01-23T15:12:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:bcee64ae7aa65876ceeae6dcaebe75109485b213528c74939602208a20706e3f", upload-time = "2026-01-23T15:12:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:defadbeb055cfcf5def58f70937145aecbd7a4bc295238ded1d0e85ae2cf0e1d", upload-time = "2026-01-23T15:12:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:886f84b181f766f53265ba0a1d503011e60f53fff9d569563ef94f24160e1072", upload-time = "2026-01-23T15:12:50Z" },
 ]
 
 [[package]]
@@ -5333,8 +5596,24 @@ dependencies = [
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas-cu12", version = "12.8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", version = "9.10.2.21", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", version = "11.3.3.83", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", version = "10.3.9.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", version = "11.7.3.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", version = "12.5.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", version = "2.27.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
     { name = "sympy" },
+    { name = "triton", version = "3.5.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -5382,27 +5661,27 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0e611cfb16724e62252b67d31073bc5c490cb83e92ecdc1192762535e0e44487", upload-time = "2026-01-23T15:12:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3de2adb9b4443dc9210ef1f1b16da3647ace53553166d6360bbbd7edd6f16e4d", upload-time = "2026-01-23T15:12:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:69b3785d28be5a9c56ab525788ec5000349ec59132a74b7d5e954b905015b992", upload-time = "2026-01-23T15:12:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:15b4ae6fe371d96bffb8e1e9af62164797db20a0dc1337345781659cfd0b8bb1", upload-time = "2026-01-23T15:13:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3bf9b442a51a2948e41216a76d7ab00f0694cfcaaa51b6f9bcab57b7f89843e6", upload-time = "2026-01-23T15:13:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7417d8c565f219d3455654cb431c6d892a3eb40246055e14d645422de13b9ea1", upload-time = "2026-01-23T15:13:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a4e06b4f441675d26b462123c8a83e77c55f1ec8ebc081203be2db1ea8054add", upload-time = "2026-01-23T15:13:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:1abe31f14b560c1f062699e966cb08ef5b67518a1cfac2d8547a3dbcd8387b06", upload-time = "2026-01-23T15:13:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3e532e553b37ee859205a9b2d1c7977fd6922f53bbb1b9bfdd5bdc00d1a60ed4", upload-time = "2026-01-23T15:13:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:39b3dff6d8fba240ae0d1bede4ca11c2531ae3b47329206512d99e17907ff74b", upload-time = "2026-01-23T15:13:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:404a7ab2fffaf2ca069e662f331eb46313692b2f1630df2720094284f390ccef", upload-time = "2026-01-23T15:13:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:161decbff26a33f13cb5ba6d2c8f458bbf56193bcc32ecc70be6dd4c7a3ee79d", upload-time = "2026-01-23T15:13:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:01b1884f724977a20c7da2f640f1c7b37f4a2c117a7f4a6c1c0424d14cb86322", upload-time = "2026-01-23T15:13:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:031a597147fa81b1e6d79ccf1ad3ccc7fafa27941d6cf26ff5caaa384fb20e92", upload-time = "2026-01-23T15:13:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:e586ab1363e3f86aa4cc133b7fdcf98deb1d2c13d43a7a6e5a6a18e9c5364893", upload-time = "2026-01-23T15:13:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:65010ab4aacce6c9a1ddfc935f986c003ca8638ded04348fd326c3e74346237c", upload-time = "2026-01-23T15:13:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:88adf5157db5da1d54b1c9fe4a6c1d20ceef00e75d854e206a87dbf69e3037dc", upload-time = "2026-01-23T15:13:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:f60e2565f261542efac07e25208fb3fc55c6fe82314a5a9cbee971edb5f27713", upload-time = "2026-01-23T15:13:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3ac2b8df2c55430e836dcda31940d47f1f5f94b8731057b6f20300ebea394dd9", upload-time = "2026-01-23T15:13:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5b688445f928f13563b7418b17c57e97bf955ab559cf73cd8f2b961f8572dbb3", upload-time = "2026-01-23T15:13:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:cf9c3e50b595721ca6b488bdcc326e0f1af73ed28b9b66eff504a96649bb5c96", upload-time = "2026-01-23T15:13:32Z" },
 ]
 
 [[package]]
@@ -5416,9 +5695,9 @@ name = "torchdata"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "torch", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "urllib3", version = "2.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
+    { name = "urllib3", version = "2.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/81/35729ce4b1a5d5e3ebf9c67d15eaf6b3e89eca2a71452242db3c2ba125df/torchdata-0.7.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:5a135c14850873d549382025265182934d46a2ef673e2c5cbb08ec656c808e63", size = 1801815, upload-time = "2023-10-04T17:00:47.616Z" },
@@ -5524,11 +5803,38 @@ wheels = [
 name = "triton"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version < '3.12' and sys_platform != 'darwin'",
+]
 dependencies = [
     { name = "filelock", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/c1/54fffb2eb13d293d9a429fead3646752ea190de0229bcf3d591ba2481263/triton-2.1.0-0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:919b06453f0033ea52c13eaf7833de0e57db3178d23d4e04f9fc71c4f2c32bf8", size = 89234153, upload-time = "2023-09-01T07:26:20.161Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/dc/6ce44d055f2fc2403c4ec6b3cfd3a9b25f57b7d95efadccdea91497f8e81/triton-3.5.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da47169e30a779bade679ce78df4810fca6d78a955843d2ddb11f226adc517dc", size = 159928005, upload-time = "2025-11-11T17:51:50.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
+    { url = "https://files.pythonhosted.org/packages/db/53/2bcc46879910991f09c063eea07627baef2bc62fe725302ba8f46a2c1ae5/triton-3.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:275a045b6ed670dd1bd005c3e6c2d61846c74c66f4512d6f33cc027b11de8fd4", size = 159940689, upload-time = "2025-11-11T17:51:55.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ba/805684a992ee32d486b7948d36aed2f5e3c643fc63883bf8bdca1c3f3980/triton-3.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56765ffe12c554cd560698398b8a268db1f616c120007bfd8829d27139abd24a", size = 159955460, upload-time = "2025-11-11T17:52:01.861Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/84/1e/7df59baef41931e21159371c481c31a517ff4c2517343b62503d0cd2be99/triton-3.5.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02c770856f5e407d24d28ddc66e33cf026e6f4d360dcb8b2fabe6ea1fc758621", size = 160072799, upload-time = "2025-11-11T17:52:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/0430e879c1e63a1016cb843261528fd3187c872c3a9539132efc39514753/triton-3.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f617aa7925f9ea9968ec2e1adaf93e87864ff51549c8f04ce658f29bbdb71e2d", size = 159956163, upload-time = "2025-11-11T17:52:12.999Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1e/63d367c576c75919e268e4fbc33c1cb33b6dc12bb85e8bfe531c2a8bd5d3/triton-3.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8932391d7f93698dfe5bc9bead77c47a24f97329e9f20c10786bb230a9083f56", size = 160073620, upload-time = "2025-11-11T17:52:18.403Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",
@@ -1146,18 +1147,19 @@ name = "dgl"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
     "python_full_version < '3.12' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pandas", marker = "sys_platform != 'darwin'" },
-    { name = "psutil", marker = "sys_platform != 'darwin'" },
-    { name = "requests", marker = "sys_platform != 'darwin'" },
-    { name = "scipy", marker = "sys_platform != 'darwin'" },
-    { name = "torchdata", marker = "sys_platform != 'darwin'" },
-    { name = "tqdm", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "pandas", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "psutil", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "requests", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "scipy", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "torchdata", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "(python_full_version < '3.12' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/c8/72de38a32f1f95634c5eaabecb4656c6796a9aadfe7764939d8350136e9c/dgl-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:343ca8d375a15aa6b50a72314ec11529b9f9467a34c29281c76a4762e6b326fe", size = 5332859, upload-time = "2024-05-13T01:10:43.796Z" },
@@ -1169,17 +1171,17 @@ name = "dgl"
 version = "2.2.1"
 source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }
 resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "numpy", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "pandas", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "psutil", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "requests", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "scipy", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "torchdata", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "pandas", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "psutil", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "torchdata", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cb5a2a5645ea36e7c25d69976a2ea95d2fe404499cbad7c30fdd4ef978b5156" },
@@ -2889,7 +2891,8 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",
@@ -3670,7 +3673,8 @@ version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",
@@ -4650,7 +4654,8 @@ version = "2025.9.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",
@@ -4790,8 +4795,8 @@ retro-star = [
     { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
 ]
 syntheseus = [
-    { name = "dgl", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
-    { name = "dgl", version = "2.2.1", source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }, marker = "(python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (python_full_version >= '3.12' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus')" },
+    { name = "dgl", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'arm64' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus')" },
+    { name = "dgl", version = "2.2.1", source = { url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" }, marker = "(python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'extra-9-retrocast-syntheseus') or (python_full_version >= '3.12' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (platform_machine != 'arm64' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (sys_platform != 'darwin' and extra == 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-dms') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-aizyn' and extra == 'extra-9-retrocast-syntheseus') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star') or (extra == 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-syntheseus')" },
     { name = "faiss-cpu", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
     { name = "numpy", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
     { name = "pandas", marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
@@ -4827,8 +4832,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aizynthfinder", marker = "extra == 'aizyn'", specifier = "==4.4.0" },
-    { name = "dgl", marker = "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'syntheseus'", url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" },
-    { name = "dgl", marker = "sys_platform != 'darwin' and extra == 'syntheseus'" },
+    { name = "dgl", marker = "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'syntheseus'", url = "https://data.dgl.ai/wheels/dgl-2.2.1-cp311-cp311-macosx_11_0_arm64.whl" },
+    { name = "dgl", marker = "(python_full_version < '3.12' and platform_machine != 'arm64' and extra == 'syntheseus') or (python_full_version < '3.11' and platform_machine == 'arm64' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')" },
     { name = "directmultistep", marker = "extra == 'dms'" },
     { name = "faiss-cpu", marker = "(python_full_version < '3.12' and extra == 'syntheseus') or (sys_platform != 'darwin' and extra == 'syntheseus')" },
     { name = "ischemist", marker = "extra == 'viz'", specifier = ">=0.2.0" },
@@ -5525,7 +5530,8 @@ name = "torch"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
     "python_full_version < '3.12' and sys_platform != 'darwin'",
 ]
@@ -5899,7 +5905,8 @@ version = "2.32.4.20250913"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",
@@ -6005,7 +6012,8 @@ version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
+    "python_full_version < '3.12' and platform_machine != 'arm64' and sys_platform == 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra != 'extra-9-retrocast-retro-star' and extra == 'extra-9-retrocast-syntheseus'",
     "python_full_version >= '3.12' and sys_platform != 'darwin' and extra != 'extra-9-retrocast-aizyn' and extra != 'extra-9-retrocast-dms' and extra == 'extra-9-retrocast-retro-star' and extra != 'extra-9-retrocast-syntheseus'",


### PR DESCRIPTION
## why
uv already supports excluding very recent package uploads, but the repo was not enforcing it. adding a repo-level 7-day cooling-off window reduces exposure to freshly published supply-chain compromises without relying on each caller to remember a cli flag.

## what changed
- set `[tool.uv].exclude-newer = "7 days"` in the root project and the `scripts/planning/run-synplanner` subproject
- added `required-version = ">=0.9.17"` so the relative-duration cutoff cannot silently noop on older `uv` clients
- refreshed the affected `uv.lock` files under the new resolver policy
- made the existing unsupported `syntheseus` dependency branch explicit on macos/python 3.12 so the new global re-resolution does not break normal root-level `uv sync`
- added `.github/dependabot.yml` to keep dependabot version updates enabled, apply a 7-day cooldown to `uv` updates, and label dependabot prs as `scope/ci-cd`

## risk
this changes dependency resolution behavior for repo-managed `uv` installs and locks. the main risky boundary was resolver truthfulness: once `exclude-newer` forced a fresh solve, an existing unsatisfiable `darwin + python 3.12 + syntheseus/dgl` branch started breaking base syncs. this pr keeps that unsupported branch explicit instead of failing implicitly during unrelated installs.

no github actions workflow changes were needed for the `uv` policy itself: the test and typing workflows already invoke repo-root `uv` commands, so they automatically inherit `[tool.uv]`. the release smoke tests use `uv run --isolated --no-project`, which is intentionally outside project-managed resolution.

the dependabot config in this pr does not implement security-only labeling. because `labels` in `dependabot.yml` applies uniformly to dependabot prs for an entry, the current setup intentionally labels routine dependabot prs as `scope/ci-cd`. a separate relabeling workflow would be needed if we later want security prs to receive `type/security` while routine version prs keep `scope/ci-cd`.

## verification
- `uv sync`
- `uv sync --extra viz`
- `uv lock`
- `uv lock --check`
- `uv sync --directory scripts/planning/run-synplanner`
- `uv lock --check --directory scripts/planning/run-synplanner`
- `git commit` pre-commit hook (`ty`) passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces a 7-day supply-chain cooling-off window by adding `exclude-newer = \"7 days\"` (with a `required-version = \">=0.9.17\"` floor) to both the root and `run-synplanner` sub-project `[tool.uv]` blocks, refreshes the affected lock files, and adds a `.github/dependabot.yml` with a matching 7-day cooldown. It also tightens the `syntheseus` extra and `dgl` wheel markers to prevent the darwin+Python 3.12 unsatisfiable branch from breaking normal `uv sync`.

- `exclude-newer = \"7 days\"` is added to both `pyproject.toml` files alongside `required-version = \">=0.9.17\"`, ensuring the cooling-off policy is enforced and not silently skipped on older uv installs.
- `syntheseus` extra dependencies now carry `sys_platform != 'darwin' or python_full_version < '3.12'` markers, and the `dgl` wheel source is restricted to `arm64` / Python 3.11 to match the actual wheel filename.
- `.github/dependabot.yml` introduces a weekly schedule with `cooldown.default-days: 7`, but is missing `open-pull-requests-limit: 0` on the `uv` entries and uses `scope/ci-cd` labels rather than the `type/security` labels described in the PR.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the uv resolver changes; the dependabot.yml has a gap between stated and actual behaviour but does not break existing workflows.

The `pyproject.toml` changes are correct and well-guarded. The `.github/dependabot.yml` is missing `open-pull-requests-limit: 0` on both `uv` entries, so Dependabot will open routine version-update PRs contrary to the stated intent, and the labels applied will not match the described `type/security` goal.

.github/dependabot.yml — the missing `open-pull-requests-limit: 0` and incorrect labels should be reviewed before merging if the Dependabot suppression goal matters.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | New file configuring Dependabot with cooldown and weekly schedule, but missing `open-pull-requests-limit: 0` to suppress routine version-update PRs as stated in the PR description, and labels don't match the described `type/security` intent. |
| pyproject.toml | Adds `exclude-newer = "7 days"` and `required-version = ">=0.9.17"` to `[tool.uv]`; refines `syntheseus` extra markers to exclude darwin+Python 3.12; tightens dgl wheel marker to arm64/Python 3.11 only. |
| scripts/planning/run-synplanner/pyproject.toml | Adds matching `[tool.uv]` block with `exclude-newer = "7 days"` and `required-version = ">=0.9.17"` to the sub-project. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[uv sync / uv lock] --> B{uv version >= 0.9.17?}
    B -- No --> C[Error: required-version not met]
    B -- Yes --> D[Apply exclude-newer = 7 days]
    D --> E{Package published < 7 days ago?}
    E -- Yes --> F[Excluded from resolution]
    E -- No --> G[Eligible for resolution]
    G --> H{darwin + Python 3.12?}
    H -- Yes --> I[syntheseus/dgl deps skipped via marker]
    H -- No --> J[Full dependency set resolved]
    K[Dependabot weekly run] --> L[cooldown: default-days 7]
    L --> M{Package age < 7 days?}
    M -- Yes --> N[Update skipped]
    M -- No --> O[PR created with scope/ci-cd label]
    O --> P[open-pull-requests-limit missing - routine PRs opened]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/dependabot.yml:1-22
**Stated goals not implemented — no `open-pull-requests-limit: 0` and wrong labels**

The PR description says the config should "label dependabot security prs as `type/security` while disabling routine version-update prs via `open-pull-requests-limit: 0`". Neither goal is met in the committed file:

1. `open-pull-requests-limit: 0` is absent from both `uv` entries, so Dependabot will open routine version-update PRs — the opposite of the stated intent.
2. The labels are `scope/ci-cd`, not `type/security`. Because `labels` in `dependabot.yml` applies uniformly to every PR from that entry (security and version alike), security alerts will not receive the `type/security` label as described.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["retune dependabot labels"](https://github.com/ischemist/project-procrustes/commit/4ee860a0146393cff45e45163fcfc1d7af3e0075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31701879)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
