### PR TITLE
fix: align adapter and ingest error reporting

### DIFF
--- a/src/retrocast/adapters/aizynth_adapter.py
+++ b/src/retrocast/adapters/aizynth_adapter.py
@@ -80,7 +80,11 @@ class AizynthAdapter(BaseAdapter):
         raises RetroCastException on failure.
         """
         # use the common recursive builder with new schema
-        target_molecule = build_molecule_from_bipartite_node(raw_mol_node=aizynth_root, ignore_stereo=ignore_stereo)
+        target_molecule = build_molecule_from_bipartite_node(
+            raw_mol_node=aizynth_root,
+            ignore_stereo=ignore_stereo,
+            adapter="aizynth",
+        )
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:

--- a/src/retrocast/adapters/askcos_adapter.py
+++ b/src/retrocast/adapters/askcos_adapter.py
@@ -8,9 +8,14 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_missing_node_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_missing_node_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import RetroCastException
+from retrocast.exceptions import RetroCastException, UnsupportedAdapterFeatureError
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
@@ -97,7 +102,10 @@ class AskcosAdapter(BaseAdapter):
     ) -> Generator[Route, None, None]:
         """validates raw askcos data, transforms its pathways, and yields route objects."""
         if self.use_full_graph:
-            raise NotImplementedError("extracting routes from the full askcos search graph is not yet implemented.")
+            raise UnsupportedAdapterFeatureError(
+                "ASKCOS full-graph route extraction is not implemented",
+                context={"adapter": "askcos", "feature": "full_graph"},
+            )
 
         try:
             validated_output = AskcosOutput.model_validate(raw_target_data)
@@ -157,6 +165,7 @@ class AskcosAdapter(BaseAdapter):
             adj_list=adj_list,
             uuid2smiles=uuid2smiles,
             node_dict=node_dict,
+            visited=set(),
             ignore_stereo=ignore_stereo,
         )
 
@@ -178,9 +187,13 @@ class AskcosAdapter(BaseAdapter):
         adj_list: dict[str, list[str]],
         uuid2smiles: dict[str, str],
         node_dict: dict[str, AskcosNode],
+        visited: set[SmilesStr] | None = None,
         ignore_stereo: bool = False,
     ) -> Molecule:
         """recursively builds a canonical molecule from a chemical uuid."""
+        if visited is None:
+            visited = set()
+
         raw_smiles = uuid2smiles.get(chem_uuid)
         if not raw_smiles:
             raise adapter_missing_node_error("askcos", node_id=chem_uuid, lookup="uuid2smiles", role="chemical")
@@ -190,6 +203,10 @@ class AskcosAdapter(BaseAdapter):
             raise adapter_missing_node_error("askcos", node_id=raw_smiles, lookup="node_dict", role="chemical")
 
         canon_smiles = canonicalize_smiles(node_data.smiles, ignore_stereo=ignore_stereo)
+        if canon_smiles in visited:
+            raise adapter_cycle_error("askcos", canon_smiles)
+
+        new_visited = visited | {canon_smiles}
         is_leaf = node_data.terminal
         synthesis_step = None
 
@@ -206,6 +223,7 @@ class AskcosAdapter(BaseAdapter):
                 adj_list=adj_list,
                 uuid2smiles=uuid2smiles,
                 node_dict=node_dict,
+                visited=new_visited,
                 ignore_stereo=ignore_stereo,
             )
 
@@ -223,6 +241,7 @@ class AskcosAdapter(BaseAdapter):
         adj_list: dict[str, list[str]],
         uuid2smiles: dict[str, str],
         node_dict: dict[str, AskcosNode],
+        visited: set[SmilesStr],
         ignore_stereo: bool = False,
     ) -> ReactionStep:
         """builds a canonical reaction step from a reaction uuid."""
@@ -245,6 +264,7 @@ class AskcosAdapter(BaseAdapter):
                 adj_list=adj_list,
                 uuid2smiles=uuid2smiles,
                 node_dict=node_dict,
+                visited=visited,
                 ignore_stereo=ignore_stereo,
             )
             reactants.append(reactant_molecule)

--- a/src/retrocast/adapters/base_adapter.py
+++ b/src/retrocast/adapters/base_adapter.py
@@ -21,8 +21,10 @@ class BaseAdapter(ABC):
         Validates, transforms, and yields Routes from raw model data.
 
         This is the primary method for an adapter. It encapsulates all model-specific
-        logic. It should be a generator that yields successful routes and handles its
-        own exceptions internally by logging and continuing.
+        logic. It should be a generator that yields successful routes, logs/skips
+        route-local transform failures when later routes for the same target can still
+        succeed, and raises typed boundary errors when the target payload itself is
+        invalid or unsupported.
 
         Args:
             raw_target_data: The raw data blob from a file for a single target.

--- a/src/retrocast/adapters/common.py
+++ b/src/retrocast/adapters/common.py
@@ -82,24 +82,26 @@ def build_molecule_from_precursor_map(
     if visited is None:
         visited = set()
 
-    # Cycle detection
-    if smiles in visited:
-        raise adapter_cycle_error(adapter, smiles)
+    canon_smiles = canonicalize_smiles(smiles, ignore_stereo=ignore_stereo)
+    if canon_smiles in visited:
+        raise adapter_cycle_error(adapter, canon_smiles)
 
-    new_visited = visited | {smiles}
-    is_leaf = smiles not in precursor_map
+    new_visited = visited | {canon_smiles}
+    reactant_smiles_list = precursor_map.get(canon_smiles)
+    if reactant_smiles_list is None:
+        reactant_smiles_list = precursor_map.get(smiles)
+    is_leaf = reactant_smiles_list is None
 
     if is_leaf:
         # This is a starting material (leaf node)
         return Molecule(
-            smiles=smiles,
-            inchikey=get_inchi_key(smiles),
+            smiles=canon_smiles,
+            inchikey=get_inchi_key(canon_smiles),
             synthesis_step=None,
             metadata={},
         )
 
     # Build reactants recursively
-    reactant_smiles_list = precursor_map[smiles]
     reactant_molecules: list[Molecule] = []
 
     for reactant_smi in reactant_smiles_list:
@@ -123,8 +125,8 @@ def build_molecule_from_precursor_map(
 
     # Create the molecule with its synthesis step
     return Molecule(
-        smiles=smiles,
-        inchikey=get_inchi_key(smiles),
+        smiles=canon_smiles,
+        inchikey=get_inchi_key(canon_smiles),
         synthesis_step=synthesis_step,
         metadata={},
     )

--- a/src/retrocast/adapters/common.py
+++ b/src/retrocast/adapters/common.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Protocol
 
-from retrocast.adapters.errors import adapter_node_type_error
+from retrocast.adapters.errors import adapter_cycle_error, adapter_node_type_error
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.models.chem import Molecule, ReactionStep
 from retrocast.typing import SmilesStr
@@ -62,6 +62,8 @@ def build_molecule_from_precursor_map(
     precursor_map: PrecursorMap,
     visited: set[SmilesStr] | None = None,
     ignore_stereo: bool = False,
+    *,
+    adapter: str = "common",
 ) -> Molecule:
     """
     Recursively builds a `Molecule` from a precursor map, with cycle detection.
@@ -82,13 +84,7 @@ def build_molecule_from_precursor_map(
 
     # Cycle detection
     if smiles in visited:
-        logger.warning(f"Cycle detected in route graph involving smiles: {smiles}. Treating as a leaf node.")
-        return Molecule(
-            smiles=smiles,
-            inchikey=get_inchi_key(smiles),
-            synthesis_step=None,
-            metadata={},
-        )
+        raise adapter_cycle_error(adapter, smiles)
 
     new_visited = visited | {smiles}
     is_leaf = smiles not in precursor_map
@@ -112,6 +108,7 @@ def build_molecule_from_precursor_map(
             precursor_map=precursor_map,
             visited=new_visited,
             ignore_stereo=ignore_stereo,
+            adapter=adapter,
         )
         reactant_molecules.append(reactant_mol)
 
@@ -133,7 +130,13 @@ def build_molecule_from_precursor_map(
     )
 
 
-def build_molecule_from_bipartite_node(raw_mol_node: BipartiteMolNode, ignore_stereo: bool = False) -> Molecule:
+def build_molecule_from_bipartite_node(
+    raw_mol_node: BipartiteMolNode,
+    ignore_stereo: bool = False,
+    *,
+    visited: set[SmilesStr] | None = None,
+    adapter: str = "common",
+) -> Molecule:
     """
     Recursively builds a `Molecule` from a raw, validated bipartite graph node.
     This is the new schema version for models like aizynthfinder, synplanner, etc.
@@ -147,9 +150,16 @@ def build_molecule_from_bipartite_node(raw_mol_node: BipartiteMolNode, ignore_st
         A Molecule object representing this node and its synthesis tree.
     """
     if raw_mol_node.type != "mol":
-        raise adapter_node_type_error("bipartite", expected="mol", actual=raw_mol_node.type, role="molecule")
+        raise adapter_node_type_error(adapter, expected="mol", actual=raw_mol_node.type, role="molecule")
+
+    if visited is None:
+        visited = set()
 
     canon_smiles = canonicalize_smiles(raw_mol_node.smiles, ignore_stereo=ignore_stereo)
+    if canon_smiles in visited:
+        raise adapter_cycle_error(adapter, canon_smiles)
+
+    new_visited = visited | {canon_smiles}
     is_leaf = raw_mol_node.in_stock or not bool(raw_mol_node.children)
 
     if is_leaf:
@@ -169,13 +179,18 @@ def build_molecule_from_bipartite_node(raw_mol_node: BipartiteMolNode, ignore_st
     raw_reaction_node: BipartiteRxnNode = raw_mol_node.children[0]
     if raw_reaction_node.type != "reaction":
         raise adapter_node_type_error(
-            "bipartite", expected="reaction", actual=raw_reaction_node.type, role="molecule child"
+            adapter, expected="reaction", actual=raw_reaction_node.type, role="molecule child"
         )
 
     # Build reactants recursively
     reactant_molecules: list[Molecule] = []
     for reactant_mol_input in raw_reaction_node.children:
-        reactant_mol = build_molecule_from_bipartite_node(raw_mol_node=reactant_mol_input, ignore_stereo=ignore_stereo)
+        reactant_mol = build_molecule_from_bipartite_node(
+            raw_mol_node=reactant_mol_input,
+            ignore_stereo=ignore_stereo,
+            visited=new_visited,
+            adapter=adapter,
+        )
         reactant_molecules.append(reactant_mol)
 
     # Extract template and mapped_smiles from metadata if available

--- a/src/retrocast/adapters/dreamretro_adapter.py
+++ b/src/retrocast/adapters/dreamretro_adapter.py
@@ -104,7 +104,10 @@ class DreamRetroAdapter(BaseAdapter):
 
         # build molecule tree from precursor map
         molecule = build_molecule_from_precursor_map(
-            smiles=expected_smiles, precursor_map=precursor_map, ignore_stereo=ignore_stereo
+            smiles=expected_smiles,
+            precursor_map=precursor_map,
+            ignore_stereo=ignore_stereo,
+            adapter="dreamretro",
         )
 
         # extract metadata

--- a/src/retrocast/adapters/errors.py
+++ b/src/retrocast/adapters/errors.py
@@ -32,6 +32,14 @@ def adapter_schema_error(adapter: str, target_id: str, detail: str, **context: A
     )
 
 
+def adapter_route_transform_error(adapter: str, target_id: str, detail: str, **context: Any) -> AdapterLogicError:
+    return AdapterLogicError(
+        f"{adapter_display_name(adapter)} could not adapt target '{target_id}': {detail}",
+        code="adapter.route_transform_failed",
+        context={"adapter": adapter, "target_id": target_id, **context},
+    )
+
+
 def adapter_target_mismatch(
     adapter: str,
     target_id: str,

--- a/src/retrocast/adapters/retrochimera_adapter.py
+++ b/src/retrocast/adapters/retrochimera_adapter.py
@@ -7,10 +7,11 @@ from typing import Any
 from pydantic import BaseModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_schema_error
-from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.adapters.common import build_molecule_from_precursor_map
+from retrocast.adapters.errors import adapter_route_transform_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
 from retrocast.exceptions import RetroCastException
-from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
+from retrocast.models.chem import Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
 logger = logging.getLogger(__name__)
@@ -74,20 +75,30 @@ class RetrochimeraAdapter(BaseAdapter):
         if validated_data.result.error is not None:
             error_msg = validated_data.result.error.get("message", "unknown error")
             error_type = validated_data.result.error.get("type", "unknown")
-            logger.warning(f"  - retrochimera reported an error for target '{target.id}': {error_type} - {error_msg}")
-            return
+            raise adapter_route_transform_error(
+                "retrochimera",
+                target.id,
+                f"model reported {error_type}: {error_msg}",
+                error_type=error_type,
+            )
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
-        if canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo) != expected_smiles:
-            logger.warning(
-                f"  - RetroChimera produced mismatched SMILES for target '{target.id}': "
-                f"expected {expected_smiles}, got {canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo)}"
+        actual_smiles = canonicalize_smiles(validated_data.smiles, ignore_stereo=ignore_stereo)
+        if actual_smiles != expected_smiles:
+            raise adapter_target_mismatch(
+                "retrochimera",
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=actual_smiles,
             )
-            return
 
         if validated_data.result.outputs is None:
-            logger.warning(f"  - no outputs found for target '{target.id}'")
-            return
+            raise adapter_route_transform_error(
+                "retrochimera",
+                target.id,
+                "validated payload is missing result outputs",
+                payload_field="result.outputs",
+            )
 
         rank = 1
         for output in validated_data.result.outputs:
@@ -108,10 +119,11 @@ class RetrochimeraAdapter(BaseAdapter):
         raises RetroCastException on failure.
         """
         precursor_map = self._build_precursor_map(route, ignore_stereo=ignore_stereo)
-        target_molecule = self._build_molecule_from_precursor_map(
+        target_molecule = build_molecule_from_precursor_map(
             smiles=SmilesStr(target.smiles),
             precursor_map=precursor_map,
             ignore_stereo=ignore_stereo,
+            adapter="retrochimera",
         )
 
         return Route(target=target_molecule, rank=rank, metadata={})
@@ -129,69 +141,3 @@ class RetrochimeraAdapter(BaseAdapter):
             canon_reactants = [canonicalize_smiles(r, ignore_stereo=ignore_stereo) for r in reaction.reactants]
             precursor_map[canon_product] = canon_reactants
         return precursor_map
-
-    def _build_molecule_from_precursor_map(
-        self,
-        smiles: SmilesStr,
-        precursor_map: dict[SmilesStr, list[SmilesStr]],
-        visited: set[SmilesStr] | None = None,
-        ignore_stereo: bool = False,
-    ) -> Molecule:
-        """
-        recursively builds a Molecule from a precursor map, with cycle detection.
-        """
-        if visited is None:
-            visited = set()
-
-        # Cycle detection
-        if smiles in visited:
-            logger.warning(f"Cycle detected in route graph involving smiles: {smiles}. Treating as a leaf node.")
-            return Molecule(
-                smiles=smiles,
-                inchikey=get_inchi_key(smiles),
-                synthesis_step=None,
-                metadata={},
-            )
-
-        new_visited = visited | {smiles}
-        is_leaf = smiles not in precursor_map
-
-        if is_leaf:
-            # This is a starting material (leaf node)
-            return Molecule(
-                smiles=smiles,
-                inchikey=get_inchi_key(smiles),
-                synthesis_step=None,
-                metadata={},
-            )
-
-        # Build reactants recursively
-        reactant_smiles_list = precursor_map[smiles]
-        reactant_molecules: list[Molecule] = []
-
-        for reactant_smi in reactant_smiles_list:
-            reactant_mol = self._build_molecule_from_precursor_map(
-                smiles=reactant_smi,
-                precursor_map=precursor_map,
-                visited=new_visited,
-                ignore_stereo=ignore_stereo,
-            )
-            reactant_molecules.append(reactant_mol)
-
-        # Create the reaction step
-        synthesis_step = ReactionStep(
-            reactants=reactant_molecules,
-            mapped_smiles=None,
-            template=None,
-            reagents=None,
-            solvents=None,
-            metadata={},
-        )
-
-        # Create the molecule with its synthesis step
-        return Molecule(
-            smiles=smiles,
-            inchikey=get_inchi_key(smiles),
-            synthesis_step=synthesis_step,
-            metadata={},
-        )

--- a/src/retrocast/adapters/retrostar_adapter.py
+++ b/src/retrocast/adapters/retrostar_adapter.py
@@ -108,7 +108,10 @@ class RetroStarAdapter(BaseAdapter):
 
         # Build the molecule tree using the new schema helper
         target_molecule = build_molecule_from_precursor_map(
-            smiles=SmilesStr(target.smiles), precursor_map=precursor_map, ignore_stereo=ignore_stereo
+            smiles=SmilesStr(target.smiles),
+            precursor_map=precursor_map,
+            ignore_stereo=ignore_stereo,
+            adapter="retrostar",
         )
 
         # Build metadata

--- a/src/retrocast/adapters/synllama_adapter.py
+++ b/src/retrocast/adapters/synllama_adapter.py
@@ -7,10 +7,11 @@ from typing import Any
 from pydantic import BaseModel, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
+from retrocast.adapters.common import build_molecule_from_precursor_map
 from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
-from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.chem import canonicalize_smiles
 from retrocast.exceptions import RetroCastException
-from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
+from retrocast.models.chem import Route, TargetIdentity
 from retrocast.typing import SmilesStr
 
 logger = logging.getLogger(__name__)
@@ -68,64 +69,13 @@ class SynLlaMaAdapter(BaseAdapter):
             )
 
         precursor_map = self._parse_synthesis_string(route.synthesis_string, ignore_stereo=ignore_stereo)
-        target_molecule = self._build_molecule_from_precursor_map(
-            smiles=SmilesStr(target.smiles), precursor_map=precursor_map, ignore_stereo=ignore_stereo
+        target_molecule = build_molecule_from_precursor_map(
+            smiles=SmilesStr(target.smiles),
+            precursor_map=precursor_map,
+            ignore_stereo=ignore_stereo,
+            adapter="synllama",
         )
         return Route(target=target_molecule, rank=rank, metadata={})
-
-    def _build_molecule_from_precursor_map(
-        self,
-        smiles: SmilesStr,
-        precursor_map: dict[SmilesStr, list[SmilesStr]],
-        visited: set[SmilesStr] | None = None,
-        ignore_stereo: bool = False,
-    ) -> Molecule:
-        """Recursively build a Molecule tree from a precursor map."""
-        if visited is None:
-            visited = set()
-
-        # Cycle detection
-        if smiles in visited:
-            logger.warning(f"Cycle detected for {smiles}, treating as leaf")
-            return Molecule(
-                smiles=smiles,
-                inchikey=get_inchi_key(smiles),
-                synthesis_step=None,
-                metadata={},
-            )
-
-        new_visited = visited | {smiles}
-
-        # Check if this is a leaf (not in precursor map)
-        if smiles not in precursor_map:
-            return Molecule(
-                smiles=smiles,
-                inchikey=get_inchi_key(smiles),
-                synthesis_step=None,
-                metadata={},
-            )
-
-        # Build reactants recursively
-        reactant_molecules = []
-        for reactant_smiles in precursor_map[smiles]:
-            reactant_mol = self._build_molecule_from_precursor_map(
-                smiles=reactant_smiles, precursor_map=precursor_map, visited=new_visited, ignore_stereo=ignore_stereo
-            )
-            reactant_molecules.append(reactant_mol)
-
-        # Create the reaction step
-        synthesis_step = ReactionStep(
-            reactants=reactant_molecules,
-            metadata={},
-        )
-
-        # Create the molecule with its synthesis step
-        return Molecule(
-            smiles=smiles,
-            inchikey=get_inchi_key(smiles),
-            synthesis_step=synthesis_step,
-            metadata={},
-        )
 
     def _parse_synthesis_string(
         self, synthesis_str: str, ignore_stereo: bool = False

--- a/src/retrocast/adapters/synplanner_adapter.py
+++ b/src/retrocast/adapters/synplanner_adapter.py
@@ -7,11 +7,16 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.adapters.errors import adapter_node_type_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_node_type_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.exceptions import RetroCastException
 from retrocast.models.chem import Molecule, ReactionStep, Route, TargetIdentity
-from retrocast.typing import ReactionSmilesStr
+from retrocast.typing import ReactionSmilesStr, SmilesStr
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +86,11 @@ class SynPlannerAdapter(BaseAdapter):
         raises RetroCastException on failure.
         """
         # use the custom recursive builder for synplanner (has mapped_smiles on reaction nodes)
-        target_molecule = self._build_molecule_from_synplanner_node(synplanner_root, ignore_stereo=ignore_stereo)
+        target_molecule = self._build_molecule_from_synplanner_node(
+            synplanner_root,
+            ignore_stereo=ignore_stereo,
+            visited=set(),
+        )
 
         # canonicalize both synplanner output and benchmark target with RDKit to align formats
         produced = canonicalize_smiles(target_molecule.smiles, remove_mapping=True, ignore_stereo=ignore_stereo)
@@ -106,7 +115,10 @@ class SynPlannerAdapter(BaseAdapter):
         return Route(target=target_molecule, rank=rank, metadata={})
 
     def _build_molecule_from_synplanner_node(
-        self, raw_mol_node: SynPlannerMoleculeInput, ignore_stereo: bool = False
+        self,
+        raw_mol_node: SynPlannerMoleculeInput,
+        ignore_stereo: bool = False,
+        visited: set[SmilesStr] | None = None,
     ) -> Molecule:
         """
         recursively builds a `Molecule` from a raw synplanner bipartite graph node.
@@ -115,7 +127,14 @@ class SynPlannerAdapter(BaseAdapter):
         if raw_mol_node.type != "mol":
             raise adapter_node_type_error("synplanner", expected="mol", actual=raw_mol_node.type, role="molecule")
 
+        if visited is None:
+            visited = set()
+
         canon_smiles = canonicalize_smiles(raw_mol_node.smiles, remove_mapping=True, ignore_stereo=ignore_stereo)
+        if canon_smiles in visited:
+            raise adapter_cycle_error("synplanner", canon_smiles)
+
+        new_visited = visited | {canon_smiles}
         is_leaf = raw_mol_node.in_stock or not bool(raw_mol_node.children)
 
         if is_leaf:
@@ -145,7 +164,11 @@ class SynPlannerAdapter(BaseAdapter):
             if not isinstance(reactant_mol_input, SynPlannerMoleculeInput):
                 actual = getattr(reactant_mol_input, "type", type(reactant_mol_input).__name__)
                 raise adapter_node_type_error("synplanner", expected="mol", actual=actual, role="reaction child")
-            reactant_mol = self._build_molecule_from_synplanner_node(reactant_mol_input, ignore_stereo=ignore_stereo)
+            reactant_mol = self._build_molecule_from_synplanner_node(
+                reactant_mol_input,
+                ignore_stereo=ignore_stereo,
+                visited=new_visited,
+            )
             reactant_molecules.append(reactant_mol)
 
         # Extract mapped_smiles from the 'smiles' field of the reaction node

--- a/src/retrocast/adapters/syntheseus_adapter.py
+++ b/src/retrocast/adapters/syntheseus_adapter.py
@@ -81,7 +81,11 @@ class SyntheseusAdapter(BaseAdapter):
         raises RetroCastException on failure.
         """
         # use the common recursive builder with new schema
-        target_molecule = build_molecule_from_bipartite_node(raw_mol_node=syntheseus_root, ignore_stereo=ignore_stereo)
+        target_molecule = build_molecule_from_bipartite_node(
+            raw_mol_node=syntheseus_root,
+            ignore_stereo=ignore_stereo,
+            adapter="syntheseus",
+        )
 
         expected_smiles = canonicalize_smiles(target.smiles, ignore_stereo=ignore_stereo)
         if target_molecule.smiles != expected_smiles:

--- a/src/retrocast/workflow/ingest.py
+++ b/src/retrocast/workflow/ingest.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.curation.filtering import deduplicate_routes
 from retrocast.curation.sampling import sample_k_by_length, sample_random_k, sample_top_k
-from retrocast.exceptions import AdapterError, ChemError
+from retrocast.exceptions import AdapterError, ChemError, InputError
 from retrocast.io.data import save_routes
 from retrocast.io.provenance import generate_model_hash
 from retrocast.models.benchmark import BenchmarkSet
@@ -39,11 +39,23 @@ def ingest_model_predictions(
     """
     logger.info(f"Ingesting results for {model_name} on {benchmark.name}...")
 
-    if sampling_strategy:
+    sampler_fn = None
+    if sampling_strategy is not None:
         if sampling_strategy not in SAMPLING_STRATEGIES:
-            raise ValueError(f"Unknown sampling strategy: {sampling_strategy}")
+            raise InputError(
+                f"Unknown sampling strategy: {sampling_strategy}",
+                code="input.invalid_sampling_strategy",
+                context={
+                    "sampling_strategy": sampling_strategy,
+                    "available_sampling_strategies": sorted(SAMPLING_STRATEGIES.keys()),
+                },
+            )
         if sample_k is None:
-            raise ValueError("Must provide sample_k when using a sampling strategy")
+            raise InputError(
+                "Must provide sample_k when using a sampling strategy",
+                code="input.missing_sample_k",
+                context={"sampling_strategy": sampling_strategy},
+            )
         sampler_fn = SAMPLING_STRATEGIES[sampling_strategy]
         logger.info(f"Applying sampling: {sampling_strategy} (k={sample_k})")
 
@@ -92,7 +104,7 @@ def ingest_model_predictions(
         # --- Deduplication & Sampling ---
         unique_routes = deduplicate_routes(routes)
 
-        if sampling_strategy:
+        if sampler_fn is not None:
             assert sample_k is not None
             unique_routes = sampler_fn(unique_routes, sample_k)
 
@@ -120,5 +132,7 @@ def ingest_model_predictions(
         f"Saved {stats.final_unique_routes_saved} valid routes. "
         f"Duplication factor: {stats.duplication_factor}x"
     )
+    if stats.failures_by_code:
+        logger.info("Ingestion failures by code: %s", dict(sorted(stats.failures_by_code.items())))
 
     return processed_routes, save_file, stats

--- a/src/retrocast/workflow/ingest.py
+++ b/src/retrocast/workflow/ingest.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -7,7 +8,7 @@ from tqdm import tqdm
 from retrocast.adapters.base_adapter import BaseAdapter
 from retrocast.curation.filtering import deduplicate_routes
 from retrocast.curation.sampling import sample_k_by_length, sample_random_k, sample_top_k
-from retrocast.exceptions import AdapterError, ChemError, InputError
+from retrocast.exceptions import AdapterError, ChemError, InputError, UnsupportedAdapterFeatureError
 from retrocast.io.data import save_routes
 from retrocast.io.provenance import generate_model_hash
 from retrocast.models.benchmark import BenchmarkSet
@@ -39,7 +40,8 @@ def ingest_model_predictions(
     """
     logger.info(f"Ingesting results for {model_name} on {benchmark.name}...")
 
-    sampler_fn = None
+    sampler_fn: Callable[[list[Route], int], list[Route]] | None = None
+    sampler_k = 0
     if sampling_strategy is not None:
         if sampling_strategy not in SAMPLING_STRATEGIES:
             raise InputError(
@@ -57,6 +59,7 @@ def ingest_model_predictions(
                 context={"sampling_strategy": sampling_strategy},
             )
         sampler_fn = SAMPLING_STRATEGIES[sampling_strategy]
+        sampler_k = sample_k
         logger.info(f"Applying sampling: {sampling_strategy} (k={sample_k})")
 
     processed_routes: dict[str, list[Route]] = {}
@@ -90,6 +93,8 @@ def ingest_model_predictions(
         try:
             # Adapter returns an iterator of Routes
             routes = list(adapter.cast(raw_payload, target=target, ignore_stereo=ignore_stereo))
+        except UnsupportedAdapterFeatureError:
+            raise
         except (AdapterError, ChemError) as e:
             logger.warning(f"Adapter failed for {target_id}: {e} [{e.code}]")
             routes = []
@@ -105,8 +110,7 @@ def ingest_model_predictions(
         unique_routes = deduplicate_routes(routes)
 
         if sampler_fn is not None:
-            assert sample_k is not None
-            unique_routes = sampler_fn(unique_routes, sample_k)
+            unique_routes = sampler_fn(unique_routes, sampler_k)
 
         processed_routes[target_id] = unique_routes
 

--- a/tests/adapters/test_askcos_adapter.py
+++ b/tests/adapters/test_askcos_adapter.py
@@ -110,6 +110,28 @@ class TestAskcosAdapterUnit(BaseAdapterTest):
         assert routes == []
         assert "adapter.cycle_detected" in caplog.text
 
+    def test_missing_root_uuid_skips_corrupted_pathway(self, raw_valid_route_data, target_input, caplog):
+        adapter = AskcosAdapter()
+        corrupted_data = copy.deepcopy(raw_valid_route_data)
+        corrupted_data["results"]["uds"]["uuid2smiles"].pop("00000000-0000-0000-0000-000000000000")
+
+        routes = list(adapter.cast(corrupted_data, target_input))
+
+        assert routes == []
+        assert "adapter.node_missing" in caplog.text
+        assert "root chemical" in caplog.text
+
+    def test_missing_reaction_uuid_skips_corrupted_pathway(self, raw_valid_route_data, target_input, caplog):
+        adapter = AskcosAdapter()
+        corrupted_data = copy.deepcopy(raw_valid_route_data)
+        corrupted_data["results"]["uds"]["pathways"][0][0]["target"] = "missing-rxn-uuid"
+
+        routes = list(adapter.cast(corrupted_data, target_input))
+
+        assert routes == []
+        assert "adapter.node_missing" in caplog.text
+        assert "reaction" in caplog.text
+
 
 @pytest.mark.contract
 class TestAskcosAdapterContract:

--- a/tests/adapters/test_askcos_adapter.py
+++ b/tests/adapters/test_askcos_adapter.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from retrocast.adapters.askcos_adapter import AskcosAdapter
+from retrocast.exceptions import UnsupportedAdapterFeatureError
 from retrocast.models.chem import TargetInput
 from tests.adapters.test_base_adapter import BaseAdapterTest
 
@@ -65,6 +66,49 @@ class TestAskcosAdapterUnit(BaseAdapterTest):
     @pytest.fixture
     def mismatched_target_input(self):
         return TargetInput(id="ethyl_acetate", smiles="CCO")
+
+    def test_use_full_graph_raises_typed_unsupported_feature(self, raw_valid_route_data, target_input):
+        adapter = AskcosAdapter(use_full_graph=True)
+
+        with pytest.raises(UnsupportedAdapterFeatureError) as exc_info:
+            list(adapter.cast(raw_valid_route_data, target_input))
+
+        assert exc_info.value.code == "adapter.unsupported_feature"
+        assert exc_info.value.context == {"adapter": "askcos", "feature": "full_graph"}
+
+    def test_cycle_detection_skips_corrupted_pathway(self, target_input, caplog):
+        adapter = AskcosAdapter()
+        cyclic_data = {
+            "results": {
+                "uds": {
+                    "node_dict": {
+                        "CCO": {"smiles": "CCO", "id": "chem-root", "type": "chemical", "terminal": False},
+                        "C": {"smiles": "C", "id": "chem-1", "type": "chemical", "terminal": False},
+                        "C>>CCO": {"smiles": "C>>CCO", "id": "rxn-1", "type": "reaction"},
+                        "CCO>>C": {"smiles": "CCO>>C", "id": "rxn-2", "type": "reaction"},
+                    },
+                    "uuid2smiles": {
+                        "00000000-0000-0000-0000-000000000000": "CCO",
+                        "uuid-rxn-1": "C>>CCO",
+                        "uuid-chem-1": "C",
+                        "uuid-rxn-2": "CCO>>C",
+                    },
+                    "pathways": [
+                        [
+                            {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn-1"},
+                            {"source": "uuid-rxn-1", "target": "uuid-chem-1"},
+                            {"source": "uuid-chem-1", "target": "uuid-rxn-2"},
+                            {"source": "uuid-rxn-2", "target": "00000000-0000-0000-0000-000000000000"},
+                        ]
+                    ],
+                }
+            }
+        }
+
+        routes = list(adapter.cast(cyclic_data, target_input))
+
+        assert routes == []
+        assert "adapter.cycle_detected" in caplog.text
 
 
 @pytest.mark.contract

--- a/tests/adapters/test_base_adapter.py
+++ b/tests/adapters/test_base_adapter.py
@@ -76,11 +76,14 @@ class BaseAdapterTest(ABC):
         assert route.rank >= 1
 
     def test_adapt_handles_unsuccessful_run(self, adapter_instance, raw_unsuccessful_run_data, target_input):
-        """Tests that data for an unsuccessful run yields no routes or a typed schema error."""
+        """Tests that data for an unsuccessful run yields no routes or a typed adapter failure."""
         try:
             routes = list(adapter_instance.cast(raw_unsuccessful_run_data, target_input))
         except AdapterSchemaError as exc:
             assert exc.code == "adapter.schema_invalid"
+        except AdapterLogicError as exc:
+            assert exc.code.startswith("adapter.")
+            assert exc.context.get("target_id") == target_input.id
         else:
             assert len(routes) == 0
 

--- a/tests/adapters/test_base_adapter.py
+++ b/tests/adapters/test_base_adapter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from retrocast.exceptions import AdapterSchemaError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
 from retrocast.models.chem import Route
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,11 @@ class BaseAdapterTest(ABC):
     def test_adapt_handles_mismatched_smiles(
         self, adapter_instance, raw_valid_route_data, mismatched_target_input, caplog
     ):
-        """Tests that a SMILES mismatch between target and data yields no routes and logs a warning."""
-        routes = list(adapter_instance.cast(raw_valid_route_data, mismatched_target_input))
-        assert len(routes) == 0
-        assert "mismatched smiles" in caplog.text.lower() or "does not match expected target" in caplog.text.lower()
+        """Tests that a SMILES mismatch either raises a typed error or yields no routes with a warning."""
+        try:
+            routes = list(adapter_instance.cast(raw_valid_route_data, mismatched_target_input))
+        except AdapterLogicError as exc:
+            assert exc.code == "adapter.target_mismatch"
+        else:
+            assert len(routes) == 0
+            assert "mismatched smiles" in caplog.text.lower() or "does not match expected target" in caplog.text.lower()

--- a/tests/adapters/test_common.py
+++ b/tests/adapters/test_common.py
@@ -137,3 +137,17 @@ class TestPrecursorMapBuilder:
         with pytest.raises(AdapterLogicError) as exc_info:
             build_molecule_from_precursor_map("CCO", precursor_map)
         assert exc_info.value.code == "adapter.cycle_detected"
+
+    def test_raises_on_cycles_when_aliases_share_a_canonical_smiles(self):
+        """different smiles spellings of the same molecule should still trip cycle detection."""
+        precursor_map = {
+            "CCO": ["OCC"],
+            "OCC": ["C"],
+            "C": ["CCO"],
+        }
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            build_molecule_from_precursor_map("CCO", precursor_map)
+
+        assert exc_info.value.code == "adapter.cycle_detected"
+        assert exc_info.value.context["smiles"] == canonicalize_smiles("CCO")

--- a/tests/adapters/test_common.py
+++ b/tests/adapters/test_common.py
@@ -51,6 +51,45 @@ class TestBipartiteBuilder:
         assert exc_info.value.code == "adapter.node_type_invalid"
         assert exc_info.value.context["expected"] == "reaction"
 
+    def test_raises_on_cycle(self):
+        """should fail if the same molecule is revisited in one path."""
+        raw_data = SimpleNamespace(
+            smiles="CCO",
+            type="mol",
+            in_stock=False,
+            children=[
+                SimpleNamespace(
+                    type="reaction",
+                    metadata={},
+                    children=[
+                        SimpleNamespace(
+                            smiles="C",
+                            type="mol",
+                            in_stock=False,
+                            children=[
+                                SimpleNamespace(
+                                    type="reaction",
+                                    metadata={},
+                                    children=[
+                                        SimpleNamespace(
+                                            smiles="CCO",
+                                            type="mol",
+                                            in_stock=False,
+                                            children=[],
+                                        )
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            build_molecule_from_bipartite_node(raw_data)
+        assert exc_info.value.code == "adapter.cycle_detected"
+
 
 class TestPrecursorMapBuilder:
     def test_build_linear_route(self):
@@ -89,24 +128,12 @@ class TestPrecursorMapBuilder:
         assert reactant_smiles == {"C", "CO"}
         assert all(r.is_leaf for r in molecule.synthesis_step.reactants)
 
-    def test_handles_cycles(self):
-        """tests that a cycle a -> b -> a is detected and handled."""
+    def test_raises_on_cycles(self):
+        """tests that a cycle a -> b -> a raises a typed adapter error."""
         precursor_map = {
             "CCO": ["C"],  # ethanol from methane
             "C": ["CCO"],  # methane from ethanol (cycle)
         }
-        molecule = build_molecule_from_precursor_map("CCO", precursor_map)
-        # molecule should be: CCO -> C -> (CCO as leaf due to cycle detection)
-        assert not molecule.is_leaf
-        rxn_a = molecule.synthesis_step
-        assert rxn_a is not None
-        reactant_b = rxn_a.reactants[0]
-        assert reactant_b.smiles == "C"
-        assert not reactant_b.is_leaf
-        rxn_b = reactant_b.synthesis_step
-        assert rxn_b is not None
-        reactant_a_cycle = rxn_b.reactants[0]
-        assert reactant_a_cycle.smiles == "CCO"
-        # cycle is broken, second CCO is a leaf
-        assert reactant_a_cycle.is_leaf
-        assert reactant_a_cycle.synthesis_step is None
+        with pytest.raises(AdapterLogicError) as exc_info:
+            build_molecule_from_precursor_map("CCO", precursor_map)
+        assert exc_info.value.code == "adapter.cycle_detected"

--- a/tests/adapters/test_dreamretro_adapter.py
+++ b/tests/adapters/test_dreamretro_adapter.py
@@ -46,6 +46,22 @@ class TestDreamRetroAdapterUnit(BaseAdapterTest):
             adapter_instance._parse_route_string(bad_route_str)
         assert exc_info.value.code == "adapter.route_string_invalid"
 
+    def test_parser_raises_on_empty_string(self, adapter_instance):
+        with pytest.raises(AdapterLogicError) as exc_info:
+            adapter_instance._parse_route_string("")
+        assert exc_info.value.code == "adapter.route_string_empty"
+
+    def test_parser_allows_single_molecule_route(self, adapter_instance):
+        target_smiles, precursor_map = adapter_instance._parse_route_string("CCO")
+
+        assert target_smiles == canonicalize_smiles("CCO")
+        assert precursor_map == {}
+
+    def test_parser_raises_when_later_step_is_malformed(self, adapter_instance):
+        with pytest.raises(AdapterLogicError) as exc_info:
+            adapter_instance._parse_route_string("CCO>>CC=O|CC=O>O")
+        assert exc_info.value.code == "adapter.route_string_invalid"
+
 
 # ============================================================================
 # Contract Tests: Verify all routes meet schema requirements

--- a/tests/adapters/test_multistepttl_adapter.py
+++ b/tests/adapters/test_multistepttl_adapter.py
@@ -41,6 +41,32 @@ class TestTtlRetroAdapterUnit(BaseAdapterTest):
     def mismatched_target_input(self):
         return TargetInput(id="ethanol", smiles="CCC")
 
+    def test_zero_step_route_returns_leaf_route(self, adapter_instance, target_input):
+        raw_data = [{"reactions": [], "metadata": {"steps": 0}}]
+
+        routes = list(adapter_instance.cast(raw_data, target_input))
+
+        assert len(routes) == 1
+        assert routes[0].target.smiles == target_input.smiles
+        assert routes[0].target.is_leaf is True
+        assert routes[0].length == 0
+
+    def test_cycle_detection_discards_invalid_route(self, adapter_instance, target_input, caplog):
+        raw_data = [
+            {
+                "reactions": [
+                    {"product": "CCO", "reactants": ["C"]},
+                    {"product": "C", "reactants": ["CCO"]},
+                ],
+                "metadata": {"steps": 2},
+            }
+        ]
+
+        routes = list(adapter_instance.cast(raw_data, target_input))
+
+        assert routes == []
+        assert "adapter.cycle_detected" in caplog.text
+
 
 @pytest.mark.integration
 class TestTtlRetroAdapterContract:

--- a/tests/adapters/test_paroutes_adapter.py
+++ b/tests/adapters/test_paroutes_adapter.py
@@ -267,6 +267,76 @@ class TestPaRoutesAdapterRegression:
         assert stats.uncanonicalizable_token_count == 1
         assert stats.top_uncanonicalizable_tokens == [("CC(C)CC1=C(CC(C)C)[AlH3]1", 1)]
 
+    def test_missing_patent_id_raises_typed_error(self, adapter):
+        raw_route = {
+            "type": "mol",
+            "smiles": "CCO",
+            "in_stock": True,
+            "children": [],
+        }
+        target_input = TargetInput(id="missing-patent", smiles=canonicalize_smiles("CCO"))
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            list(adapter.cast(raw_route, target_input))
+
+        assert exc_info.value.code == "adapter.patent_id_missing"
+
+    def test_malformed_condition_slot_is_counted_non_fatally(self, adapter, raw_paroutes_data):
+        raw_route = deepcopy(raw_paroutes_data["paroutes-ex-1"])
+        raw_route["children"][0]["metadata"]["rsmi"] = "not-a-valid-rsmi"
+        stats = ConditionSlotParseStatistics()
+        target_input = TargetInput(id="paroutes-ex-1", smiles=canonicalize_smiles(raw_route["smiles"]))
+
+        route = list(adapter.cast(raw_route, target_input, condition_slot_parse_statistics=stats))[0]
+
+        step = route.target.synthesis_step
+        assert step is not None
+        assert "condition_slot" not in step.metadata
+        assert stats.malformed_rsmi_count == 1
+        assert stats.uncanonicalizable_token_count == 0
+
+    def test_report_statistics_logs_years_and_unparsed_categories(self, caplog):
+        adapter = PaRoutesAdapter()
+        adapter.year_counts["2015"] = 2
+        adapter.unparsed_categories["unknown_format"] = 1
+
+        with caplog.at_level("INFO"):
+            adapter.report_statistics()
+
+        assert "Parsed Year 2015: 2 routes" in caplog.text
+        assert "Category 'unknown_format': 1 routes" in caplog.text
+
+
+class TestPaRoutesAdapterDiagnostics:
+    def test_adapt_route_with_diagnostics_returns_route_on_success(self, raw_paroutes_data):
+        adapter = PaRoutesAdapter()
+        raw_route = raw_paroutes_data["paroutes-ex-1"]
+        target = TargetInput(id="paroutes-ex-1", smiles=canonicalize_smiles(raw_route["smiles"]))
+        stats = ConditionSlotParseStatistics()
+
+        result = adapter.adapt_route_with_diagnostics(raw_route, target, stats)
+
+        assert result.error is None
+        assert result.route is not None
+        assert result.route.metadata["patent_id"] == "US20150051201A1"
+
+    def test_adapt_route_with_diagnostics_captures_typed_error(self):
+        adapter = PaRoutesAdapter()
+        raw_route = {
+            "type": "mol",
+            "smiles": "CCO",
+            "in_stock": True,
+            "children": [],
+        }
+        target = TargetInput(id="missing-patent", smiles=canonicalize_smiles("CCO"))
+        stats = ConditionSlotParseStatistics()
+
+        result = adapter.adapt_route_with_diagnostics(raw_route, target, stats)
+
+        assert result.route is None
+        assert result.error is not None
+        assert result.error.code == "adapter.patent_id_missing"
+
 
 class TestPaRoutesYearParsing:
     @pytest.mark.parametrize(

--- a/tests/adapters/test_resolve.py
+++ b/tests/adapters/test_resolve.py
@@ -1,0 +1,118 @@
+import json
+
+import pytest
+
+from retrocast.adapters import get_adapter
+from retrocast.adapters.resolve import (
+    DEFAULT_RAW_RESULTS_FILENAME,
+    _read_manifest_directives,
+    resolve_adapter,
+    resolve_raw_results_filename,
+)
+from retrocast.exceptions import AdapterResolutionError
+
+
+@pytest.mark.unit
+class TestReadManifestDirectives:
+    def test_missing_manifest_returns_empty_dict(self, tmp_path, caplog):
+        with caplog.at_level("DEBUG"):
+            directives = _read_manifest_directives(tmp_path)
+
+        assert directives == {}
+        assert "No manifest.json found" in caplog.text
+
+    def test_malformed_manifest_returns_empty_dict(self, tmp_path, caplog):
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text("{not valid json")
+
+        with caplog.at_level("WARNING"):
+            directives = _read_manifest_directives(tmp_path)
+
+        assert directives == {}
+        assert "Failed to read manifest" in caplog.text
+
+    def test_non_mapping_directives_returns_empty_dict(self, tmp_path, caplog):
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps({"directives": ["not", "a", "dict"]}))
+
+        with caplog.at_level("WARNING"):
+            directives = _read_manifest_directives(tmp_path)
+
+        assert directives == {}
+        assert "Manifest directives is not a dict" in caplog.text
+
+
+@pytest.mark.unit
+class TestResolveAdapter:
+    def test_resolve_adapter_prefers_cli_override(self, tmp_path):
+        adapter, source = resolve_adapter(
+            cli_adapter="aizynth",
+            raw_dir=tmp_path,
+            model_name="test-model",
+        )
+
+        assert adapter is get_adapter("aizynth")
+        assert source == "cli"
+
+    def test_resolve_adapter_uses_manifest_when_cli_is_absent(self, tmp_path):
+        (tmp_path / "manifest.json").write_text(json.dumps({"directives": {"adapter": "askcos"}}))
+
+        adapter, source = resolve_adapter(
+            cli_adapter=None,
+            raw_dir=tmp_path,
+            model_name="test-model",
+        )
+
+        assert adapter is get_adapter("askcos")
+        assert source == "manifest"
+
+    def test_resolve_adapter_invalid_cli_override_raises(self, tmp_path):
+        with pytest.raises(AdapterResolutionError) as exc_info:
+            resolve_adapter(
+                cli_adapter="nope",
+                raw_dir=tmp_path,
+                model_name="test-model",
+            )
+
+        assert exc_info.value.code == "adapter.unknown"
+        assert exc_info.value.context["source"] == "cli"
+
+    def test_resolve_adapter_invalid_manifest_adapter_raises(self, tmp_path):
+        (tmp_path / "manifest.json").write_text(json.dumps({"directives": {"adapter": "nope"}}))
+
+        with pytest.raises(AdapterResolutionError) as exc_info:
+            resolve_adapter(
+                cli_adapter=None,
+                raw_dir=tmp_path,
+                model_name="test-model",
+            )
+
+        assert exc_info.value.code == "adapter.unknown"
+        assert exc_info.value.context["source"] == "manifest"
+        assert exc_info.value.context["adapter"] == "nope"
+
+    def test_resolve_adapter_missing_configuration_raises(self, tmp_path):
+        with pytest.raises(AdapterResolutionError) as exc_info:
+            resolve_adapter(
+                cli_adapter=None,
+                raw_dir=tmp_path,
+                model_name="test-model",
+            )
+
+        assert exc_info.value.code == "adapter.resolution_missing"
+        assert exc_info.value.context == {"model": "test-model", "raw_dir": str(tmp_path)}
+
+
+@pytest.mark.unit
+class TestResolveRawResultsFilename:
+    def test_uses_default_filename_when_manifest_has_no_override(self, tmp_path):
+        assert resolve_raw_results_filename(raw_dir=tmp_path) == DEFAULT_RAW_RESULTS_FILENAME
+
+    def test_uses_manifest_override_and_logs_it(self, tmp_path, caplog):
+        (tmp_path / "manifest.json").write_text(json.dumps({"directives": {"raw_results_filename": "valid.json.gz"}}))
+
+        with caplog.at_level("DEBUG"):
+            filename = resolve_raw_results_filename(raw_dir=tmp_path)
+
+        assert filename == "valid.json.gz"
+        assert "Using raw_results_filename 'valid.json.gz'" in caplog.text

--- a/tests/adapters/test_retrochimera_adapter.py
+++ b/tests/adapters/test_retrochimera_adapter.py
@@ -4,6 +4,7 @@ import pytest
 
 from retrocast.adapters.retrochimera_adapter import RetrochimeraAdapter
 from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
 from retrocast.models.chem import TargetInput
 from tests.adapters.test_base_adapter import BaseAdapterTest
 
@@ -37,8 +38,8 @@ class TestRetrochimeraAdapterUnit(BaseAdapterTest):
 
     @pytest.fixture
     def raw_unsuccessful_run_data(self):
-        # represents a model failure
-        return {"smiles": "CCO", "result": {"error": {"message": "failed"}}}
+        # represents a target with no extracted routes but no adapter contract failure
+        return {"smiles": "CCO", "result": {"outputs": []}}
 
     @pytest.fixture
     def raw_invalid_schema_data(self):
@@ -52,6 +53,32 @@ class TestRetrochimeraAdapterUnit(BaseAdapterTest):
     @pytest.fixture
     def mismatched_target_input(self):
         return TargetInput(id="ethanol", smiles="CCC")
+
+    def test_adapt_raises_on_reported_model_error(self, adapter_instance, target_input):
+        raw_data = {"smiles": "CCO", "result": {"error": {"type": "search_failed", "message": "failed"}}}
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            list(adapter_instance.cast(raw_data, target_input))
+
+        assert exc_info.value.code == "adapter.route_transform_failed"
+        assert exc_info.value.context == {
+            "adapter": "retrochimera",
+            "target_id": target_input.id,
+            "error_type": "search_failed",
+        }
+
+    def test_adapt_raises_when_outputs_are_missing(self, adapter_instance, target_input):
+        raw_data = {"smiles": "CCO", "result": {}}
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            list(adapter_instance.cast(raw_data, target_input))
+
+        assert exc_info.value.code == "adapter.route_transform_failed"
+        assert exc_info.value.context == {
+            "adapter": "retrochimera",
+            "target_id": target_input.id,
+            "payload_field": "result.outputs",
+        }
 
 
 @pytest.mark.integration

--- a/tests/adapters/test_retrochimera_adapter.py
+++ b/tests/adapters/test_retrochimera_adapter.py
@@ -80,6 +80,38 @@ class TestRetrochimeraAdapterUnit(BaseAdapterTest):
             "payload_field": "result.outputs",
         }
 
+    def test_route_level_failure_skips_only_bad_route(
+        self, adapter_instance, raw_valid_route_data, target_input, caplog
+    ):
+        raw_data = {
+            "smiles": "CCO",
+            "result": {
+                "outputs": [
+                    {
+                        "routes": [
+                            raw_valid_route_data["result"]["outputs"][0]["routes"][0],
+                            {
+                                "reactions": [
+                                    {"product": "CCO", "reactants": ["C"], "probability": 0.9},
+                                    {"product": "C", "reactants": ["CCO"], "probability": 0.8},
+                                ],
+                                "num_steps": 2,
+                                "step_probability_min": 0.8,
+                                "step_probability_product": 0.72,
+                            },
+                        ],
+                        "num_routes": 2,
+                    }
+                ]
+            },
+        }
+
+        routes = list(adapter_instance.cast(raw_data, target_input))
+
+        assert len(routes) == 1
+        assert routes[0].target.smiles == target_input.smiles
+        assert "adapter.cycle_detected" in caplog.text
+
 
 @pytest.mark.integration
 class TestRetrochimeraAdapterContract:

--- a/tests/adapters/test_retrostar_adapter.py
+++ b/tests/adapters/test_retrostar_adapter.py
@@ -50,6 +50,16 @@ class TestRetroStarAdapterUnit(BaseAdapterTest):
             adapter_instance._parse_route_string(bad_route_str)
         assert exc_info.value.code == "adapter.route_string_invalid"
 
+    def test_parser_raises_on_empty_string(self, adapter_instance):
+        with pytest.raises(AdapterLogicError) as exc_info:
+            adapter_instance._parse_route_string("")
+        assert exc_info.value.code == "adapter.route_string_empty"
+
+    def test_parser_raises_when_later_step_is_malformed(self, adapter_instance):
+        with pytest.raises(AdapterLogicError) as exc_info:
+            adapter_instance._parse_route_string("CCO>0.9>CC=O|CC=O>0.8")
+        assert exc_info.value.code == "adapter.route_string_invalid"
+
 
 # ============================================================================
 # Contract Tests: Verify all routes meet schema requirements

--- a/tests/adapters/test_synllama_adapter.py
+++ b/tests/adapters/test_synllama_adapter.py
@@ -85,6 +85,16 @@ class TestSynLlamaAdapterUnit(BaseAdapterTest):
             adapter_instance._parse_synthesis_string(bad_string)
         assert exc_info.value.code == expected_code
 
+    def test_route_with_no_templates_is_treated_as_leaf(self, adapter_instance):
+        raw_data = [{"synthesis_string": "CC(C)=O"}]
+        target_input = TargetInput(id="acetone-leaf", smiles=canonicalize_smiles("CC(C)=O"))
+
+        routes = list(adapter_instance.cast(raw_data, target_input))
+
+        assert len(routes) == 1
+        assert routes[0].target.is_leaf is True
+        assert routes[0].length == 0
+
 
 @pytest.mark.integration
 class TestSynLlamaAdapterContract:

--- a/tests/adapters/test_synplanner_adapter.py
+++ b/tests/adapters/test_synplanner_adapter.py
@@ -52,6 +52,47 @@ class TestSynPlannerAdapterUnit(BaseAdapterTest):
     def mismatched_target_input(self):
         return TargetInput(id="ethanol", smiles="CCC")
 
+    def test_cycle_detection_discards_invalid_route(self, adapter_instance, caplog):
+        raw_data = [
+            {
+                "smiles": "CCO",
+                "type": "mol",
+                "in_stock": False,
+                "children": [
+                    {
+                        "type": "reaction",
+                        "smiles": "[C:1]>>[C:1][C:2][O:3]",
+                        "children": [
+                            {
+                                "smiles": "C",
+                                "type": "mol",
+                                "in_stock": False,
+                                "children": [
+                                    {
+                                        "type": "reaction",
+                                        "smiles": "[C:1][C:2][O:3]>>[C:1]",
+                                        "children": [
+                                            {
+                                                "smiles": "CCO",
+                                                "type": "mol",
+                                                "in_stock": False,
+                                                "children": [],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        routes = list(adapter_instance.cast(raw_data, TargetInput(id="ethanol", smiles="CCO")))
+
+        assert routes == []
+        assert "adapter.cycle_detected" in caplog.text
+
 
 # ========================================
 # Contract Tests

--- a/tests/workflow/test_pipeline.py
+++ b/tests/workflow/test_pipeline.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.exceptions import AdapterSchemaError, ChemRuntimeError, InputError
+from retrocast.exceptions import AdapterSchemaError, ChemRuntimeError, InputError, UnsupportedAdapterFeatureError
 from retrocast.io.data import load_routes
 from retrocast.models.benchmark import BenchmarkSet, BenchmarkTarget
 from retrocast.models.chem import Route, TargetIdentity
@@ -72,6 +72,18 @@ class ChemFailingAdapter(BaseAdapter):
         raise ChemRuntimeError(
             "synthetic chemistry failure",
             context={"target_id": target.id},
+        )
+
+
+class UnsupportedFeatureAdapter(BaseAdapter):
+    """Adapter that fails fast on a workflow-level unsupported feature."""
+
+    def cast(
+        self, raw_target_data: Any, target: TargetIdentity, ignore_stereo: bool = False
+    ) -> Generator[Route, None, None]:
+        raise UnsupportedAdapterFeatureError(
+            "synthetic unsupported feature",
+            context={"adapter": "synthetic", "feature": "full_graph"},
         )
 
 
@@ -399,6 +411,25 @@ class TestIngestModelPredictions:
             "target_1": {"chem.runtime_error": 1},
             "target_2": {"chem.runtime_error": 1},
         }
+
+    @pytest.mark.integration
+    def test_ingest_re_raises_unsupported_adapter_features(self, tmp_path, synthetic_benchmark):
+        adapter = UnsupportedFeatureAdapter()
+        raw_data = {
+            "target_1": [{"bad": "payload"}],
+            "target_2": [{"bad": "payload"}],
+        }
+
+        with pytest.raises(UnsupportedAdapterFeatureError) as exc_info:
+            ingest_model_predictions(
+                model_name="unsupported-model",
+                benchmark=synthetic_benchmark,
+                raw_data=raw_data,
+                adapter=adapter,
+                output_dir=tmp_path,
+            )
+
+        assert exc_info.value.code == "adapter.unsupported_feature"
 
 
 # =============================================================================

--- a/tests/workflow/test_pipeline.py
+++ b/tests/workflow/test_pipeline.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from retrocast.adapters.base_adapter import BaseAdapter
-from retrocast.exceptions import AdapterSchemaError, ChemRuntimeError
+from retrocast.exceptions import AdapterSchemaError, ChemRuntimeError, InputError
 from retrocast.io.data import load_routes
 from retrocast.models.benchmark import BenchmarkSet, BenchmarkTarget
 from retrocast.models.chem import Route, TargetIdentity
@@ -312,10 +312,10 @@ class TestIngestModelPredictions:
 
     @pytest.mark.integration
     def test_ingest_invalid_sampling_strategy_raises(self, tmp_path, synthetic_benchmark):
-        """Test that invalid sampling strategy raises ValueError."""
+        """Test that invalid sampling strategy raises a typed input error."""
         adapter = SyntheticAdapter()
 
-        with pytest.raises(ValueError, match="Unknown sampling strategy"):
+        with pytest.raises(InputError) as exc_info:
             ingest_model_predictions(
                 model_name="test",
                 benchmark=synthetic_benchmark,
@@ -325,13 +325,15 @@ class TestIngestModelPredictions:
                 sampling_strategy="invalid-strategy",
                 sample_k=3,
             )
+        assert exc_info.value.code == "input.invalid_sampling_strategy"
+        assert exc_info.value.context["sampling_strategy"] == "invalid-strategy"
 
     @pytest.mark.integration
     def test_ingest_sampling_without_k_raises(self, tmp_path, synthetic_benchmark):
-        """Test that sampling without sample_k raises ValueError."""
+        """Test that sampling without sample_k raises a typed input error."""
         adapter = SyntheticAdapter()
 
-        with pytest.raises(ValueError, match="Must provide sample_k"):
+        with pytest.raises(InputError) as exc_info:
             ingest_model_predictions(
                 model_name="test",
                 benchmark=synthetic_benchmark,
@@ -341,22 +343,25 @@ class TestIngestModelPredictions:
                 sampling_strategy="top-k",
                 sample_k=None,
             )
+        assert exc_info.value.code == "input.missing_sample_k"
+        assert exc_info.value.context == {"sampling_strategy": "top-k"}
 
     @pytest.mark.integration
-    def test_ingest_records_structured_adapter_failures(self, tmp_path, synthetic_benchmark):
+    def test_ingest_records_structured_adapter_failures(self, tmp_path, synthetic_benchmark, caplog):
         adapter = FailingAdapter()
         raw_data = {
             "target_1": [{"bad": "payload"}],
             "target_2": [{"bad": "payload"}],
         }
 
-        processed, _, stats = ingest_model_predictions(
-            model_name="failing-model",
-            benchmark=synthetic_benchmark,
-            raw_data=raw_data,
-            adapter=adapter,
-            output_dir=tmp_path,
-        )
+        with caplog.at_level("INFO"):
+            processed, _, stats = ingest_model_predictions(
+                model_name="failing-model",
+                benchmark=synthetic_benchmark,
+                raw_data=raw_data,
+                adapter=adapter,
+                output_dir=tmp_path,
+            )
 
         assert processed["target_1"] == []
         assert processed["target_2"] == []
@@ -367,6 +372,7 @@ class TestIngestModelPredictions:
             "target_2": {"adapter.schema_invalid": 1},
         }
         assert stats.to_manifest_dict()["failures_by_code"] == {"adapter.schema_invalid": 2}
+        assert "Ingestion failures by code: {'adapter.schema_invalid': 2}" in caplog.text
 
     @pytest.mark.integration
     def test_ingest_records_chem_failures_per_target(self, tmp_path, synthetic_benchmark):


### PR DESCRIPTION
## why
recent error-handling updates defined stable boundary codes and moved paroutes training-set prep onto structured failure summaries, but ingest and several adapters were still on legacy behavior. that left some malformed routes silently truncated into synthetic leaves, some target-level adapter failures indistinguishable from "no routes found", and ingest logs without the same by-code summary already persisted in manifests.

## what changed
- tightened the shared adapter builders so cyclic precursor-map and bipartite routes now raise typed adapter failures with truthful adapter ids instead of being silently flattened.
- aligned adapter call sites and target-level failures across askcos, retrochimera, synllama, aizynth, syntheseus, synplanner, dreamretro, and retrostar with the structured error contract.
- updated ingest to raise typed `input.*` sampling configuration errors and log `failures_by_code` summaries alongside the existing manifest statistics.
- expanded focused adapter and workflow tests around cycle handling, unsupported features, target-payload failures, and ingest logging.

## risk
this intentionally changes malformed-route behavior: cyclic raw routes now fail fast with typed adapter errors instead of being partially adapted as fake leaves, so malformed payloads may yield fewer saved routes while producing better failure accounting. workflow ownership stays the same: target-level adapter failures are counted and skipped by ingest, while route-local failures remain local to multi-route adapters.

## verification
- `uv run pytest tests/adapters tests/workflow/test_pipeline.py`
- `git commit` pre-commit hooks: `ruff`, `ruff (formatter)`, `ty`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cycle detection now prevents synthesis of invalid pathways containing loops.
  * Error reporting enhanced with specific error codes for easier troubleshooting and diagnosis.

* **Bug Fixes**
  * Improved validation of input parameters with structured error messages.
  * Better handling of unsupported adapter features with clear feedback.
  * Enhanced error context in adapter failures for improved debugging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns adapter and ingest error reporting to a structured failure contract: cyclic routes now raise typed `adapter.cycle_detected` errors instead of being silently converted to leaf nodes, several retrochimera target-level failures are promoted from logged warnings to raised `AdapterError` exceptions, and `ingest_model_predictions` gains typed `InputError` for sampling mis-configuration and now re-raises `UnsupportedAdapterFeatureError` before the catch-all handler so misconfigured adapters fail fast.

- **Cycle detection hardened**: `build_molecule_from_precursor_map` and `build_molecule_from_bipartite_node` in `common.py` now canonicalize SMILES before visiting-set membership checks and raise `adapter_cycle_error` on re-entry, replacing the previous silent leaf-substitution in both the shared helper and the duplicated per-adapter methods (which are now removed).
- **Retrochimera target-level failures promoted**: `result.error`, SMILES mismatch, and missing `result.outputs` in `retrochimera_adapter.py` now raise structured `AdapterLogicError`/`AdapterSchemaError` exceptions instead of logging and returning, so ingest correctly counts them in `failures_by_code`.
- **Ingest receives `failures_by_code` log and fixes `UnsupportedAdapterFeatureError` propagation**: the new `except UnsupportedAdapterFeatureError: raise` guard before `except (AdapterError, ChemError)` ensures a misconfigured adapter (e.g. `AskcosAdapter(use_full_graph=True)`) crashes the entire ingest call on the first target rather than silently producing zero routes for all targets.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the behavioral change (cyclic routes now fail fast with typed errors instead of silently becoming leaf nodes) is intentional and well-tested, and two previously silent failure modes in ingest are now correctly surfaced.

All changed adapter paths now raise typed errors rather than silently swallowing failures. The UnsupportedAdapterFeatureError re-raise guard in ingest correctly prevents zero-route silent runs. Cycle detection canonicalises SMILES before visited-set membership, closing the alias-evasion gap. The retrochimera target-level promotions are covered by new unit tests, and the shared builder changes are exercised by both the bipartite and precursor-map test suites.

No files require special attention. The one style observation in retrochimera_adapter.py (reuse of adapter_route_transform_error for two distinct failure kinds) does not affect correctness.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/retrocast/adapters/common.py | Rewrites cycle detection to use canonical SMILES in visited set and raises typed adapter_cycle_error instead of silently creating a leaf; adds adapter and visited keyword args to both builders. |
| src/retrocast/adapters/errors.py | Adds adapter_route_transform_error factory returning AdapterLogicError with code adapter.route_transform_failed; no issues found. |
| src/retrocast/adapters/retrochimera_adapter.py | Promotes target-level silent returns to typed raises; uses shared build_molecule_from_precursor_map; route-level cycle failures are correctly caught and skipped. adapter_route_transform_error is reused for semantically distinct target-level failures (model error vs. missing outputs) producing the same ambiguous code in stats. |
| src/retrocast/workflow/ingest.py | Adds typed InputError for sampling config errors, re-raises UnsupportedAdapterFeatureError before the catch-all, replaces dead assert with sampler_k variable, and logs failures_by_code summary. |
| src/retrocast/adapters/askcos_adapter.py | Promotes use_full_graph path from bare NotImplementedError to UnsupportedAdapterFeatureError; threads visited set through cycle detection; no issues found. |
| tests/workflow/test_pipeline.py | Adds UnsupportedFeatureAdapter stub and test confirming ingest re-raises; updates sampling error tests to assert typed InputError codes; adds failures_by_code log-line assertion. |
| tests/adapters/test_retrochimera_adapter.py | Adds tests for typed target-level raises and a mixed-batch test verifying that the cyclic route is skipped while the valid route is still yielded. |
| tests/adapters/test_common.py | Replaces old cycle-tolerance test with two raising tests; adds canonical-alias cycle test to cover the SMILES-normalization edge case. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant ingest as ingest_model_predictions
    participant adapter as Adapter.cast()
    participant builder as build_molecule_from_*

    Caller->>ingest: ingest_model_predictions(adapter, ...)
    Note over ingest: validate sampling config<br/>(raises InputError if invalid)

    loop each target
        ingest->>adapter: adapter.cast(raw_payload, target)
        alt UnsupportedAdapterFeatureError
            adapter-->>ingest: raise UnsupportedAdapterFeatureError
            ingest-->>Caller: re-raise (fail fast)
        else target-level AdapterError / ChemError
            adapter-->>ingest: raise AdapterError
            ingest->>ingest: log warning + count in failures_by_code
        else yields routes
            loop each route
                adapter->>builder: "build_molecule_from_*(smiles, visited)"
                alt cycle detected (canon_smiles in visited)
                    builder-->>adapter: raise adapter_cycle_error
                    adapter->>adapter: log + skip route (route-local)
                else
                    builder-->>adapter: Molecule
                    adapter-->>ingest: yield Route
                end
            end
        end
    end

    ingest->>ingest: deduplicate + sample routes
    Note over ingest: log failures_by_code summary
    ingest-->>Caller: processed_routes, save_file, stats
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/retrocast/workflow/ingest.py`, line 93-98 ([link](https://github.com/ischemist/project-procrustes/blob/840f0ad180da7eca106f84e6ab0ec573820225d8/src/retrocast/workflow/ingest.py#L93-L98)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`UnsupportedAdapterFeatureError` silently swallowed per-target**

   `UnsupportedAdapterFeatureError` now inherits from `AdapterError`, so the `except (AdapterError, ChemError)` handler here catches it for every target in the benchmark. When `AskcosAdapter(use_full_graph=True)` is passed to `ingest_model_predictions`, each call to `adapter.cast(...)` raises immediately (before inspecting any target data), the exception is caught, a per-target warning is logged, and processing continues — resulting in zero routes saved for all N targets with no upfront failure.

   Before this PR, `cast` raised a bare `NotImplementedError`, which was **not** caught by this handler and would crash the ingest on the first target, giving a clear signal. The new behavior succeeds silently with an empty result set, which is harder to diagnose than an outright failure.

   Consider re-raising `UnsupportedAdapterFeatureError` before the target loop, or excluding it from the handler so it propagates to the caller.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/retrocast/workflow/ingest.py
   Line: 93-98

   Comment:
   **`UnsupportedAdapterFeatureError` silently swallowed per-target**

   `UnsupportedAdapterFeatureError` now inherits from `AdapterError`, so the `except (AdapterError, ChemError)` handler here catches it for every target in the benchmark. When `AskcosAdapter(use_full_graph=True)` is passed to `ingest_model_predictions`, each call to `adapter.cast(...)` raises immediately (before inspecting any target data), the exception is caught, a per-target warning is logged, and processing continues — resulting in zero routes saved for all N targets with no upfront failure.

   Before this PR, `cast` raised a bare `NotImplementedError`, which was **not** caught by this handler and would crash the ingest on the first target, giving a clear signal. The new behavior succeeds silently with an empty result set, which is harder to diagnose than an outright failure.

   Consider re-raising `UnsupportedAdapterFeatureError` before the target loop, or excluding it from the handler so it propagates to the caller.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/adapters/retrochimera_adapter.py:75-83
`adapter_route_transform_error` is reused for two semantically distinct target-level failures: a model-reported search error and a missing `outputs` field. Both collapse into the code `"adapter.route_transform_failed"` in failure statistics, making it impossible for an operator reading logs to distinguish "the upstream model returned an error" from "the parsed payload was structurally incomplete." Since `errors.py` already has per-failure-type factory functions, consider giving each distinct failure its own code (e.g. `"adapter.model_error"` for the `result.error` branch).

```suggestion
        if validated_data.result.error is not None:
            error_msg = validated_data.result.error.get("message", "unknown error")
            error_type = validated_data.result.error.get("type", "unknown")
            raise adapter_route_transform_error(
                "retrochimera",
                target.id,
                f"model reported {error_type}: {error_msg}",
                error_type=error_type,
                failure_kind="model_error",
            )
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address pr review follow-ups"](https://github.com/ischemist/project-procrustes/commit/f62bca9cbef56f1ba479078b6e393a6cef4f9482) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31892426)</sub>

<!-- /greptile_comment -->