### PR TITLE
use pinned cooldown-guard release binary in ci

### DIFF
--- a/.github/workflows/cooldown-guard-reconcile.yml
+++ b/.github/workflows/cooldown-guard-reconcile.yml
@@ -13,25 +13,31 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     env:
-      COOLDOWN_GUARD_VERSION: "0.1.1"
+      COOLDOWN_GUARD_VERSION: "0.1.2"
+      COOLDOWN_GUARD_SHA256: "644f2dd532a116f2b4ade67ab3f8fd407c72f4a294bc347a7bd653cfdb66b33c"
     steps:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: install python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
+      - name: download cooldown-guard release binary
+        env:
+          GH_TOKEN: ${{ secrets.COOLDOWN_GUARD_DOWNLOAD_TOKEN }}
+        run: |
+          test -n "${GH_TOKEN}" || {
+            echo "COOLDOWN_GUARD_DOWNLOAD_TOKEN secret is required to download private release assets." >&2
+            exit 1
+          }
+          gh release download "v${COOLDOWN_GUARD_VERSION}" \
+            --repo ischemist/cooldown-guard \
+            --pattern "cooldown-guard-linux-x86_64"
+          echo "${COOLDOWN_GUARD_SHA256}  cooldown-guard-linux-x86_64" | sha256sum -c -
+          chmod +x cooldown-guard-linux-x86_64
 
       - name: apply cooldown cleanup if possible
         id: cleanup
         run: |
           set -euo pipefail
-          # Avoid inheriting the repo's own uv cooldown policy while bootstrapping cooldown-guard itself.
-          uvx --no-config --from "cooldown-guard==${COOLDOWN_GUARD_VERSION}" cooldown-guard cleanup --project . --apply
+          ./cooldown-guard-linux-x86_64 cleanup --project . --apply
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/cooldown-guard-reconcile.yml
+++ b/.github/workflows/cooldown-guard-reconcile.yml
@@ -20,16 +20,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: download cooldown-guard release binary
-        env:
-          GH_TOKEN: ${{ secrets.COOLDOWN_GUARD_DOWNLOAD_TOKEN }}
         run: |
-          test -n "${GH_TOKEN}" || {
-            echo "COOLDOWN_GUARD_DOWNLOAD_TOKEN secret is required to download private release assets." >&2
-            exit 1
-          }
-          gh release download "v${COOLDOWN_GUARD_VERSION}" \
-            --repo ischemist/cooldown-guard \
-            --pattern "cooldown-guard-linux-x86_64"
+          curl -fsSL -o cooldown-guard-linux-x86_64 \
+            "https://github.com/ischemist/cooldown-guard/releases/download/v${COOLDOWN_GUARD_VERSION}/cooldown-guard-linux-x86_64"
           echo "${COOLDOWN_GUARD_SHA256}  cooldown-guard-linux-x86_64" | sha256sum -c -
           chmod +x cooldown-guard-linux-x86_64
 

--- a/.github/workflows/cooldown-guard-validate.yml
+++ b/.github/workflows/cooldown-guard-validate.yml
@@ -17,20 +17,25 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     env:
-      COOLDOWN_GUARD_VERSION: "0.1.1"
+      COOLDOWN_GUARD_VERSION: "0.1.2"
+      COOLDOWN_GUARD_SHA256: "644f2dd532a116f2b4ade67ab3f8fd407c72f4a294bc347a7bd653cfdb66b33c"
     steps:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: install python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
+      - name: download cooldown-guard release binary
+        env:
+          GH_TOKEN: ${{ secrets.COOLDOWN_GUARD_DOWNLOAD_TOKEN }}
+        run: |
+          test -n "${GH_TOKEN}" || {
+            echo "COOLDOWN_GUARD_DOWNLOAD_TOKEN secret is required to download private release assets." >&2
+            exit 1
+          }
+          gh release download "v${COOLDOWN_GUARD_VERSION}" \
+            --repo ischemist/cooldown-guard \
+            --pattern "cooldown-guard-linux-x86_64"
+          echo "${COOLDOWN_GUARD_SHA256}  cooldown-guard-linux-x86_64" | sha256sum -c -
+          chmod +x cooldown-guard-linux-x86_64
 
       - name: validate cooldown guard ledger
-        run: |
-          # Avoid inheriting the repo's own uv cooldown policy while bootstrapping cooldown-guard itself.
-          uvx --no-config --from "cooldown-guard==${COOLDOWN_GUARD_VERSION}" cooldown-guard validate --project .
+        run: ./cooldown-guard-linux-x86_64 validate --project .

--- a/.github/workflows/cooldown-guard-validate.yml
+++ b/.github/workflows/cooldown-guard-validate.yml
@@ -24,16 +24,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: download cooldown-guard release binary
-        env:
-          GH_TOKEN: ${{ secrets.COOLDOWN_GUARD_DOWNLOAD_TOKEN }}
         run: |
-          test -n "${GH_TOKEN}" || {
-            echo "COOLDOWN_GUARD_DOWNLOAD_TOKEN secret is required to download private release assets." >&2
-            exit 1
-          }
-          gh release download "v${COOLDOWN_GUARD_VERSION}" \
-            --repo ischemist/cooldown-guard \
-            --pattern "cooldown-guard-linux-x86_64"
+          curl -fsSL -o cooldown-guard-linux-x86_64 \
+            "https://github.com/ischemist/cooldown-guard/releases/download/v${COOLDOWN_GUARD_VERSION}/cooldown-guard-linux-x86_64"
           echo "${COOLDOWN_GUARD_SHA256}  cooldown-guard-linux-x86_64" | sha256sum -c -
           chmod +x cooldown-guard-linux-x86_64
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,7 +31,10 @@ nav = [
   { "Rationale" = [
     "rationale/training-set-releases.md"
   ] },
-  { "Developers" = ["developers/adapters.md"] }
+  { "Developers" = [
+    "developers/adapters.md",
+    "developers/errors.md"
+  ] }
 ]
 # With the "extra_css" option you can add your own CSS styling to customize
 # your Zensical project according to your needs. You can add any number of


### PR DESCRIPTION
## summary
- switch cooldown-guard workflows from `uvx` to the pinned `v0.1.2` linux release binary
- verify the downloaded binary against the pinned sha256 `644f2dd532a116f2b4ade67ab3f8fd407c72f4a294bc347a7bd653cfdb66b33c`
- use authenticated `gh release download` because `ischemist/cooldown-guard` is private
- remove the runtime dependency on `uv` and `python` for these workflows

## verification
- parsed both workflow files with `yaml.safe_load(...)`
- `gh release download v0.1.2 --repo ischemist/cooldown-guard --pattern 'cooldown-guard-linux-x86_64'`
- `shasum -a 256 cooldown-guard-linux-x86_64`

## required setup
- add repository secret `COOLDOWN_GUARD_DOWNLOAD_TOKEN`
- the token needs `contents: read` access to `ischemist/cooldown-guard`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cooldown-guard tooling from version 0.1.1 to 0.1.2.
  * Enhanced internal validation and reconciliation workflows with pre-built binary downloads and SHA-256 verification for improved reliability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/86)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches both cooldown-guard workflows from `uvx`/Python to a pinned v0.1.2 release binary with SHA256 verification, removing the runtime dependency on `uv` and Python. It also adds a `developers/errors.md` entry to the `zensical.toml` documentation nav.

- Both workflows now download `cooldown-guard-linux-x86_64` via `curl -fsSL` and verify it against a pinned SHA256 before executing it — a sound supply-chain hardening approach.
- The reconcile workflow downloads the binary into the workspace root; `peter-evans/create-pull-request` stages untracked files with `git add -A`, so the binary will be committed to the repository on every reconcile run that produces changes.
- The `zensical.toml` change is a straightforward documentation nav update unrelated to the workflow changes.

<h3>Confidence Score: 3/5</h3>

The reconcile workflow will accidentally commit the downloaded binary into the repository on every run that produces changes.

The reconcile workflow writes the binary into the workspace root, which peter-evans/create-pull-request picks up via its implicit git add -A, committing the executable on every reconcile run that produces changes. Previously flagged authentication gaps for the private release repo also remain unaddressed.

.github/workflows/cooldown-guard-reconcile.yml requires attention: the binary download target path needs to move outside the workspace to prevent it from being committed by the auto-PR step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/cooldown-guard-reconcile.yml | Replaces uv/python setup with a pinned binary download + SHA256 verification; binary is downloaded into the workspace root, which causes peter-evans/create-pull-request to accidentally commit it on every reconcile run that produces changes. |
| .github/workflows/cooldown-guard-validate.yml | Replaces uv/python setup with same pinned binary download + SHA256 check; no auto-commit step so the workspace binary concern does not apply here. |
| zensical.toml | Adds `developers/errors.md` to the documentation navigation; unrelated to workflow changes and appears correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/cooldown-guard-reconcile.yml:22-33
**Binary downloaded into workspace will be committed by `create-pull-request`**

The binary is written to `cooldown-guard-linux-x86_64` in the workspace root — an untracked file. The `git diff --quiet` guard on line 34 only checks tracked-file modifications, so the binary passes undetected. `peter-evans/create-pull-request@v7` runs `git add -A` internally before creating its PR, which stages every untracked file in the workspace, including this binary. The result is that every reconcile run that produces changes will also commit the ~multi-MB executable into the repository.

Fix: download the binary to a path outside the workspace (e.g. `/tmp/cooldown-guard-linux-x86_64`) and update the `sha256sum` check and `./cooldown-guard-linux-x86_64` invocation on line 33 to use that path.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: add errors guide to zensical nav"](https://github.com/ischemist/project-procrustes/commit/f7e2e286edbefe6a229000ba32b14024ff074d7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31981955)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->