### PR TITLE
align developer error handling docs

### DIFF
--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -154,7 +154,7 @@ Adapter resolution happens before `cast` and raises `AdapterResolutionError` (`a
 
 Use `retrocast.adapters.errors.adapter_schema_error()` and `adapter_target_mismatch()` where they fit; they keep messages, codes, and context consistent.
 
-During `ingest`, workflow boundaries aggregate target-level adapter failures by `error.code` and persist the summary in manifest `statistics.failures_by_code`.
+During `ingest`, workflow boundaries aggregate target-level `AdapterError` and `ChemError` failures by `error.code`. In the ingest CLI path, that summary is persisted in manifest `statistics.failures_by_code`.
 
 ### Adapter Error Examples
 

--- a/docs/developers/adapters.md
+++ b/docs/developers/adapters.md
@@ -133,6 +133,8 @@ Some models have unique structures that don't fit the above patterns (e.g., grap
 
 Adapter error `code` values are lowercase machine contracts. Keep adapter names in `context["adapter"]` lowercase so callers can aggregate by `ADAPTER_MAP` key. Human-facing messages should use proper model capitalization, such as `DreamRetro`, `DMS`, or `MolBuilder`.
 
+For the shared exception shape, wrapping rules, and workflow-level failure accounting, see [Error Handling](errors.md).
+
 An adapter may raise these expected errors from `cast`:
 
 | exception | code | when it is raised | caller policy |
@@ -151,6 +153,8 @@ An adapter may raise these expected errors from `cast`:
 Adapter resolution happens before `cast` and raises `AdapterResolutionError` (`adapter.unknown` or `adapter.resolution_missing`) when the CLI or manifest cannot select an adapter.
 
 Use `retrocast.adapters.errors.adapter_schema_error()` and `adapter_target_mismatch()` where they fit; they keep messages, codes, and context consistent.
+
+During `ingest`, workflow boundaries aggregate target-level adapter failures by `error.code` and persist the summary in manifest `statistics.failures_by_code`.
 
 ### Adapter Error Examples
 

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -52,11 +52,11 @@ except ValidationError as exc:
 Handle failures by class and code, not by message text:
 
 ```python
-from retrocast.exceptions import AdapterError
+from retrocast.exceptions import AdapterError, ChemError
 
 try:
     routes = list(adapter.cast(raw_payload, target=target))
-except AdapterError as exc:
+except (AdapterError, ChemError) as exc:
     stats.record_failure(exc.code, target_id=target_id)
     routes = []
 ```
@@ -86,7 +86,7 @@ Route root mismatches should use `adapter.target_mismatch`; malformed raw payloa
 
 Batch workflows that continue after expected failures must count them by stable code.
 
-For `ingest`, the CLI writes `stats.to_manifest_dict()` into the manifest `statistics` block, so counts land under `statistics.failures_by_code`. The workflow also logs the same sorted summary.
+For `ingest`, `ingest_model_predictions()` logs the sorted failure summary and returns `stats`. The ingest CLI path then writes `stats.to_manifest_dict()` into the manifest `statistics` block, so counts land under `statistics.failures_by_code`.
 
 ```json
 {

--- a/docs/developers/errors.md
+++ b/docs/developers/errors.md
@@ -1,19 +1,27 @@
-# error handling
+---
+icon: lucide/triangle-alert
+---
 
-retrocast treats expected boundary failures as typed exceptions with stable codes.
-messages are for humans; codes and context are the contract.
 
-## rules
+# Error Handling
 
-- raise `RetroCastException` subclasses only at package, cli, io, adapter, workflow, and benchmark boundaries.
-- preserve causes with `raise ... from exc` when wrapping filesystem, json, gzip, pydantic, rdkit, or serializer failures.
-- let ordinary `ValueError`, `TypeError`, and `RuntimeError` represent local programmer errors.
-- library code raises; cli and workflow boundaries decide whether to abort, skip, count, or continue.
-- never branch on exception prose. branch on `error.code`.
+RetroCast treats expected boundary failures as typed exceptions with stable codes. Messages are for humans; codes and context are the contract.
 
-## shape
+!!! info "Codes are the public contract"
 
-all boundary-facing exceptions expose:
+    Do not branch on exception prose. Branch on `error.code`.
+
+## Rules
+
+- Raise `RetroCastException` subclasses only at package, CLI, I/O, adapter, workflow, and benchmark boundaries.
+- Preserve causes with `raise ... from exc` when wrapping filesystem, JSON, gzip, Pydantic, RDKit, or serializer failures.
+- Let ordinary `ValueError`, `TypeError`, and `RuntimeError` represent local programmer errors.
+- Library code raises; CLI and workflow boundaries decide whether to abort, skip, count, or continue.
+- Never branch on exception prose. Branch on `error.code`.
+
+## Shape
+
+All boundary-facing exceptions expose:
 
 ```json
 {
@@ -24,41 +32,81 @@ all boundary-facing exceptions expose:
 }
 ```
 
-use `error.to_dict()` when persisting or reporting the structured form.
+Use `error.to_dict()` when persisting or reporting the structured form.
 
-## taxonomy
+## Examples
 
-| family | base class | examples | meaning |
+Wrap expected boundary failures with a stable code and context:
+
+```python
+from pydantic import ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error
+
+try:
+    validated = MyRawOutput.model_validate(raw_target_data)
+except ValidationError as exc:
+    raise adapter_schema_error("dms", target.id, "invalid route list") from exc
+```
+
+Handle failures by class and code, not by message text:
+
+```python
+from retrocast.exceptions import AdapterError
+
+try:
+    routes = list(adapter.cast(raw_payload, target=target))
+except AdapterError as exc:
+    stats.record_failure(exc.code, target_id=target_id)
+    routes = []
+```
+
+## Taxonomy
+
+| Family | Base class | Examples | Meaning |
 | --- | --- | --- | --- |
-| `input.*` | `InputError` | `input.invalid` | external cli/config input is invalid |
-| `security.*` | `SecurityError` | `security.path_invalid`, `security.path_traversal` | path, filename, or filesystem boundary input is unsafe |
-| `config.*` | `ConfigurationError` | `config.invalid_color` | config values cannot be interpreted safely |
-| `chem.*` | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | chemistry parsing, identity, or backend failure |
-| `schema.*` | `SchemaLogicError` | `schema.logic_error` | data is structurally valid but logically impossible |
-| `benchmark.*` | `BenchmarkError` | `benchmark.validation_failed` | benchmark construction or uniqueness contract failed |
-| `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch`, `adapter.cycle_detected`, `adapter.route_string_invalid` | raw model output failed adapter boundary contracts |
-| `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.unsupported_format`, `io.write_failed` | artifact read, decode, shape, format, or write failure |
-| `serialization.*` | `RetroCastSerializationError` | `serialization.syntheseus_failed` | conversion to external route formats failed |
-| `workflow.*` | `WorkflowError` | `workflow.error` | orchestration failed at a workflow boundary |
+| `input.*` | `InputError` | `input.invalid` | External CLI/config input is invalid |
+| `security.*` | `SecurityError` | `security.path_invalid`, `security.path_traversal` | Path, filename, or filesystem boundary input is unsafe |
+| `config.*` | `ConfigurationError` | `config.invalid_color` | Config values cannot be interpreted safely |
+| `chem.*` | `ChemError` | `chem.invalid_smiles`, `chem.runtime_error` | Chemistry parsing, identity, or backend failure |
+| `schema.*` | `SchemaLogicError` | `schema.logic_error` | Data is structurally valid but logically impossible |
+| `benchmark.*` | `BenchmarkError` | `benchmark.validation_failed` | Benchmark construction or uniqueness contract failed |
+| `adapter.*` | `AdapterError` | `adapter.schema_invalid`, `adapter.target_mismatch`, `adapter.cycle_detected`, `adapter.route_string_invalid` | Raw model output failed adapter boundary contracts |
+| `io.*` | `DataIOError` | `io.not_found`, `io.decode_failed`, `io.invalid_artifact_shape`, `io.unsupported_format`, `io.write_failed` | Artifact read, decode, shape, format, or write failure |
+| `serialization.*` | `RetroCastSerializationError` | `serialization.syntheseus_failed` | Conversion to external route formats failed |
+| `workflow.*` | `WorkflowError` | `workflow.error` | Orchestration failed at a workflow boundary |
 
-## adapter policy
+## Adapter Policy
 
-adapter schema errors are fatal for one target payload and counted by the workflow.
-individual route transform errors may be logged and skipped when the adapter can keep processing the rest of the target.
-route root mismatches should use `adapter.target_mismatch`; malformed raw payloads should use `adapter.schema_invalid`.
+Adapter schema errors are fatal for one target payload and counted by the workflow. Individual route transform errors may be logged and skipped when the adapter can keep processing the rest of the target.
 
-## workflow accounting
+Route root mismatches should use `adapter.target_mismatch`; malformed raw payloads should use `adapter.schema_invalid`.
 
-batch workflows that continue after expected failures must count them by stable code.
-ingestion persists `failures_by_code` in manifests so runs can be compared without log scraping.
+## Workflow Accounting
 
-## cli policy
+Batch workflows that continue after expected failures must count them by stable code.
 
-the cli is the process boundary. it formats known `RetroCastException` instances with code and context, logs unexpected errors with tracebacks, and exits non-zero for fatal command failures.
+For `ingest`, the CLI writes `stats.to_manifest_dict()` into the manifest `statistics` block, so counts land under `statistics.failures_by_code`. The workflow also logs the same sorted summary.
 
-## tests
+```json
+{
+    "statistics": {
+        "failures_by_code": {
+            "adapter.schema_invalid": 2,
+            "chem.runtime_error": 1
+        }
+    }
+}
+```
 
-test the exception class and `code`; assert exact message text only when copy itself is the public contract.
-when wrapping matters, assert `__cause__` is present.
+Training-set curation preserves the adaptation summary shape instead of using the ingest `statistics` block. In those release manifests, the counts live under `summary.adaptation....failures_by_code`.
+
+## CLI Policy
+
+The CLI is the process boundary. It formats known `RetroCastException` instances with code and context, logs unexpected errors with tracebacks, and exits non-zero for fatal command failures.
+
+## Tests
+
+Test the exception class and `code`; assert exact message text only when copy itself is the public contract. When wrapping matters, assert `__cause__` is present.
 
 See [adapter errors](adapters.md#adapter-error-examples) for concrete examples of route-local adapter failures.


### PR DESCRIPTION
## why
the developer docs had drifted around the new typed error contract. `errors.md` did not match the style of other developer docs, and the ingest versus training manifest shapes for failure counts were easy to misstate.

## what changed
- restyled `docs/developers/errors.md` to match the other developer-facing docs, including icon/frontmatter, title casing, and a shared-contract admonition
- added concrete examples for wrapping validation failures and recording failures by stable `error.code`
- clarified where failure counts appear in ingest manifests versus training release manifests
- linked `docs/developers/adapters.md` back to the shared error-handling contract and noted ingest-level aggregation

## risk
low risk. this is docs-only, and the main review question is whether the wording matches the current code paths for ingest and training manifests.

## verification
- checked the docs against `src/retrocast/workflow/ingest.py`, `src/retrocast/cli/handlers.py`, and the training release/adaptation code paths
- ran `git diff --check`
- commit hooks ran `ty` and it passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR realigns `docs/developers/errors.md` and `docs/developers/adapters.md` with the current typed-error contract. Both files had drifted from the actual code paths for ingest and training manifests.

- `errors.md` is restyled to match other developer docs (icon/frontmatter, title casing, admonition), adds concrete code examples that correctly catch both `AdapterError` and `ChemError`, and distinguishes where `failures_by_code` lands in ingest manifests (`statistics.failures_by_code`) versus training-release manifests (`summary.adaptation....failures_by_code`).
- `adapters.md` gains a cross-reference to the shared error-handling contract and an explicit note that ingest aggregates both `AdapterError` and `ChemError` failures by code — correcting the previous implicit suggestion that only adapter errors are counted.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime impact; the updated examples and manifest-path descriptions match the actual source code.

Both changed files are developer docs. The code examples were verified against ingest.py (catches AdapterError and ChemError, calls stats.record_failure), the ingest manifest path (statistics.failures_by_code via stats.to_manifest_dict()) was confirmed in handlers.py, and the training manifest path (summary.adaptation....failures_by_code) was traced through route_release.py and records.py. No discrepancies found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/developers/errors.md | Full restyle plus new Examples and Workflow Accounting sections; code examples now correctly catch (AdapterError, ChemError) matching ingest.py, and manifest paths are accurately distinguished between ingest and training. |
| docs/developers/adapters.md | Two short additions: a cross-reference to errors.md and a sentence explicitly naming both AdapterError and ChemError in the ingest accounting description. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[adapter.cast] -->|success| B[routes collected]
    A -->|raises AdapterError| C["stats.record_failure(exc.code)"]
    A -->|raises ChemError| C
    C --> D[failures_by_code updated]
    B --> E[ingest_model_predictions returns stats]
    D --> E
    E -->|stats.to_manifest_dict| F[manifest statistics block]
    F --> G["statistics.failures_by_code (ingest manifests)"]
    E -->|training curation path| H[AdaptationStatistics.to_manifest_dict]
    H --> I["summary.adaptation....failures_by_code (training release manifests)"]
```

<sub>Reviews (2): Last reviewed commit: ["address pr feedback on error docs"](https://github.com/ischemist/project-procrustes/commit/ee6b91e8f220f21346c6a4e569458231d3b3503f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31991366)</sub>

<!-- /greptile_comment -->