### PR TITLE
chore: modernize package publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 0
     labels:
       - "scope/ci-cd"
+      - "type/security"
     groups:
       root-python-deps:
         patterns:
@@ -19,9 +20,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 0
     labels:
       - "scope/ci-cd"
+      - "type/security"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-name: "Publish to PyPi"
+name: "Publish to PyPI"
 
 on:
   release:
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: master
-          fetch-depth: 0  # Full history needed for setuptools-scm to read git tags
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0  # Full history needed for VCS-derived package versions
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install Python 3.13

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,7 @@ Provider-output adaptation APIs now return `PredictedRoute`, an envelope around 
 
 Prediction manifest `content_hash` values are now order-sensitive within each target because route list order is the ranking signal. Re-exported manifests can therefore differ from older manifests even when the route structures are otherwise identical.
 
-`adapt_single_route(...)` and `adapt_routes(...)` emit `RetroCastFutureWarning` in v0.6 and are scheduled for removal in v0.7.
+`adapt_single_route(...)` and `adapt_routes(...)` emit `RetroCastFutureWarning` in v0.6 and are scheduled for removal in v0.9. See the [deprecation schedule](developers/deprecations.md) for the current removal plan.
 
 ### 1-5 Minute Migration
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,18 +4,34 @@ icon: lucide/history
 
 # Changelog
 
-## v0.6 Adapter Workflow Split
+## v0.6.0
 
-v0.6 makes the adapter API more explicit. Earlier versions centered the public workflow on `ingest`, which did two jobs at once:
+v0.6.0 makes RetroCast more useful as a general route-standardization library, not only as a benchmark runner. The main design change is the split between adapting provider output into canonical predictions and collecting those predictions onto benchmark targets for scoring.
+
+For the full machine-generated change list, see the GitHub comparison after the release tag is published: [v0.5.3...v0.6.0](https://github.com/ischemist/project-procrustes/compare/v0.5.3...v0.6.0).
+
+### Highlights
+
+- Added `PredictedRoute`, an envelope around canonical `Route` chemistry for provider-level rank, score, confidence, source row, and metadata.
+- Split adaptation from benchmark collection with `adapt_provider_output(...)`, `adapt_target_keyed_provider_output(...)`, and `collect_benchmark_predictions(...)`.
+- Kept `retrocast ingest` as the project-mode convenience command for the common raw-output-to-benchmark-routes workflow.
+- Added route-corpus IO and CLI support for streamable prediction artifacts such as `.jsonl.gz`.
+- Added support for flat LLM completion corpora with `<synthesis_step>` XML blocks.
+- Added new adapter coverage, including MolBuilder, and renamed public adapter classes/slugs toward canonical planner names.
+- Added stable error codes for adapter, IO, CLI, and workflow boundaries, with ingest failure counts persisted into manifests.
+- Added PaRoutes training-set release utilities and hosted dataset loaders.
+- Improved release packaging so PyPI releases build from the release tag, support intentional dev releases, and use Hatchling/Hatch VCS for dynamic versions.
+
+### Adapter Workflow Split
+
+Earlier versions centered the public workflow on `ingest`, which did two jobs at once:
 
 1. standardize raw planner output into canonical `Route` objects
 2. collect those routes onto benchmark targets and write `routes.json.gz`
 
-That shape worked for benchmark runs, but it made RetroCast feel less like a general route-standardization library. In v0.6, standardization and benchmark collection are separate library workflows. `ingest` still exists as the project-mode convenience command that runs both.
+That shape worked for benchmark runs, but it made RetroCast feel less like a general route-standardization library. In v0.6.0, standardization and benchmark collection are separate library workflows. `ingest` still exists as the one-command wrapper that runs both.
 
-### What Changed
-
-| Before v0.6 | v0.6 replacement | Why |
+| Before v0.6.0 | v0.6.0 replacement | Why |
 | --- | --- | --- |
 | `adapt_single_route(raw, target, adapter_name)` | `adapt_route(raw_route, adapter)` | The one-route API no longer requires target context when the raw route carries its own target. |
 | `adapt_routes(raw, target, adapter_name)` | `adapt_provider_output(raw_provider_output, adapter)` | Standardization can now handle one provider output without benchmark target context. |
@@ -23,13 +39,22 @@ That shape worked for benchmark runs, but it made RetroCast feel less like a gen
 | `retrocast ingest` for project-mode benchmark runs | still `retrocast ingest` | Project mode keeps the one-command convenience wrapper. |
 | `Route.rank` | `PredictedRoute.rank` during provider-output adaptation, list order in scoring inputs | Keeps canonical `Route` free of benchmark/list-position metadata while preserving provider rank. |
 
-Provider-output adaptation APIs now return `PredictedRoute`, an envelope around canonical `Route` chemistry. It carries provider-level metadata such as rank, score, confidence, and source row provenance. `adapt_route(...)` remains the single-payload chemistry API and returns `Route | None`; use `adapt_prediction(...)` when you explicitly want a one-off prediction envelope. Scoring artifacts remain benchmark-keyed `dict[target_id, list[Route]]` so existing evaluation semantics stay stable.
+Provider-output adaptation APIs now return `PredictedRoute`, an envelope around canonical `Route` chemistry. It carries provider-level metadata such as rank, score, confidence, and source row provenance. `adapt_route(...)` remains the single-payload chemistry API and returns `Route | None`; use `adapt_prediction(...)` when you explicitly want a one-off prediction envelope.
 
-Prediction manifest `content_hash` values are now order-sensitive within each target because route list order is the ranking signal. Re-exported manifests can therefore differ from older manifests even when the route structures are otherwise identical.
+Scoring artifacts remain benchmark-keyed `dict[target_id, list[Route]]` so existing evaluation semantics stay stable. Prediction manifest `content_hash` values are now order-sensitive within each target because route list order is the ranking signal. Re-exported manifests can therefore differ from older manifests even when the route structures are otherwise identical.
 
-`adapt_single_route(...)` and `adapt_routes(...)` emit `RetroCastFutureWarning` in v0.6 and are scheduled for removal in v0.9. See the [deprecation schedule](developers/deprecations.md) for the current removal plan.
+### Deprecations
 
-### 1-5 Minute Migration
+The v0.6.0 compatibility layer intentionally warns instead of removing the old names immediately. These surfaces are scheduled for removal in v0.9.0:
+
+- legacy adapter slugs such as `aizynth`, `dms`, `dreamretro`, and `ursa-llm`
+- legacy adapter class aliases such as `AizynthAdapter`, `DMSAdapter`, `DreamRetroAdapter`, and `UrsaLlmAdapter`
+- target-local adaptation helpers such as `adapt_single_route(...)`, `adapt_routes(...)`, `adapt_route_corpus(...)`, and `adapt_benchmark_keyed_route_corpus(...)`
+- collection policy aliases `skip` and `report`
+
+See the [deprecation schedule](developers/deprecations.md) for the canonical removal plan.
+
+### Migration
 
 For one raw route-like payload:
 
@@ -81,8 +106,6 @@ collected = collect_benchmark_predictions(predictions, benchmark)
 routes_by_target = collected.routes_by_target
 ```
 
-### CLI Migration
-
 Ad-hoc CLI users can now run the two steps explicitly:
 
 ```bash
@@ -98,4 +121,4 @@ retrocast collect \
   --output routes.json.gz
 ```
 
-Project-mode users can keep using `retrocast ingest`. In v0.6 it remains the one-command wrapper that adapts raw output and then collects routes onto the selected benchmark.
+Project-mode users can keep using `retrocast ingest`.

--- a/docs/developers/deprecations.md
+++ b/docs/developers/deprecations.md
@@ -1,0 +1,30 @@
+---
+icon: lucide/calendar-clock
+---
+
+# Deprecation Schedule
+
+RetroCast uses warnings to keep pre-1.0 cleanup visible without forcing every downstream project to migrate immediately. A deprecated API remains usable until the removal version listed here, emits `RetroCastFutureWarning`, and should have a documented replacement before removal.
+
+## Policy
+
+- Treat the removal version in the warning as the public contract.
+- Prefer one minor release of warning time for narrow aliases and two minor releases for workflow/API shape changes.
+- Do not remove deprecated behavior in patch releases.
+- Update this page in the same PR that adds, delays, or removes a deprecation.
+
+## Scheduled Removals
+
+| removal | deprecated surface | replacement |
+| --- | --- | --- |
+| `0.9.0` | legacy adapter slugs such as `aizynth`, `dms`, `dreamretro`, and `ursa-llm` | canonical adapter slugs from `retrocast list-adapters`, such as `aizynthfinder`, `directmultistep`, `dreamretroer`, and `ursa` |
+| `0.9.0` | legacy adapter class aliases such as `AizynthAdapter`, `DMSAdapter`, `DreamRetroAdapter`, `TtlRetroAdapter`, `RetrochimeraAdapter`, `SynLLaMaAdapter`, `SynLlaMaAdapter`, and `UrsaLlmAdapter` | canonical adapter classes such as `AiZynthFinderAdapter`, `DirectMultiStepAdapter`, `DreamRetroErAdapter`, `MultiStepTTLAdapter`, `RetroChimeraAdapter`, `SynLlamaAdapter`, and `UrsaAdapter` |
+| `0.9.0` | `adapt_single_route(...)` and `adapt_routes(...)` | `adapt_route(...)`, `adapt_provider_output(...)`, or `adapt_target_keyed_provider_output(...)`, depending on input shape |
+| `0.9.0` | `adapt_route_corpus(...)` and `adapt_benchmark_keyed_route_corpus(...)` | `adapt_provider_output(...)` and `adapt_target_keyed_provider_output(...)` |
+| `0.9.0` | collection policies `on_unknown_target="skip"`, `on_unknown_target="report"`, `on_ambiguous_target="skip"`, and `on_ambiguous_target="report"` | `on_unknown_target="ignore"` or `on_ambiguous_target="ignore"` |
+
+## Migration Notes
+
+Adapter names now distinguish public model names from compatibility aliases. CLI users should pass canonical slugs; library users should import canonical classes. The aliases still work until `0.9.0`, but new docs and examples should not introduce them.
+
+The adaptation API is moving away from target-local helpers toward explicit workflow names. Use `adapt_route(...)` for a single raw route, `adapt_provider_output(...)` when adapting a streamable provider artifact into `PredictedRoute` objects, and `adapt_target_keyed_provider_output(...)` when the raw artifact is already keyed by benchmark target.

--- a/docs/guides/library/adaptation.md
+++ b/docs/guides/library/adaptation.md
@@ -134,7 +134,7 @@ Use `adapt_provider_output(...)` when your planner writes a streamable corpus, s
 
 Use `adapt_target_keyed_provider_output(...)` when your planner writes a mapping like `{target_id: raw_predictions_for_target}` or `{target_smiles: raw_predictions_for_target}`. This can simplify model runners because target association is explicit at the top level, and RetroCast can reject unknown or ambiguous keys early.
 
-`adapt_routes(...)` and `adapt_single_route(...)` are deprecated target-local compatibility helpers in v0.6 and will be removed in v0.7. Use `adapt_route(...)` for one raw route, `adapt_provider_output(...)` for ordinary standardization, or `adapt_target_keyed_provider_output(...)` when the raw provider output is keyed by target.
+`adapt_routes(...)` and `adapt_single_route(...)` are deprecated target-local compatibility helpers in v0.6 and will be removed in v0.9. Use `adapt_route(...)` for one raw route, `adapt_provider_output(...)` for ordinary standardization, or `adapt_target_keyed_provider_output(...)` when the raw provider output is keyed by target. See the [deprecation schedule](../../developers/deprecations.md) for the current removal plan.
 
 !!! note "Route ordering"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ New to RetroCast? Start here:
 - **[Training Sets](guides/training-sets.md)** - Load PaRoutes route and reaction training artifacts
 - **[Training-Set Release Rationale](rationale/training-set-releases.md)** - How PaRoutes route and single-step releases are created
 - **[Error Handling](developers/errors.md)** - Stable error codes and boundary contracts
+- **[Deprecation Schedule](developers/deprecations.md)** - Compatibility aliases and planned removal versions
 
 ## Benchmarks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs>=0.5.0"]
 build-backend = "hatchling.build"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [tool.coverage.run]
 omit = [
@@ -91,12 +91,23 @@ lint.select = [
 ]
 lint.ignore = ["E501", "SIM108"]
 
-[tool.setuptools.packages.find]
-where = ["src"]
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools_scm]
+[tool.hatch.version.raw-options]
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/retrocast"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/LICENSE",
+  "/README.md",
+  "/pyproject.toml",
+  "/src/retrocast",
+]
 
 [tool.ty.src]
 exclude = ["tests", "scripts"]

--- a/src/retrocast/adapters/__init__.py
+++ b/src/retrocast/adapters/__init__.py
@@ -76,7 +76,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.{_DEPRECATED_ADAPTER_REPLACEMENTS[name]}",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type
@@ -103,14 +103,14 @@ def get_adapter(adapter_name: str) -> BaseAdapter:
 
 
 def normalize_adapter_slug(adapter_name: str) -> str:
-    """Return the canonical adapter slug, warning for deprecated pre-0.7 slugs."""
+    """Return the canonical adapter slug, warning for deprecated pre-0.9 slugs."""
     canonical_name = DEPRECATED_ADAPTER_SLUGS.get(adapter_name)
     if canonical_name is None:
         return adapter_name
     warn_deprecated(
         old=f"adapter slug '{adapter_name}'",
         new=f"'{canonical_name}'",
-        remove_in="0.7",
+        remove_in="0.9",
         note="Update --adapter flags and manifest directives.",
         stacklevel=3,
     )
@@ -131,7 +131,7 @@ def adapt_single_route(
     warn_deprecated(
         old="adapt_single_route",
         new="adapt_route(...)",
-        remove_in="0.7",
+        remove_in="0.9",
         note="This wrapper returns the first successful route or None; "
         "use target-free `adapt_route(...)` for single-route adaptation.",
         stacklevel=2,
@@ -175,7 +175,7 @@ def adapt_routes(
     warn_deprecated(
         old="adapt_routes",
         new="adapt_provider_output(...) or adapt_target_keyed_provider_output(...)",
-        remove_in="0.7",
+        remove_in="0.9",
         note="Target-local adaptation is being removed from the public API. "
         "Use provider-output workflows for route standardization.",
         stacklevel=2,

--- a/src/retrocast/adapters/aizynth_adapter.py
+++ b/src/retrocast/adapters/aizynth_adapter.py
@@ -128,7 +128,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.AiZynthFinderAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/dms_adapter.py
+++ b/src/retrocast/adapters/dms_adapter.py
@@ -160,7 +160,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.DirectMultiStepAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/dreamretro_adapter.py
+++ b/src/retrocast/adapters/dreamretro_adapter.py
@@ -169,7 +169,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.DreamRetroErAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/multistepttl_adapter.py
+++ b/src/retrocast/adapters/multistepttl_adapter.py
@@ -181,7 +181,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.MultiStepTTLAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/retrochimera_adapter.py
+++ b/src/retrocast/adapters/retrochimera_adapter.py
@@ -196,7 +196,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.RetroChimeraAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/synllama_adapter.py
+++ b/src/retrocast/adapters/synllama_adapter.py
@@ -166,7 +166,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.SynLlamaAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/adapters/ursa_llm_adapter.py
+++ b/src/retrocast/adapters/ursa_llm_adapter.py
@@ -208,7 +208,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecated(
         old=f"{__name__}.{name}",
         new=f"{__name__}.UrsaAdapter",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     globals()[name] = adapter_type

--- a/src/retrocast/workflow/adapt.py
+++ b/src/retrocast/workflow/adapt.py
@@ -288,7 +288,7 @@ def adapt_route_corpus(
     warn_deprecated(
         old="adapt_route_corpus(...)",
         new="adapt_provider_output(...)",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     return adapt_provider_output(raw_data, adapter, ignore_stereo=ignore_stereo, stats=stats)
@@ -306,7 +306,7 @@ def adapt_benchmark_keyed_route_corpus(
     warn_deprecated(
         old="adapt_benchmark_keyed_route_corpus(...)",
         new="adapt_target_keyed_provider_output(...)",
-        remove_in="0.7",
+        remove_in="0.9",
         stacklevel=2,
     )
     return adapt_target_keyed_provider_output(

--- a/src/retrocast/workflow/collect.py
+++ b/src/retrocast/workflow/collect.py
@@ -23,7 +23,7 @@ def _normalize_collection_policy(policy: str, *, name: str) -> Literal["ignore",
         warn_deprecated(
             old=f"{name}={policy!r}",
             new=f"{name}='ignore'",
-            remove_in="0.7",
+            remove_in="0.9",
             note="'skip' and 'report' were aliases for the ignore behavior.",
             stacklevel=3,
         )

--- a/zensical.toml
+++ b/zensical.toml
@@ -41,7 +41,8 @@ nav = [
   ] },
   { "Developers" = [
     "developers/adapters.md",
-    "developers/errors.md"
+    "developers/errors.md",
+    "developers/deprecations.md"
   ] }
 ]
 # With the "extra_css" option you can add your own CSS styling to customize


### PR DESCRIPTION
## why

retrocast is being dogfooded across downstream projects, but unreleased work currently tends to require github-url dependencies. the existing pypi publish workflow was also brittle for dev releases because it checked out `master` during a release event, so a `v0.7.0.dev1` release could publish whatever `master` pointed at rather than the release tag.

## what changed

- switch package builds from setuptools/setuptools-scm to hatchling/hatch-vcs while preserving the existing vcs-derived version behavior (`guess-next-dev`, no local suffix).
- make both release workflows checkout the published release tag with full history so dynamic versions resolve from the intended commit.
- tighten hatchling artifact selection so the source distribution carries the package sources and package metadata rather than broad repository contents.
- pause routine dependabot prs while preserving security-oriented labeling.

## risk

packaging/release risk is the main boundary. the runtime package API is not intentionally changed, but build backend behavior and artifact inclusion are changed. the smoke tests exercise wheel and sdist installs to catch missing package files or broken entry points.

## verification

- `uv build`
- `uv run --isolated --no-project --with dist/*.whl --with pytest pytest tests/smoke_test.py -q` -> 15 passed
- `uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest tests/smoke_test.py -q` -> 15 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.7.0.dev1 uv build --out-dir /tmp/retrocast-dev-build`
- `uv lock --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781904388&installation_id=125602297&pr_number=96&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F96&signature=ab739d85012f3d5c46bc03988638af92d707b8f8a2de43f44aa43575cc919011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modernizes the packaging and release pipeline: it switches the build backend from setuptools/setuptools-scm to hatchling/hatch-vcs, fixes both publish workflows to check out the release tag (rather than `master`) with full history, and bumps all deprecation removal versions from `0.7` to `0.9` in sync with a new formal deprecation schedule document.

- **Workflow fix**: both `publish-pypi.yml` and `publish-release.yml` now use `ref: ${{ github.event.release.tag_name }}` with `fetch-depth: 0`, ensuring dev releases build from the correct commit rather than whatever `master` points at.
- **Build backend**: `hatchling` + `hatch-vcs` replace `setuptools` + `setuptools-scm` with identical `version_scheme = "guess-next-dev"` / `local_scheme = "no-local-version"` options, and explicit `include` lists tighten sdist artifact scope.
- **Deprecation housekeeping**: all `remove_in="0.7"` markers across adapters and workflow helpers are updated to `"0.9"`, and a new `docs/developers/deprecations.md` page documents the full removal schedule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — packaging-only change with no runtime API modifications and smoke-test verification covering both wheel and sdist installs.

Both publish workflows now correctly resolve VCS-derived versions from the tagged commit, the hatchling configuration mirrors the previous setuptools-scm options, and all deprecation markers are updated consistently across the codebase. Smoke tests were run against actual build artifacts before this PR was opened.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi.yml | Fixes checkout to use release tag name and full history instead of hardcoded master; adds smoke tests for wheel and sdist installs. |
| .github/workflows/publish-release.yml | Adds explicit tag checkout with full history to the release workflow, matching the fix applied to publish-pypi.yml. |
| pyproject.toml | Switches build backend from setuptools/setuptools-scm to hatchling/hatch-vcs, preserving version_scheme and local_scheme; adds explicit sdist/wheel artifact inclusion lists. |
| .github/dependabot.yml | Sets open-pull-requests-limit to 0 for both pip and github-actions ecosystems (pausing auto-PRs) and adds a type/security label to both entries. |
| src/retrocast/adapters/__init__.py | Bumps all deprecation remove_in values from "0.7" to "0.9" consistently with the updated deprecation schedule. |
| docs/developers/deprecations.md | New file documenting the deprecation policy and scheduled removal table for all deprecated adapter slugs, class aliases, and API surfaces at v0.9.0. |
| docs/changelog.md | Expands v0.6.0 changelog with highlights, corrects deprecation removal version from v0.7 to v0.9, and links to the new deprecation schedule page. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Release Event
    participant CIpypi as publish-pypi.yml
    participant CIrel as publish-release.yml
    participant Checkout as actions/checkout
    participant uv as uv build
    participant PyPI as PyPI

    GH->>CIpypi: release published (tag_name)
    GH->>CIrel: release published (tag_name)

    CIpypi->>Checkout: "ref=tag_name, fetch-depth=0"
    CIrel->>Checkout: "ref=tag_name, fetch-depth=0"
    Note over Checkout: Full history lets hatch-vcs resolve version from tag

    CIpypi->>uv: uv build (hatchling + hatch-vcs)
    uv-->>CIpypi: "dist/*.whl + dist/*.tar.gz"
    CIpypi->>CIpypi: Smoke test wheel
    CIpypi->>CIpypi: Smoke test sdist
    CIpypi->>PyPI: uv publish

    CIrel->>uv: uv build (hatchling + hatch-vcs)
    uv-->>CIrel: "dist/*"
    CIrel->>GH: Upload artifacts to release
```

<sub>Reviews (4): Last reviewed commit: ["chore: pin hatch build floors"](https://github.com/ischemist/project-procrustes/commit/8e5cf1487c666a61e3f44788ed7b98a526ad9c7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33124334)</sub>

<!-- /greptile_comment -->