### PR TITLE
Add schema v2 PaRoutes adapter

### DIFF
--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -37,7 +37,7 @@ Basic schema
 ```python
 class Molecule(BaseModel):
     smiles: SmilesStr
-    inchikey: InchiKeyStr
+    inchikey: InChIKeyStr
     product_of: Reaction | None = None
     annotations: dict[str, Any] = Field(default_factory=dict)
 
@@ -260,11 +260,11 @@ By default, adapt tries to turn raw planner output into canonical `Route` object
 
 ```python
 class FailureRecord(BaseModel):
-    code: str
+    code: ErrorCode
     message: str | None = None
     target_id: str | None = None
     target_smiles: SmilesStr | None = None
-    target_inchikey: InchiKeyStr | None = None
+    target_inchikey: InChIKeyStr | None = None
     context: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -326,7 +326,7 @@ where `Task` is defined through `Target`s and `TaskConstraints`:
 class Target(BaseModel):
     id: str
     smiles: SmilesStr
-    inchikey: InchiKeyStr
+    inchikey: InChIKeyStr
     acceptable_routes: list[Route] = Field(default_factory=list)
     annotations: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/retrocast/typing.py
+++ b/src/retrocast/typing.py
@@ -4,8 +4,14 @@ from typing import NewType
 SmilesStr = NewType("SmilesStr", str)
 """Represents a canonical SMILES string for a molecule."""
 
-InchiKeyStr = NewType("InchiKeyStr", str)
+InChIKeyStr = NewType("InChIKeyStr", str)
 """Represents an InChIKey string, the primary canonical identifier for molecules."""
+
+InchiKeyStr = InChIKeyStr
+"""Deprecated spelling. Use InChIKeyStr."""
 
 ReactionSmilesStr = NewType("ReactionSmilesStr", str)
 """Represents a reaction SMILES string, e.g., 'reactant1.reactant2>>product'."""
+
+ErrorCode = NewType("ErrorCode", str)
+"""Stable machine-readable error code. Messages remain human-readable prose."""

--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Schema v2 adapters."""
+
+from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.paroutes import PaRoutesAdapter
+
+__all__ = ["Adapter", "AdaptMode", "PaRoutesAdapter", "RawRouteEntry"]

--- a/src/retrocast/v2/adapters/base.py
+++ b/src/retrocast/v2/adapters/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+AdaptMode = Literal["strict", "prune"]
+
+
+@dataclass(frozen=True, slots=True)
+class RawRouteEntry:
+    payload: Any
+    source_key: str | None = None
+    source_row_index: int | None = None
+    source_record_id: str | None = None
+    target_hint_id: str | None = None
+    target_hint_smiles: str | None = None
+    source_order: int | None = None
+
+
+class Adapter(Protocol):
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]: ...
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route: ...

--- a/src/retrocast/v2/adapters/paroutes.py
+++ b/src/retrocast/v2/adapters/paroutes.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_node_type_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, ChemError, InvalidSmilesError
+from retrocast.typing import ReactionSmilesStr, SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.models.route import Molecule, Reaction, Route
+from retrocast.v2.models.task import Target
+
+logger = logging.getLogger(__name__)
+
+
+# SECTION: Raw PaRoutes Schema
+
+
+class PaRoutesReactionMetadata(BaseModel):
+    id: str = Field(..., alias="ID")
+    rsmi: str | None = None
+    smiles: str | None = None
+    reaction_hash: str | None = None
+    ring_breaker: bool | None = Field(None, alias="RingBreaker")
+
+
+class PaRoutesBaseNode(BaseModel):
+    smiles: str
+    children: list[PaRoutesNode] = Field(default_factory=list)
+
+
+class PaRoutesMoleculeInput(PaRoutesBaseNode):
+    type: Literal["mol"]
+    in_stock: bool = False
+
+
+class PaRoutesReactionInput(PaRoutesBaseNode):
+    type: Literal["reaction"]
+    metadata: PaRoutesReactionMetadata
+    children: list[PaRoutesMoleculeInput] = Field(default_factory=list)
+
+
+PaRoutesNode = Annotated[PaRoutesMoleculeInput | PaRoutesReactionInput, Field(discriminator="type")]
+
+PaRoutesMoleculeInput.model_rebuild()
+PaRoutesReactionInput.model_rebuild()
+
+
+# SECTION: Condition Slot Annotations
+
+
+class ConditionSlotParseStatistics(BaseModel):
+    malformed_rsmi_count: int = 0
+    uncanonicalizable_token_count: int = 0
+    uncanonicalizable_tokens: dict[str, int] = Field(default_factory=lambda: defaultdict(int))
+
+    @property
+    def distinct_uncanonicalizable_token_count(self) -> int:
+        return len(self.uncanonicalizable_tokens)
+
+    @property
+    def top_uncanonicalizable_tokens(self) -> list[tuple[str, int]]:
+        return sorted(self.uncanonicalizable_tokens.items(), key=lambda item: (-item[1], item[0]))[:5]
+
+
+def _extract_condition_slot(
+    rsmi: str | None,
+    *,
+    condition_slot_parse_statistics: ConditionSlotParseStatistics | None = None,
+) -> str | None:
+    if not rsmi:
+        return None
+
+    parts = rsmi.split(">")
+    if len(parts) != 3:
+        if condition_slot_parse_statistics is not None:
+            condition_slot_parse_statistics.malformed_rsmi_count += 1
+        return None
+
+    condition_slot = parts[1].strip()
+    return condition_slot or None
+
+
+def _parse_condition_slot_smiles(
+    condition_slot: str,
+    *,
+    condition_slot_parse_statistics: ConditionSlotParseStatistics | None = None,
+) -> list[SmilesStr]:
+    parsed_smiles: list[SmilesStr] = []
+    for token in condition_slot.split("."):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            parsed_smiles.append(canonicalize_smiles(token, remove_mapping=True))
+        except ChemError:
+            if condition_slot_parse_statistics is not None:
+                condition_slot_parse_statistics.uncanonicalizable_token_count += 1
+                condition_slot_parse_statistics.uncanonicalizable_tokens[token] += 1
+
+    return sorted(parsed_smiles)
+
+
+def _build_condition_slot_annotations(
+    *,
+    source_id: str,
+    rsmi: str | None,
+    ring_breaker: bool | None,
+    condition_slot_parse_statistics: ConditionSlotParseStatistics | None = None,
+) -> dict[str, Any]:
+    annotations: dict[str, Any] = {"source_id": source_id}
+    if ring_breaker is not None:
+        annotations["ring_breaker"] = ring_breaker
+
+    condition_slot = _extract_condition_slot(
+        rsmi,
+        condition_slot_parse_statistics=condition_slot_parse_statistics,
+    )
+    if condition_slot is not None:
+        annotations["condition_slot"] = condition_slot
+        condition_slot_smiles = _parse_condition_slot_smiles(
+            condition_slot,
+            condition_slot_parse_statistics=condition_slot_parse_statistics,
+        )
+        if condition_slot_smiles:
+            annotations["condition_slot_smiles"] = condition_slot_smiles
+
+    return annotations
+
+
+# SECTION: Adapter
+
+
+class PaRoutesAdapter:
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            validated_route_root = PaRoutesMoleculeInput.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("paroutes", target_id, "invalid molecule route root") from exc
+
+        yield RawRouteEntry(payload=validated_route_root, source_key=source_key, source_order=1)
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        if not isinstance(raw_route, PaRoutesMoleculeInput):
+            raw_route = PaRoutesMoleculeInput.model_validate(raw_route)
+
+        target_id = target.id if target is not None else "<unknown>"
+        patent_ids = self._get_patent_ids(raw_route)
+        if len(patent_ids) > 1:
+            raise AdapterLogicError(
+                f"PaRoutes route for target '{target_id}' contains reactions from multiple patents",
+                code="adapter.multiple_patents",
+                context={"adapter": "paroutes", "target_id": target_id, "patent_ids": sorted(patent_ids)},
+            )
+        if not patent_ids:
+            raise AdapterLogicError(
+                f"PaRoutes route for target '{target_id}' does not contain a patent id",
+                code="adapter.patent_id_missing",
+                context={"adapter": "paroutes", "target_id": target_id},
+            )
+
+        route_target = self._build_molecule(raw_route, visited=set(), mode=mode)
+        if route_target is None:
+            raise AdapterLogicError(
+                "PaRoutes target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "paroutes", "target_id": target_id},
+            )
+
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "paroutes",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=route_target.smiles,
+                )
+
+        return Route(target=route_target, annotations={"patent_id": next(iter(patent_ids))})
+
+    def _get_patent_ids(self, node: PaRoutesMoleculeInput, visited: set[str] | None = None) -> set[str]:
+        if visited is None:
+            visited = set()
+        if node.smiles in visited:
+            logger.warning("cycle detected in _get_patent_ids for smiles: %s", node.smiles)
+            return set()
+
+        patent_ids: set[str] = set()
+        new_visited = visited | {node.smiles}
+        for reaction_node in node.children:
+            if not isinstance(reaction_node, PaRoutesReactionInput):
+                continue
+            patent_ids.add(reaction_node.metadata.id.split(";")[0])
+            for reactant_node in reaction_node.children:
+                patent_ids.update(self._get_patent_ids(reactant_node, visited=new_visited))
+        return patent_ids
+
+    def _build_molecule(
+        self,
+        raw_mol_node: PaRoutesMoleculeInput,
+        visited: set[SmilesStr],
+        *,
+        mode: AdaptMode,
+    ) -> Molecule | None:
+        if raw_mol_node.type != "mol":
+            raise adapter_node_type_error("paroutes", expected="mol", actual=raw_mol_node.type, role="molecule")
+
+        try:
+            canon_smiles = canonicalize_smiles(raw_mol_node.smiles)
+        except InvalidSmilesError:
+            if mode == "prune":
+                return None
+            raise
+
+        if canon_smiles in visited:
+            raise adapter_cycle_error("paroutes", canon_smiles)
+
+        if raw_mol_node.in_stock or not raw_mol_node.children:
+            return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+        if len(raw_mol_node.children) > 1:
+            logger.warning("molecule %s has multiple child reactions; only the first is used", canon_smiles)
+
+        reaction_node = raw_mol_node.children[0]
+        if not isinstance(reaction_node, PaRoutesReactionInput):
+            actual = getattr(reaction_node, "type", type(reaction_node).__name__)
+            raise adapter_node_type_error("paroutes", expected="reaction", actual=actual, role="molecule child")
+
+        reactants = []
+        for reactant_node in reaction_node.children:
+            reactant = self._build_molecule(reactant_node, visited | {canon_smiles}, mode=mode)
+            if reactant is not None:
+                reactants.append(reactant)
+
+        reaction = Reaction(
+            reactants=reactants,
+            mapped_reaction_smiles=ReactionSmilesStr(reaction_node.metadata.rsmi)
+            if reaction_node.metadata.rsmi
+            else None,
+            annotations=_build_condition_slot_annotations(
+                source_id=reaction_node.metadata.id,
+                rsmi=reaction_node.metadata.rsmi,
+                ring_breaker=reaction_node.metadata.ring_breaker,
+            ),
+        )
+        return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles), product_of=reaction)
+
+
+# SECTION: Diagnostics
+
+
+def analyze_condition_slots(
+    raw_route: Mapping[str, Any],
+    *,
+    stats: ConditionSlotParseStatistics,
+) -> None:
+    def visit(node: Mapping[str, Any]) -> None:
+        children = node.get("children")
+        if not isinstance(children, list):
+            return
+        for child in children:
+            if not isinstance(child, Mapping):
+                continue
+            if child.get("type") == "reaction":
+                metadata = child.get("metadata")
+                if isinstance(metadata, Mapping) and isinstance(metadata.get("ID"), str):
+                    _build_condition_slot_annotations(
+                        source_id=metadata["ID"],
+                        rsmi=metadata.get("rsmi") if isinstance(metadata.get("rsmi"), str) else None,
+                        ring_breaker=metadata.get("RingBreaker")
+                        if isinstance(metadata.get("RingBreaker"), bool)
+                        else None,
+                        condition_slot_parse_statistics=stats,
+                    )
+            visit(child)
+
+    visit(raw_route)

--- a/src/retrocast/v2/adapters/paroutes.py
+++ b/src/retrocast/v2/adapters/paroutes.py
@@ -52,9 +52,6 @@ class PaRoutesReactionInput(PaRoutesBaseNode):
 
 PaRoutesNode = Annotated[PaRoutesMoleculeInput | PaRoutesReactionInput, Field(discriminator="type")]
 
-PaRoutesMoleculeInput.model_rebuild()
-PaRoutesReactionInput.model_rebuild()
-
 
 # SECTION: Condition Slot Annotations
 
@@ -229,12 +226,16 @@ class PaRoutesAdapter:
         patent_ids: set[str] = set()
         new_visited = visited | {node.smiles}
         for reaction_node in node.children:
-            if not isinstance(reaction_node, PaRoutesReactionInput):
-                continue
+            reaction_node = self._require_reaction_node(reaction_node, role="molecule child")
             patent_ids.add(reaction_node.metadata.id.split(";")[0])
             for reactant_node in reaction_node.children:
                 patent_ids.update(self._get_patent_ids(reactant_node, visited=new_visited))
         return patent_ids
+
+    def _require_reaction_node(self, node: PaRoutesNode, *, role: str) -> PaRoutesReactionInput:
+        if isinstance(node, PaRoutesReactionInput):
+            return node
+        raise adapter_node_type_error("paroutes", expected="reaction", actual=node.type, role=role)
 
     def _build_molecule(
         self,
@@ -243,9 +244,6 @@ class PaRoutesAdapter:
         *,
         mode: AdaptMode,
     ) -> Molecule | None:
-        if raw_mol_node.type != "mol":
-            raise adapter_node_type_error("paroutes", expected="mol", actual=raw_mol_node.type, role="molecule")
-
         try:
             canon_smiles = canonicalize_smiles(raw_mol_node.smiles)
         except InvalidSmilesError:
@@ -262,10 +260,7 @@ class PaRoutesAdapter:
         if len(raw_mol_node.children) > 1:
             logger.warning("molecule %s has multiple child reactions; only the first is used", canon_smiles)
 
-        reaction_node = raw_mol_node.children[0]
-        if not isinstance(reaction_node, PaRoutesReactionInput):
-            actual = getattr(reaction_node, "type", type(reaction_node).__name__)
-            raise adapter_node_type_error("paroutes", expected="reaction", actual=actual, role="molecule child")
+        reaction_node = self._require_reaction_node(raw_mol_node.children[0], role="molecule child")
 
         reactants = []
         for reactant_node in reaction_node.children:

--- a/src/retrocast/v2/adapters/paroutes.py
+++ b/src/retrocast/v2/adapters/paroutes.py
@@ -148,13 +148,34 @@ class PaRoutesAdapter:
         *,
         source_key: str | None = None,
     ) -> Iterator[RawRouteEntry]:
-        target_id = source_key or "<unknown>"
+        if not isinstance(raw_payload, Mapping):
+            target_id = source_key or "<unknown>"
+            raise adapter_schema_error("paroutes", target_id, "expected route root or mapping of target ids to routes")
+
+        is_route_root = raw_payload.get("type") == "mol" or "smiles" in raw_payload or "children" in raw_payload
+        if is_route_root:
+            target_id = source_key or "<unknown>"
+            yield RawRouteEntry(
+                payload=self._validate_route_root(raw_payload, target_id=target_id),
+                source_key=source_key,
+                source_order=1,
+            )
+            return
+
+        for source_order, (target_id, raw_route) in enumerate(raw_payload.items(), start=1):
+            if not isinstance(target_id, str):
+                raise adapter_schema_error("paroutes", source_key or "<unknown>", "target id keys must be strings")
+            yield RawRouteEntry(
+                payload=self._validate_route_root(raw_route, target_id=target_id),
+                source_key=target_id,
+                source_order=source_order,
+            )
+
+    def _validate_route_root(self, raw_route: Any, *, target_id: str) -> PaRoutesMoleculeInput:
         try:
-            validated_route_root = PaRoutesMoleculeInput.model_validate(raw_payload)
+            return PaRoutesMoleculeInput.model_validate(raw_route)
         except ValidationError as exc:
             raise adapter_schema_error("paroutes", target_id, "invalid molecule route root") from exc
-
-        yield RawRouteEntry(payload=validated_route_root, source_key=source_key, source_order=1)
 
     def cast(
         self,
@@ -163,22 +184,20 @@ class PaRoutesAdapter:
         mode: AdaptMode = "strict",
         target: Target | None = None,
     ) -> Route:
-        if not isinstance(raw_route, PaRoutesMoleculeInput):
-            raw_route = PaRoutesMoleculeInput.model_validate(raw_route)
-
         target_id = target.id if target is not None else "<unknown>"
+        raw_route = self._validate_route_root(raw_route, target_id=target_id)
         patent_ids = self._get_patent_ids(raw_route)
-        if len(patent_ids) > 1:
-            raise AdapterLogicError(
-                f"PaRoutes route for target '{target_id}' contains reactions from multiple patents",
-                code="adapter.multiple_patents",
-                context={"adapter": "paroutes", "target_id": target_id, "patent_ids": sorted(patent_ids)},
-            )
         if not patent_ids:
             raise AdapterLogicError(
                 f"PaRoutes route for target '{target_id}' does not contain a patent id",
                 code="adapter.patent_id_missing",
                 context={"adapter": "paroutes", "target_id": target_id},
+            )
+        if len(patent_ids) > 1:
+            raise AdapterLogicError(
+                f"PaRoutes route for target '{target_id}' contains reactions from multiple patents",
+                code="adapter.multiple_patents",
+                context={"adapter": "paroutes", "target_id": target_id, "patent_ids": sorted(patent_ids)},
             )
 
         route_target = self._build_molecule(raw_route, visited=set(), mode=mode)
@@ -205,8 +224,7 @@ class PaRoutesAdapter:
         if visited is None:
             visited = set()
         if node.smiles in visited:
-            logger.warning("cycle detected in _get_patent_ids for smiles: %s", node.smiles)
-            return set()
+            raise adapter_cycle_error("paroutes", node.smiles)
 
         patent_ids: set[str] = set()
         new_visited = visited | {node.smiles}
@@ -254,6 +272,14 @@ class PaRoutesAdapter:
             reactant = self._build_molecule(reactant_node, visited | {canon_smiles}, mode=mode)
             if reactant is not None:
                 reactants.append(reactant)
+        if not reactants:
+            if mode == "prune":
+                return None
+            raise AdapterLogicError(
+                "PaRoutes reaction has no reactants",
+                code="adapter.reaction_empty",
+                context={"adapter": "paroutes", "smiles": canon_smiles},
+            )
 
         reaction = Reaction(
             reactants=reactants,

--- a/src/retrocast/v2/adapters/paroutes.py
+++ b/src/retrocast/v2/adapters/paroutes.py
@@ -59,7 +59,7 @@ PaRoutesNode = Annotated[PaRoutesMoleculeInput | PaRoutesReactionInput, Field(di
 class ConditionSlotParseStatistics(BaseModel):
     malformed_rsmi_count: int = 0
     uncanonicalizable_token_count: int = 0
-    uncanonicalizable_tokens: dict[str, int] = Field(default_factory=lambda: defaultdict(int))
+    uncanonicalizable_tokens: defaultdict[str, int] = Field(default_factory=lambda: defaultdict(int))
 
     @property
     def distinct_uncanonicalizable_token_count(self) -> int:
@@ -183,7 +183,7 @@ class PaRoutesAdapter:
     ) -> Route:
         target_id = target.id if target is not None else "<unknown>"
         raw_route = self._validate_route_root(raw_route, target_id=target_id)
-        patent_ids = self._get_patent_ids(raw_route)
+        patent_ids = self._get_patent_ids(raw_route, mode=mode)
         if not patent_ids:
             raise AdapterLogicError(
                 f"PaRoutes route for target '{target_id}' does not contain a patent id",
@@ -217,19 +217,38 @@ class PaRoutesAdapter:
 
         return Route(target=route_target, annotations={"patent_id": next(iter(patent_ids))})
 
-    def _get_patent_ids(self, node: PaRoutesMoleculeInput, visited: set[str] | None = None) -> set[str]:
+    def _get_patent_ids(
+        self,
+        node: PaRoutesMoleculeInput,
+        *,
+        mode: AdaptMode,
+        visited: set[str] | None = None,
+    ) -> set[str]:
         if visited is None:
             visited = set()
-        if node.smiles in visited:
-            raise adapter_cycle_error("paroutes", node.smiles)
+        try:
+            canon_smiles = canonicalize_smiles(node.smiles)
+        except InvalidSmilesError:
+            if mode == "prune":
+                return set()
+            raise
+        if canon_smiles in visited:
+            raise adapter_cycle_error("paroutes", canon_smiles)
 
         patent_ids: set[str] = set()
-        new_visited = visited | {node.smiles}
-        for reaction_node in node.children:
-            reaction_node = self._require_reaction_node(reaction_node, role="molecule child")
-            patent_ids.add(reaction_node.metadata.id.split(";")[0])
+        new_visited = visited | {canon_smiles}
+        if node.children:
+            reaction_node = self._require_reaction_node(node.children[0], role="molecule child")
+            patent_id = reaction_node.metadata.id.split(";", 1)[0].strip()
+            if not patent_id:
+                raise AdapterLogicError(
+                    "PaRoutes reaction metadata contains an empty patent id",
+                    code="adapter.patent_id_missing",
+                    context={"adapter": "paroutes", "source_id": reaction_node.metadata.id},
+                )
+            patent_ids.add(patent_id)
             for reactant_node in reaction_node.children:
-                patent_ids.update(self._get_patent_ids(reactant_node, visited=new_visited))
+                patent_ids.update(self._get_patent_ids(reactant_node, mode=mode, visited=new_visited))
         return patent_ids
 
     def _require_reaction_node(self, node: PaRoutesNode, *, role: str) -> PaRoutesReactionInput:

--- a/src/retrocast/v2/models/__init__.py
+++ b/src/retrocast/v2/models/__init__.py
@@ -1,5 +1,6 @@
 """Schema v2 models."""
 
+from retrocast.v2.models.candidates import Candidate, FailureRecord
 from retrocast.v2.models.route import (
     InChIKeyLevel,
     Molecule,
@@ -13,8 +14,12 @@ from retrocast.v2.models.route import (
     validate_molecule_id,
     validate_reaction_id,
 )
+from retrocast.v2.models.task import Benchmark, Target, Task, TaskConstraints
 
 __all__ = [
+    "Benchmark",
+    "Candidate",
+    "FailureRecord",
     "InChIKeyLevel",
     "Molecule",
     "MoleculeId",
@@ -24,6 +29,9 @@ __all__ = [
     "ReactionView",
     "Route",
     "RoutePath",
+    "Target",
+    "Task",
+    "TaskConstraints",
     "validate_molecule_id",
     "validate_reaction_id",
 ]

--- a/src/retrocast/v2/models/candidates.py
+++ b/src/retrocast/v2/models/candidates.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.models.route import Route
+
+
+class FailureRecord(BaseModel):
+    code: ErrorCode
+    message: str | None = None
+    target_id: str | None = None
+    target_smiles: SmilesStr | None = None
+    target_inchikey: InChIKeyStr | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+
+
+class Candidate(BaseModel):
+    rank: int
+    route: Route | None = None
+    failure: FailureRecord | None = None
+
+    @model_validator(mode="after")
+    def _require_route_or_failure(self) -> Candidate:
+        if self.route is None and self.failure is None:
+            raise ValueError("Candidate requires route or failure.")
+        if self.route is not None and self.failure is not None:
+            raise ValueError("Candidate cannot contain both route and failure.")
+        return self

--- a/src/retrocast/v2/models/route.py
+++ b/src/retrocast/v2/models/route.py
@@ -9,7 +9,7 @@ from pydantic import AfterValidator, BaseModel, Field
 
 from retrocast.chem import InchiKeyLevel as InChIKeyLevel
 from retrocast.chem import reduce_inchikey
-from retrocast.typing import InchiKeyStr, ReactionSmilesStr, SmilesStr
+from retrocast.typing import InChIKeyStr, ReactionSmilesStr, SmilesStr
 
 RouteNodeKind = Literal["m", "r"]
 
@@ -138,7 +138,7 @@ class Reaction(BaseModel):
 
 class Molecule(BaseModel):
     smiles: SmilesStr
-    inchikey: InchiKeyStr
+    inchikey: InChIKeyStr
     product_of: Reaction | None = None
     annotations: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/retrocast/v2/models/task.py
+++ b/src/retrocast/v2/models/task.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+from retrocast.chem import get_inchi_key
+from retrocast.exceptions import ChemError
 from retrocast.typing import InChIKeyStr, SmilesStr
 from retrocast.v2.models.route import Route
 
@@ -14,6 +16,16 @@ class Target(BaseModel):
     inchikey: InChIKeyStr
     acceptable_routes: list[Route] = Field(default_factory=list)
     annotations: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> Target:
+        try:
+            expected_inchikey = get_inchi_key(self.smiles)
+        except ChemError as exc:
+            raise ValueError("Target.smiles must be valid.") from exc
+        if self.inchikey != expected_inchikey:
+            raise ValueError("Target.inchikey must match Target.smiles.")
+        return self
 
 
 class TaskConstraints(BaseModel):
@@ -29,6 +41,13 @@ class Task(BaseModel):
     constraints: dict[str, TaskConstraints] = Field(default_factory=dict)
     annotations: dict[str, Any] = Field(default_factory=dict)
     schema_version: Literal["2"] = "2"
+
+    @model_validator(mode="after")
+    def _validate_target_keys(self) -> Task:
+        mismatches = [key for key, target in self.targets.items() if key != target.id]
+        if mismatches:
+            raise ValueError("Task.targets keys must match Target.id values.")
+        return self
 
 
 class Benchmark(Task):

--- a/src/retrocast/v2/models/task.py
+++ b/src/retrocast/v2/models/task.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from retrocast.typing import InChIKeyStr, SmilesStr
+from retrocast.v2.models.route import Route
+
+
+class Target(BaseModel):
+    id: str
+    smiles: SmilesStr
+    inchikey: InChIKeyStr
+    acceptable_routes: list[Route] = Field(default_factory=list)
+    annotations: dict[str, Any] = Field(default_factory=dict)
+
+
+class TaskConstraints(BaseModel):
+    stock: str | None = None
+    required_leaves_smiles: list[SmilesStr] | None = None
+    route_depth: int | Literal["short", "medium", "long"] | None = None
+
+
+class Task(BaseModel):
+    name: str
+    targets: dict[str, Target]
+    default_constraints: TaskConstraints = Field(default_factory=TaskConstraints)
+    constraints: dict[str, TaskConstraints] = Field(default_factory=dict)
+    annotations: dict[str, Any] = Field(default_factory=dict)
+    schema_version: Literal["2"] = "2"
+
+
+class Benchmark(Task):
+    description: str = ""

--- a/tests/v2/adapters/base.py
+++ b/tests/v2/adapters/base.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from retrocast.exceptions import AdapterError, AdapterLogicError, AdapterSchemaError, ChemError
+from retrocast.v2.adapters.base import Adapter
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+
+@dataclass(frozen=True)
+class RawExtractionContractCase:
+    valid_payload: Any
+    malformed_payload: Any
+    source_key: str = "source-1"
+    expected_entry_count: int | None = None
+    expected_source_keys: list[str | None] | None = None
+    expected_source_order: int | None = None
+
+
+@dataclass(frozen=True)
+class CastContractCase:
+    valid_raw_route: Any
+    malformed_raw_route: Any
+    target: Target
+    mismatched_target: Target
+    expected_root_reactant_count: int | None = None
+
+
+@dataclass(frozen=True)
+class InvalidSmilesContractCase:
+    invalid_leaf_raw_route: Any
+    expected_pruned_root_reactants: list[str] | None = None
+    supports_prune: bool = True
+
+
+@dataclass(frozen=True)
+class AdapterContractCase:
+    adapter: Adapter
+    extraction: RawExtractionContractCase
+    casting: CastContractCase
+    invalid_smiles: InvalidSmilesContractCase | None = None
+
+
+def assert_adapter_accepts_valid_route(
+    adapter: Adapter,
+    raw_route: Any,
+    target: Target,
+) -> Route:
+    route = adapter.cast(raw_route, target=target)
+
+    assert isinstance(route, Route)
+    assert route.schema_version == "2"
+    assert route.target.smiles == target.smiles
+    assert route.target.inchikey
+    return route
+
+
+class AdapterContractSuite:
+    @pytest.fixture
+    def adapter_contract_case(self) -> AdapterContractCase:
+        raise NotImplementedError
+
+    @pytest.mark.contract
+    def test_iter_raw_routes_accepts_valid_payload(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        extraction = case.extraction
+
+        entries = list(case.adapter.iter_raw_routes(extraction.valid_payload, source_key=extraction.source_key))
+
+        assert entries
+        assert entries[0].payload is not None
+        if extraction.expected_entry_count is not None:
+            assert len(entries) == extraction.expected_entry_count
+        if extraction.expected_source_keys is not None:
+            assert [entry.source_key for entry in entries] == extraction.expected_source_keys
+        else:
+            assert entries[0].source_key == extraction.source_key
+        if extraction.expected_source_order is not None:
+            assert entries[0].source_order == extraction.expected_source_order
+
+    @pytest.mark.contract
+    def test_iter_raw_routes_rejects_malformed_payload(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        extraction = case.extraction
+
+        with pytest.raises(AdapterSchemaError) as exc_info:
+            list(case.adapter.iter_raw_routes(extraction.malformed_payload, source_key=extraction.source_key))
+
+        assert exc_info.value.code == "adapter.schema_invalid"
+
+    @pytest.mark.contract
+    def test_cast_accepts_valid_route(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        casting = case.casting
+
+        route = assert_adapter_accepts_valid_route(case.adapter, casting.valid_raw_route, casting.target)
+
+        if casting.expected_root_reactant_count is not None:
+            assert route.target.product_of is not None
+            assert len(route.target.product_of.reactants) == casting.expected_root_reactant_count
+
+    @pytest.mark.contract
+    def test_cast_rejects_malformed_route(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        casting = case.casting
+
+        with pytest.raises(AdapterSchemaError) as exc_info:
+            case.adapter.cast(casting.malformed_raw_route, target=casting.target)
+
+        assert exc_info.value.code == "adapter.schema_invalid"
+
+    @pytest.mark.contract
+    def test_cast_rejects_target_mismatch(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        casting = case.casting
+
+        with pytest.raises(AdapterLogicError) as exc_info:
+            case.adapter.cast(casting.valid_raw_route, target=casting.mismatched_target)
+
+        assert exc_info.value.code == "adapter.target_mismatch"
+
+    @pytest.mark.contract
+    def test_cast_strict_rejects_invalid_smiles(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        invalid_smiles = case.invalid_smiles
+        if invalid_smiles is None:
+            pytest.skip("raw format does not provide an invalid-leaf contract case")
+
+        with pytest.raises((AdapterError, ChemError)) as exc_info:
+            case.adapter.cast(invalid_smiles.invalid_leaf_raw_route, target=case.casting.target, mode="strict")
+
+        assert exc_info.value.code == "chem.invalid_smiles" or exc_info.value.code.startswith("adapter.")
+
+    @pytest.mark.contract
+    def test_cast_prune_drops_invalid_leaf(self, adapter_contract_case: AdapterContractCase) -> None:
+        case = adapter_contract_case
+        invalid_smiles = case.invalid_smiles
+        if invalid_smiles is None:
+            pytest.skip("raw format does not provide an invalid-leaf contract case")
+        if not invalid_smiles.supports_prune:
+            with pytest.raises(AdapterError) as exc_info:
+                case.adapter.cast(invalid_smiles.invalid_leaf_raw_route, target=case.casting.target, mode="prune")
+            assert exc_info.value.code.startswith("adapter.")
+            return
+        if invalid_smiles.expected_pruned_root_reactants is None:
+            pytest.skip("prune contract case does not specify expected root reactants")
+
+        route = case.adapter.cast(invalid_smiles.invalid_leaf_raw_route, target=case.casting.target, mode="prune")
+
+        root_reactants = [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()]
+        assert root_reactants == invalid_smiles.expected_pruned_root_reactants

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -20,10 +20,23 @@ from tests.v2.adapters.base import (
     RawExtractionContractCase,
 )
 
+# SECTION: Fixtures
+
 
 def target_for(raw_route: dict, target_id: str = "target") -> Target:
     smiles = canonicalize_smiles(raw_route["smiles"])
     return Target(id=target_id, smiles=smiles, inchikey=get_inchi_key(smiles))
+
+
+def target_for_entry(entry) -> Target:
+    smiles = canonicalize_smiles(entry.payload.smiles)
+    return Target(id=entry.source_key, smiles=smiles, inchikey=get_inchi_key(smiles))
+
+
+def load_real_paroutes_payload() -> dict:
+    path = Path("tests/testing_data/paroutes.json.gz")
+    with gzip.open(path, "rt", encoding="utf-8") as file:
+        return json.load(file)
 
 
 @pytest.fixture
@@ -84,6 +97,9 @@ def raw_paroutes_payload(raw_paroutes_route) -> dict:
     return {"paroutes-ex-1": raw_paroutes_route, "paroutes-ex-2": second_route}
 
 
+# SECTION: Shared Contract Suite
+
+
 class TestPaRoutesAdapterContract(AdapterContractSuite):
     @pytest.fixture
     def adapter_contract_case(
@@ -125,16 +141,38 @@ class TestPaRoutesAdapterContract(AdapterContractSuite):
         assert len(route.target.product_of.reactants) == 2
 
 
+# SECTION: Regression Tests
+
+
 @pytest.mark.regression
 def test_paroutes_iter_raw_routes_accepts_real_fixture_payload() -> None:
-    path = Path("tests/testing_data/paroutes.json.gz")
-    with gzip.open(path, "rt", encoding="utf-8") as file:
-        raw_payload = json.load(file)
+    raw_payload = load_real_paroutes_payload()
 
     entries = list(PaRoutesAdapter().iter_raw_routes(raw_payload))
 
     assert [entry.source_key for entry in entries] == ["paroutes-ex-1", "paroutes-ex-2"]
     assert [entry.source_order for entry in entries] == [1, 2]
+
+
+@pytest.mark.regression
+def test_paroutes_casts_real_fixture_routes_with_stable_signatures() -> None:
+    adapter = PaRoutesAdapter()
+    entries = list(adapter.iter_raw_routes(load_real_paroutes_payload()))
+
+    routes = [adapter.cast(entry.payload, target=target_for_entry(entry)) for entry in entries]
+
+    assert [route.signature() for route in routes] == [
+        "d79f5952f18331a4c889c073db1aac16a9842c7474900c3cd81aca276184e11e",
+        "b83d6ef3188683bb33b26921cb9ba9a0669ad389f695d941a3de6fa420730985",
+    ]
+    assert [route.annotations["patent_id"] for route in routes] == ["US20150051201A1", "US08242133B2"]
+    assert [[reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] for route in routes] == [
+        ["CN1CCn2ncc(N)c21", "CNc1nc(Cl)ncc1C(F)(F)F"],
+        ["Nc1cc(OC(F)(F)F)ccc1O", "O=C(O)c1ccncc1Cl"],
+    ]
+
+
+# SECTION: Contract Tests
 
 
 @pytest.mark.contract
@@ -312,6 +350,9 @@ def test_paroutes_prune_mode_drops_branch_when_all_reactants_are_invalid() -> No
         adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"), mode="prune")
 
     assert exc_info.value.code == "adapter.target_pruned"
+
+
+# SECTION: Diagnostics Tests
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.paroutes import ConditionSlotParseStatistics, PaRoutesAdapter, analyze_condition_slots
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+
+def target_for(raw_route: dict, target_id: str = "target") -> Target:
+    smiles = canonicalize_smiles(raw_route["smiles"])
+    return Target(id=target_id, smiles=smiles, inchikey=get_inchi_key(smiles))
+
+
+@pytest.fixture
+def raw_paroutes_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "C.CCO>O.C>CCO", "RingBreaker": False},
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True, "children": []},
+                    {
+                        "type": "mol",
+                        "smiles": "CC",
+                        "children": [
+                            {
+                                "type": "reaction",
+                                "smiles": "CC",
+                                "metadata": {"ID": "US123;2", "rsmi": "C>C>CC"},
+                                "children": [{"type": "mol", "smiles": "C", "in_stock": True, "children": []}],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.contract
+def test_paroutes_iter_raw_routes_validates_route_root(raw_paroutes_route) -> None:
+    adapter = PaRoutesAdapter()
+
+    entries = list(adapter.iter_raw_routes(raw_paroutes_route, source_key="paroutes-ex-1"))
+
+    assert len(entries) == 1
+    assert entries[0].source_key == "paroutes-ex-1"
+    assert entries[0].source_order == 1
+
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(adapter.iter_raw_routes({"smiles": "CCO"}, source_key="bad"))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_paroutes_cast_emits_route(raw_paroutes_route) -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = raw_paroutes_route
+
+    route = adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
+
+    assert isinstance(route, Route)
+    assert route.schema_version == "2"
+    assert route.annotations["patent_id"] == "US123"
+    assert route.target.smiles == canonicalize_smiles(raw_route["smiles"])
+    assert route.target.inchikey
+    assert route.target.product_of is not None
+    assert len(route.target.product_of.reactants) == 2
+
+
+@pytest.mark.contract
+def test_paroutes_reaction_annotations_keep_condition_slot(raw_paroutes_route) -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = raw_paroutes_route
+
+    route = adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
+    reaction = route.reaction_at("rc:r:/").value
+    raw_reaction = raw_route["children"][0]
+    condition_slot = raw_reaction["metadata"]["rsmi"].split(">")[1]
+
+    assert reaction.mapped_reaction_smiles == raw_reaction["metadata"]["rsmi"]
+    assert reaction.template is None
+    assert reaction.annotations["source_id"] == raw_reaction["metadata"]["ID"]
+    assert reaction.annotations["ring_breaker"] is False
+    assert reaction.annotations["condition_slot"] == condition_slot
+    assert reaction.annotations["condition_slot_smiles"] == sorted(
+        canonicalize_smiles(token) for token in condition_slot.split(".")
+    )
+    assert "reaction_hash" not in reaction.annotations
+    assert "smiles" not in reaction.annotations
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_mismatched_target(raw_paroutes_route) -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = raw_paroutes_route
+    target = Target(id="paroutes-ex-1", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC"))
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter.cast(raw_route, target=target)
+    assert exc_info.value.code == "adapter.target_mismatch"
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_mixed_patents(raw_paroutes_route) -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = deepcopy(raw_paroutes_route)
+    raw_route["children"][0]["children"][1]["children"][0]["metadata"]["ID"] = "OTHER;1234"
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
+    assert exc_info.value.code == "adapter.multiple_patents"
+
+
+@pytest.mark.contract
+def test_paroutes_prune_mode_drops_invalid_branch() -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "C.CCO>>CCO"},
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True, "children": []},
+                    {"type": "mol", "smiles": "not-smiles", "in_stock": True, "children": []},
+                ],
+            }
+        ],
+    }
+
+    strict_target = target_for(raw_route, "prune-target")
+    with pytest.raises(InvalidSmilesError):
+        adapter.cast(raw_route, target=strict_target, mode="strict")
+
+    route = adapter.cast(raw_route, target=strict_target, mode="prune")
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == [SmilesStr("C")]
+
+
+@pytest.mark.contract
+def test_analyze_condition_slots_counts_non_fatal_failures(raw_paroutes_route) -> None:
+    raw_route = deepcopy(raw_paroutes_route)
+    raw_route["children"][0]["metadata"]["rsmi"] = "not-a-valid-rsmi"
+    stats = ConditionSlotParseStatistics()
+
+    analyze_condition_slots(raw_route, stats=stats)
+
+    assert stats.malformed_rsmi_count == 1
+    assert stats.uncanonicalizable_token_count == 0

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.paroutes import ConditionSlotParseStatistics, PaRoutesAdapter, analyze_condition_slots
 from retrocast.v2.models.task import Target
@@ -138,6 +138,31 @@ def test_paroutes_iter_raw_routes_accepts_real_fixture_payload() -> None:
 
 
 @pytest.mark.contract
+def test_paroutes_iter_raw_routes_accepts_single_route_root(raw_paroutes_route) -> None:
+    entries = list(PaRoutesAdapter().iter_raw_routes(raw_paroutes_route, source_key="single-target"))
+
+    assert len(entries) == 1
+    assert entries[0].source_key == "single-target"
+    assert entries[0].source_order == 1
+
+
+@pytest.mark.contract
+def test_paroutes_iter_raw_routes_rejects_non_mapping_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(PaRoutesAdapter().iter_raw_routes(["not", "a", "payload"], source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_paroutes_iter_raw_routes_rejects_non_string_target_keys(raw_paroutes_route) -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(PaRoutesAdapter().iter_raw_routes({1: raw_paroutes_route}))
+
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
 def test_paroutes_reaction_annotations_keep_condition_slot(raw_paroutes_route) -> None:
     adapter = PaRoutesAdapter()
     raw_route = raw_paroutes_route
@@ -168,6 +193,30 @@ def test_paroutes_rejects_mixed_patents(raw_paroutes_route) -> None:
     with pytest.raises(AdapterLogicError) as exc_info:
         adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
     assert exc_info.value.code == "adapter.multiple_patents"
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_missing_patent_id() -> None:
+    raw_route = {"type": "mol", "smiles": "CCO", "in_stock": True, "children": []}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "missing-patent"))
+
+    assert exc_info.value.code == "adapter.patent_id_missing"
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_molecule_child_under_molecule() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [{"type": "mol", "smiles": "C", "children": []}],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "bad-topology"))
+
+    assert exc_info.value.code == "adapter.node_type_invalid"
 
 
 @pytest.mark.contract
@@ -206,6 +255,44 @@ def test_paroutes_rejects_cycles_before_patent_checks() -> None:
 
 
 @pytest.mark.contract
+def test_paroutes_rejects_cycles_after_smiles_canonicalization() -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "OCC>>CCO"},
+                "children": [{"type": "mol", "smiles": "OCC", "children": []}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter.cast(raw_route, target=target_for(raw_route, "cycle-target"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_empty_reaction_in_strict_mode() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {"type": "reaction", "smiles": "CCO", "metadata": {"ID": "US123;1", "rsmi": ">>CCO"}, "children": []}
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "empty-reaction"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
 def test_paroutes_prune_mode_drops_branch_when_all_reactants_are_invalid() -> None:
     adapter = PaRoutesAdapter()
     raw_route = {
@@ -236,4 +323,39 @@ def test_analyze_condition_slots_counts_non_fatal_failures(raw_paroutes_route) -
     analyze_condition_slots(raw_route, stats=stats)
 
     assert stats.malformed_rsmi_count == 1
+    assert stats.uncanonicalizable_token_count == 0
+
+
+@pytest.mark.contract
+def test_analyze_condition_slots_counts_uncanonicalizable_tokens(raw_paroutes_route) -> None:
+    raw_route = deepcopy(raw_paroutes_route)
+    raw_route["children"][0]["metadata"]["rsmi"] = "CCO>not-smiles..O>CCO"
+    stats = ConditionSlotParseStatistics()
+
+    analyze_condition_slots(raw_route, stats=stats)
+
+    assert stats.uncanonicalizable_token_count == 1
+    assert stats.distinct_uncanonicalizable_token_count == 1
+    assert stats.top_uncanonicalizable_tokens == [("not-smiles", 1)]
+
+
+@pytest.mark.contract
+def test_analyze_condition_slots_ignores_missing_rsmi(raw_paroutes_route) -> None:
+    raw_route = deepcopy(raw_paroutes_route)
+    raw_route["children"][0]["metadata"].pop("rsmi")
+    stats = ConditionSlotParseStatistics()
+
+    analyze_condition_slots(raw_route, stats=stats)
+
+    assert stats.malformed_rsmi_count == 0
+    assert stats.uncanonicalizable_token_count == 0
+
+
+@pytest.mark.contract
+def test_analyze_condition_slots_ignores_malformed_tree_shapes() -> None:
+    stats = ConditionSlotParseStatistics()
+
+    analyze_condition_slots({"children": [{"children": "not-a-list"}, "not-a-node"]}, stats=stats)
+
+    assert stats.malformed_rsmi_count == 0
     assert stats.uncanonicalizable_token_count == 0

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import gzip
+import json
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
+from retrocast.exceptions import AdapterLogicError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.paroutes import ConditionSlotParseStatistics, PaRoutesAdapter, analyze_condition_slots
-from retrocast.v2.models.route import Route
 from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
 
 
 def target_for(raw_route: dict, target_id: str = "target") -> Target:
@@ -47,35 +56,85 @@ def raw_paroutes_route() -> dict:
     }
 
 
-@pytest.mark.contract
-def test_paroutes_iter_raw_routes_validates_route_root(raw_paroutes_route) -> None:
-    adapter = PaRoutesAdapter()
+@pytest.fixture
+def raw_paroutes_invalid_leaf_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "C.CCO>>CCO"},
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True, "children": []},
+                    {"type": "mol", "smiles": "not-smiles", "in_stock": True, "children": []},
+                ],
+            }
+        ],
+    }
 
-    entries = list(adapter.iter_raw_routes(raw_paroutes_route, source_key="paroutes-ex-1"))
 
-    assert len(entries) == 1
-    assert entries[0].source_key == "paroutes-ex-1"
-    assert entries[0].source_order == 1
+@pytest.fixture
+def raw_paroutes_payload(raw_paroutes_route) -> dict:
+    second_route = deepcopy(raw_paroutes_route)
+    second_route["smiles"] = "CCC"
+    second_route["children"][0]["smiles"] = "CCC"
+    second_route["children"][0]["metadata"]["rsmi"] = "C.CC>>CCC"
+    return {"paroutes-ex-1": raw_paroutes_route, "paroutes-ex-2": second_route}
 
-    with pytest.raises(AdapterSchemaError) as exc_info:
-        list(adapter.iter_raw_routes({"smiles": "CCO"}, source_key="bad"))
-    assert exc_info.value.code == "adapter.schema_invalid"
+
+class TestPaRoutesAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self,
+        raw_paroutes_payload,
+        raw_paroutes_route,
+        raw_paroutes_invalid_leaf_route,
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=PaRoutesAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_paroutes_payload,
+                malformed_payload={"smiles": "CCO"},
+                source_key="paroutes-fixture",
+                expected_entry_count=2,
+                expected_source_keys=["paroutes-ex-1", "paroutes-ex-2"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=raw_paroutes_route,
+                malformed_raw_route={"smiles": "CCO"},
+                target=target_for(raw_paroutes_route, "paroutes-ex-1"),
+                mismatched_target=Target(id="paroutes-ex-1", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=raw_paroutes_invalid_leaf_route,
+                expected_pruned_root_reactants=["C"],
+            ),
+        )
+
+    @pytest.mark.contract
+    def test_cast_preserves_patent_annotation(self, raw_paroutes_route) -> None:
+        adapter = PaRoutesAdapter()
+
+        route = adapter.cast(raw_paroutes_route, target=target_for(raw_paroutes_route, "paroutes-ex-1"))
+
+        assert route.annotations["patent_id"] == "US123"
+        assert len(route.target.product_of.reactants) == 2
 
 
-@pytest.mark.contract
-def test_paroutes_cast_emits_route(raw_paroutes_route) -> None:
-    adapter = PaRoutesAdapter()
-    raw_route = raw_paroutes_route
+@pytest.mark.regression
+def test_paroutes_iter_raw_routes_accepts_real_fixture_payload() -> None:
+    path = Path("tests/testing_data/paroutes.json.gz")
+    with gzip.open(path, "rt", encoding="utf-8") as file:
+        raw_payload = json.load(file)
 
-    route = adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
+    entries = list(PaRoutesAdapter().iter_raw_routes(raw_payload))
 
-    assert isinstance(route, Route)
-    assert route.schema_version == "2"
-    assert route.annotations["patent_id"] == "US123"
-    assert route.target.smiles == canonicalize_smiles(raw_route["smiles"])
-    assert route.target.inchikey
-    assert route.target.product_of is not None
-    assert len(route.target.product_of.reactants) == 2
+    assert [entry.source_key for entry in entries] == ["paroutes-ex-1", "paroutes-ex-2"]
+    assert [entry.source_order for entry in entries] == [1, 2]
 
 
 @pytest.mark.contract
@@ -101,17 +160,6 @@ def test_paroutes_reaction_annotations_keep_condition_slot(raw_paroutes_route) -
 
 
 @pytest.mark.contract
-def test_paroutes_rejects_mismatched_target(raw_paroutes_route) -> None:
-    adapter = PaRoutesAdapter()
-    raw_route = raw_paroutes_route
-    target = Target(id="paroutes-ex-1", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC"))
-
-    with pytest.raises(AdapterLogicError) as exc_info:
-        adapter.cast(raw_route, target=target)
-    assert exc_info.value.code == "adapter.target_mismatch"
-
-
-@pytest.mark.contract
 def test_paroutes_rejects_mixed_patents(raw_paroutes_route) -> None:
     adapter = PaRoutesAdapter()
     raw_route = deepcopy(raw_paroutes_route)
@@ -123,7 +171,7 @@ def test_paroutes_rejects_mixed_patents(raw_paroutes_route) -> None:
 
 
 @pytest.mark.contract
-def test_paroutes_prune_mode_drops_invalid_branch() -> None:
+def test_paroutes_rejects_cycles_before_patent_checks() -> None:
     adapter = PaRoutesAdapter()
     raw_route = {
         "type": "mol",
@@ -132,21 +180,51 @@ def test_paroutes_prune_mode_drops_invalid_branch() -> None:
             {
                 "type": "reaction",
                 "smiles": "CCO",
-                "metadata": {"ID": "US123;1", "rsmi": "C.CCO>>CCO"},
+                "metadata": {"ID": "US123;1", "rsmi": "CC>>CCO"},
                 "children": [
-                    {"type": "mol", "smiles": "C", "in_stock": True, "children": []},
-                    {"type": "mol", "smiles": "not-smiles", "in_stock": True, "children": []},
+                    {
+                        "type": "mol",
+                        "smiles": "CC",
+                        "children": [
+                            {
+                                "type": "reaction",
+                                "smiles": "CC",
+                                "metadata": {"ID": "US123;2", "rsmi": "CCO>>CC"},
+                                "children": [{"type": "mol", "smiles": "CCO", "children": []}],
+                            }
+                        ],
+                    }
                 ],
             }
         ],
     }
 
-    strict_target = target_for(raw_route, "prune-target")
-    with pytest.raises(InvalidSmilesError):
-        adapter.cast(raw_route, target=strict_target, mode="strict")
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter.cast(raw_route, target=target_for(raw_route, "cycle-target"))
 
-    route = adapter.cast(raw_route, target=strict_target, mode="prune")
-    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == [SmilesStr("C")]
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_paroutes_prune_mode_drops_branch_when_all_reactants_are_invalid() -> None:
+    adapter = PaRoutesAdapter()
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "not-smiles>>CCO"},
+                "children": [{"type": "mol", "smiles": "not-smiles", "in_stock": True, "children": []}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter.cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -234,11 +234,44 @@ def test_paroutes_rejects_mixed_patents(raw_paroutes_route) -> None:
 
 
 @pytest.mark.contract
+def test_paroutes_patent_scan_uses_only_selected_reaction(raw_paroutes_route) -> None:
+    raw_route = deepcopy(raw_paroutes_route)
+    raw_route["children"].append(
+        {
+            "type": "reaction",
+            "smiles": raw_route["smiles"],
+            "metadata": {"ID": "OTHER;1", "rsmi": "C>>CCO"},
+            "children": [{"type": "mol", "smiles": "C", "children": []}],
+        }
+    )
+
+    route = PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "paroutes-ex-1"))
+
+    assert route.annotations["patent_id"] == "US123"
+
+
+@pytest.mark.contract
 def test_paroutes_rejects_missing_patent_id() -> None:
     raw_route = {"type": "mol", "smiles": "CCO", "in_stock": True, "children": []}
 
     with pytest.raises(AdapterLogicError) as exc_info:
         PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "missing-patent"))
+
+    assert exc_info.value.code == "adapter.patent_id_missing"
+
+
+@pytest.mark.contract
+def test_paroutes_rejects_empty_patent_id() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {"type": "reaction", "smiles": "CCO", "metadata": {"ID": " ;1", "rsmi": "C>>CCO"}, "children": []}
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        PaRoutesAdapter().cast(raw_route, target=target_for(raw_route, "empty-patent"))
 
     assert exc_info.value.code == "adapter.patent_id_missing"
 

--- a/tests/v2/models/test_candidates.py
+++ b/tests/v2/models/test_candidates.py
@@ -28,6 +28,17 @@ def test_candidate_accepts_failure_record() -> None:
 
 
 @pytest.mark.unit
+def test_candidate_accepts_route() -> None:
+    route = one_step_route()
+
+    candidate = Candidate(rank=1, route=route)
+
+    assert candidate.rank == 1
+    assert candidate.route == route
+    assert candidate.failure is None
+
+
+@pytest.mark.unit
 def test_candidate_requires_route_or_failure() -> None:
     with pytest.raises(ValidationError):
         Candidate(rank=1)

--- a/tests/v2/models/test_candidates.py
+++ b/tests/v2/models/test_candidates.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.models.candidates import Candidate, FailureRecord
+from retrocast.v2.models.route import Molecule, Reaction, Route
+
+
+def one_step_route() -> Route:
+    leaf = Molecule(smiles=SmilesStr("C"), inchikey=InChIKeyStr("AAAAAAAAAAAAAA-UHFFFAOYSA-N"))
+    target = Molecule(
+        smiles=SmilesStr("CC"),
+        inchikey=InChIKeyStr("BBBBBBBBBBBBBB-UHFFFAOYSA-N"),
+        product_of=Reaction(reactants=[leaf]),
+    )
+    return Route(target=target)
+
+
+@pytest.mark.unit
+def test_candidate_accepts_failure_record() -> None:
+    failure = FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="target-1")
+
+    candidate = Candidate(rank=1, failure=failure)
+
+    assert candidate.rank == 1
+    assert candidate.failure == failure
+    assert candidate.route is None
+
+
+@pytest.mark.unit
+def test_candidate_requires_route_or_failure() -> None:
+    with pytest.raises(ValidationError):
+        Candidate(rank=1)
+
+
+@pytest.mark.unit
+def test_candidate_rejects_both_route_and_failure() -> None:
+    failure = FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="target-1")
+
+    with pytest.raises(ValidationError):
+        Candidate(rank=1, route=one_step_route(), failure=failure)

--- a/tests/v2/models/test_route_signatures.py
+++ b/tests/v2/models/test_route_signatures.py
@@ -3,7 +3,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
-from retrocast.typing import InchiKeyStr, SmilesStr
+from retrocast.typing import InChIKeyStr, SmilesStr
 from retrocast.v2.models.route import InChIKeyLevel, Molecule, Reaction, Route
 
 KEY_A = "AAAAAAAAAAAAAA-UHFFFAOYSA-N"
@@ -16,7 +16,7 @@ KEY_A_STEREO_2 = "AAAAAAAAAAAAAA-CCCCCCCCSA-N"
 
 
 def molecule(smiles: str, inchikey: str, product_of: Reaction | None = None) -> Molecule:
-    return Molecule(smiles=SmilesStr(smiles), inchikey=InchiKeyStr(inchikey), product_of=product_of)
+    return Molecule(smiles=SmilesStr(smiles), inchikey=InChIKeyStr(inchikey), product_of=product_of)
 
 
 def one_step_route(reactants: list[Molecule], *, target_key: str = KEY_C) -> Route:

--- a/tests/v2/models/test_task.py
+++ b/tests/v2/models/test_task.py
@@ -16,6 +16,18 @@ def test_target_uses_canonical_identity_fields() -> None:
 
 
 @pytest.mark.unit
+def test_target_rejects_mismatched_identity_fields() -> None:
+    with pytest.raises(ValidationError):
+        Target(id="bad", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCC"))
+
+
+@pytest.mark.unit
+def test_target_rejects_invalid_smiles() -> None:
+    with pytest.raises(ValidationError):
+        Target(id="bad", smiles=SmilesStr("not-smiles"), inchikey=get_inchi_key("CCO"))
+
+
+@pytest.mark.unit
 def test_task_rejects_other_schema_versions() -> None:
     target = Target(id="ethanol", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
     task = Task(name="one-target", targets={target.id: target})
@@ -24,6 +36,14 @@ def test_task_rejects_other_schema_versions() -> None:
     assert isinstance(task.default_constraints, TaskConstraints)
     with pytest.raises(ValidationError):
         Task.model_validate({"name": "bad", "targets": {}, "schema_version": "3"})
+
+
+@pytest.mark.unit
+def test_task_rejects_target_key_mismatch() -> None:
+    target = Target(id="ethanol", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+
+    with pytest.raises(ValidationError):
+        Task(name="bad-target-map", targets={"wrong": target})
 
 
 @pytest.mark.unit

--- a/tests/v2/models/test_task.py
+++ b/tests/v2/models/test_task.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from retrocast.chem import get_inchi_key
+from retrocast.typing import SmilesStr
+from retrocast.v2.models.task import Benchmark, Target, Task, TaskConstraints
+
+
+@pytest.mark.unit
+def test_target_uses_canonical_identity_fields() -> None:
+    target = Target(id="ethanol", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+
+    assert target.id == "ethanol"
+    assert target.inchikey == get_inchi_key("CCO")
+    assert target.acceptable_routes == []
+
+
+@pytest.mark.unit
+def test_task_rejects_other_schema_versions() -> None:
+    target = Target(id="ethanol", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+    task = Task(name="one-target", targets={target.id: target})
+
+    assert task.schema_version == "2"
+    assert isinstance(task.default_constraints, TaskConstraints)
+    with pytest.raises(ValidationError):
+        Task.model_validate({"name": "bad", "targets": {}, "schema_version": "3"})
+
+
+@pytest.mark.unit
+def test_benchmark_is_a_task_with_description() -> None:
+    benchmark = Benchmark(name="bench", description="small", targets={})
+
+    assert benchmark.name == "bench"
+    assert benchmark.description == "small"


### PR DESCRIPTION
**Why**
Schema v2 has the route kernel, but the adapt slice needed a v2 adapter boundary for real PaRoutes payloads. PaRoutes extraction should operate on the full target-keyed raw artifact, while casting remains route-local.

**What Changed**
- Added v2 adapter protocol primitives and `RawRouteEntry`.
- Added v2 `Target`, `Task`, `Candidate`, and `FailureRecord` models needed by the adapt path.
- Added a PaRoutes adapter that emits v2 `Route` objects directly.
- Added a reusable v2 adapter contract suite for `iter_raw_routes` and `cast`.
- Added PaRoutes contract and regression coverage, including `tests/testing_data/paroutes.json.gz` and stable route signatures.

**Risk**
The key boundary is `raw PaRoutes payload -> RawRouteEntry -> Route`. The adapter rejects malformed raw schemas, target mismatches, cycles, mixed patents, empty reactions, and strict invalid SMILES with typed error codes. Prune mode drops invalid branches without emitting empty reactions.

**Verification**
- `uv run pytest`
- `uv run pytest tests/v2 --cov=retrocast.v2.adapters.paroutes --cov=retrocast.v2.models.candidates --cov-report=term-missing`
- `uv run ruff check src/retrocast/v2/adapters/paroutes.py tests/v2/adapters/base.py tests/v2/adapters/test_paroutes.py tests/v2/models/test_candidates.py`

**Review**
Self-reviewed against `.practices/docs/common/pr-review.md`; no red/yellow findings remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v2 adapter infrastructure for converting and validating route data with `strict`/`prune` adaptation modes, including PaRoutes adapter support.
  * Introduced v2 models: `Task`, `Target`, `Candidate`, `Benchmark`, and `FailureRecord` with constraint validation.
  * Added `ErrorCode` type for structured error handling.

* **Bug Fixes**
  * Corrected `InChIKeyStr` type capitalization with backward-compatible deprecation alias.

* **Documentation**
  * Updated schema documentation for type corrections.

* **Tests**
  * Added comprehensive adapter contract and model validation test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the v2 adapter layer for PaRoutes: protocol primitives (`Adapter`, `RawRouteEntry`, `AdaptMode`), five new Pydantic models (`Target`, `Task`, `Benchmark`, `Candidate`, `FailureRecord`), and a `PaRoutesAdapter` that converts raw target-keyed PaRoutes payloads into v2 `Route` objects with patent extraction, SMILES canonicalisation, and strict/prune adaptation modes. It also corrects the `InChIKeyStr` capitalisation with a backward-compatible alias.

- **Adapter core** (`paroutes.py`): `iter_raw_routes` detects single-route vs. target-keyed dict payloads and validates each root; `cast` runs patent-ID collection (`_get_patent_ids`) then recursive molecule construction (`_build_molecule`), rejecting cycles, mixed patents, empty reactions, and target SMILES mismatches.
- **Models** (`task.py`, `candidates.py`): `Target` cross-validates `smiles`/`inchikey` at construction; `Candidate` enforces exactly one of `route` or `failure`; `Task` enforces key\u2013id alignment across `targets`.
- **Tests**: a reusable `AdapterContractSuite` for future adapters, regression tests with stable route signatures against `paroutes.json.gz`, and per-behaviour contract tests covering all documented rejection paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of the known _get_patent_ids / _build_molecule in_stock traversal divergence noted in the prior review round.

The adapter's two-pass design contains a structural asymmetry where _get_patent_ids does not mirror _build_molecule's in_stock early-exit, meaning patent IDs can be collected from subtrees that route construction silently discards. Real PaRoutes data has in_stock molecules as leaves so regression tests pass, but the invariant is unenforced in code. Models and tests are otherwise sound.

src/retrocast/v2/adapters/paroutes.py — specifically the relationship between _get_patent_ids and _build_molecule traversal rules.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/paroutes.py | Core adapter converting raw PaRoutes JSON to v2 Route objects; contains the known _get_patent_ids / _build_molecule in_stock traversal divergence and a misleading error code when root SMILES is invalid in prune mode. |
| src/retrocast/v2/adapters/base.py | Defines the Adapter Protocol and RawRouteEntry dataclass; clean, minimal, and correct. |
| src/retrocast/v2/models/candidates.py | Adds FailureRecord and Candidate models with mutual-exclusivity validator; clean and well-tested. |
| src/retrocast/v2/models/task.py | Adds Target (with smiles/inchikey cross-validation), Task, TaskConstraints, and Benchmark models; correct and well-tested. |
| tests/v2/adapters/test_paroutes.py | Comprehensive contract, regression, and edge-case test suite covering cycles, mixed patents, empty reactions, prune mode, and stable route signatures against a real fixture. |
| tests/v2/adapters/base.py | Reusable adapter contract suite with dataclass-based case fixtures; clean design for future adapter implementations. |
| src/retrocast/typing.py | Corrects InChIKeyStr capitalisation, adds backward-compatible InchiKeyStr alias, and introduces ErrorCode NewType. |
| src/retrocast/v2/models/route.py | Minimal change: updates import from deprecated InchiKeyStr to InChIKeyStr. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant PaRoutesAdapter
    participant _validate_route_root
    participant _get_patent_ids
    participant _build_molecule

    Caller->>PaRoutesAdapter: iter_raw_routes(raw_payload)
    PaRoutesAdapter->>_validate_route_root: raw_dict (per target key)
    _validate_route_root-->>PaRoutesAdapter: PaRoutesMoleculeInput
    PaRoutesAdapter-->>Caller: RawRouteEntry(payload, source_key, source_order)

    Caller->>PaRoutesAdapter: cast(raw_route, target, mode)
    PaRoutesAdapter->>_validate_route_root: raw_route
    PaRoutesAdapter->>_get_patent_ids: validated root
    note over _get_patent_ids: cycle detection, patent ID via children[0]
    _get_patent_ids-->>PaRoutesAdapter: set[str] exactly 1
    PaRoutesAdapter->>_build_molecule: "validated root, visited={}"
    note over _build_molecule: cycle detection, in_stock early-exit, prune
    _build_molecule-->>PaRoutesAdapter: Molecule or None
    PaRoutesAdapter->>PaRoutesAdapter: SMILES match vs target
    PaRoutesAdapter-->>Caller: "Route(target, annotations={patent_id})"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/retrocast/v2/adapters/paroutes.py`, line 338-351 ([link](https://github.com/ischemist/project-procrustes/blob/2f0702d015d3a8dbf0580b23726b029c9fec087c/src/retrocast/v2/adapters/paroutes.py#L338-L351)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`_get_patent_ids` diverges from `_build_molecule` traversal rules**

   `_get_patent_ids` descends into every child reaction of every molecule node unconditionally, but `_build_molecule` applies two early-exit rules that are absent here:

   1. **`in_stock` molecules are treated as leaves** — `_build_molecule` returns immediately when `raw_mol_node.in_stock` is true, but `_get_patent_ids` still recurses into their children and collects patent IDs from synthesis routes that will never be included in the built route.
   2. **Only the first child reaction is used** — `_build_molecule` warns and uses only `children[0]`, but `_get_patent_ids` iterates over all reactions in the `for reaction_node in node.children` loop.

   The result is that `_get_patent_ids` can collect patent IDs from parts of the tree that `_build_molecule` will silently discard, causing a false `adapter.multiple_patents` rejection for a route that would in practice be built from a single patent's data.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/retrocast/v2/adapters/paroutes.py
   Line: 338-351

   Comment:
   **`_get_patent_ids` diverges from `_build_molecule` traversal rules**

   `_get_patent_ids` descends into every child reaction of every molecule node unconditionally, but `_build_molecule` applies two early-exit rules that are absent here:

   1. **`in_stock` molecules are treated as leaves** — `_build_molecule` returns immediately when `raw_mol_node.in_stock` is true, but `_get_patent_ids` still recurses into their children and collects patent IDs from synthesis routes that will never be included in the built route.
   2. **Only the first child reaction is used** — `_build_molecule` warns and uses only `children[0]`, but `_get_patent_ids` iterates over all reactions in the `for reaction_node in node.children` loop.

   The result is that `_get_patent_ids` can collect patent IDs from parts of the tree that `_build_molecule` will silently discard, causing a false `adapter.multiple_patents` rejection for a route that would in practice be built from a single patent's data.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/v2/adapters/paroutes.py:344-352
**Invalid root SMILES in prune mode surfaces as wrong error code**

When the root molecule's `smiles` string fails `canonicalize_smiles`, `_get_patent_ids` returns an empty set in prune mode (line 350–351). Control returns to `cast`, which immediately raises `adapter.patent_id_missing`. The caller sees a misleading "no patent id" error instead of anything pointing to an invalid target SMILES. Because `_build_molecule` is never reached, `adapter.target_pruned` is also not raised. An explicit guard at the top of `cast` — canonicalizing the root's SMILES before calling `_get_patent_ids` — would surface the real failure with an accurate error code in both modes.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address v2 adapter review findings"](https://github.com/ischemist/project-procrustes/commit/66e166e823f07aba88627d17a44f8f81db46bbb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34292281)</sub>

<!-- /greptile_comment -->