### PR TITLE
Add schema v2 ASKCOS adapter

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -1,6 +1,13 @@
 """Schema v2 adapters."""
 
+from retrocast.v2.adapters.askcos import AskcosAdapter
 from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
 
-__all__ = ["Adapter", "AdaptMode", "PaRoutesAdapter", "RawRouteEntry"]
+__all__ = [
+    "Adapter",
+    "AdaptMode",
+    "AskcosAdapter",
+    "PaRoutesAdapter",
+    "RawRouteEntry",
+]

--- a/src/retrocast/v2/adapters/askcos.py
+++ b/src/retrocast/v2/adapters/askcos.py
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 ASKCOS_ROOT_UUID = "00000000-0000-0000-0000-000000000000"
 
 
+# SECTION: Raw ASKCOS Schema
+
+
 class AskcosBaseNode(BaseModel):
     smiles: str
     id: str
@@ -87,6 +90,9 @@ class AskcosPathwayPayload:
     uuid2smiles: dict[str, str]
     node_dict: dict[str, AskcosNode]
     annotations: dict[str, Any]
+
+
+# SECTION: Adapter
 
 
 class AskcosAdapter:
@@ -273,6 +279,9 @@ class AskcosAdapter:
             template=node.model_metadata[0].get_template() if node.model_metadata else None,
             annotations={"source_id": node.id},
         )
+
+
+# SECTION: Annotations
 
 
 def _extract_run_annotations(stats: dict[str, Any]) -> dict[str, Any]:

--- a/src/retrocast/v2/adapters/askcos.py
+++ b/src/retrocast/v2/adapters/askcos.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Annotated, Any, Literal
@@ -82,7 +83,7 @@ class AskcosOutput(BaseModel):
     results: AskcosResults
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class AskcosPathwayPayload:
     pathway_edges: tuple[AskcosPathwayEdge, ...]
     uuid2smiles: MappingProxyType[str, str]
@@ -120,10 +121,10 @@ class AskcosAdapter:
         for pathway_index, pathway_edges in enumerate(uds.pathways, start=1):
             yield RawRouteEntry(
                 payload=AskcosPathwayPayload(
-                    pathway_edges=tuple(pathway_edges),
-                    uuid2smiles=MappingProxyType(uds.uuid2smiles),
-                    node_dict=MappingProxyType(uds.node_dict),
-                    annotations=MappingProxyType(annotations),
+                    pathway_edges=tuple(edge.model_copy(deep=True) for edge in pathway_edges),
+                    uuid2smiles=MappingProxyType(deepcopy(uds.uuid2smiles)),
+                    node_dict=MappingProxyType(deepcopy(uds.node_dict)),
+                    annotations=MappingProxyType(deepcopy(annotations)),
                 ),
                 source_key=source_key,
                 source_order=pathway_index,

--- a/src/retrocast/v2/adapters/askcos.py
+++ b/src/retrocast/v2/adapters/askcos.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from retrocast.adapters.errors import (
+    adapter_cycle_error,
+    adapter_missing_node_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError, UnsupportedAdapterFeatureError
+from retrocast.typing import ReactionSmilesStr, SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.models.route import Molecule, Reaction, Route
+from retrocast.v2.models.task import Target
+
+logger = logging.getLogger(__name__)
+
+ASKCOS_ROOT_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+class AskcosBaseNode(BaseModel):
+    smiles: str
+    id: str
+
+
+class AskcosChemicalNode(AskcosBaseNode):
+    type: Literal["chemical"]
+    terminal: bool
+
+
+class AskcosModelMetadata(BaseModel):
+    source: dict[str, Any] = Field(default_factory=dict)
+
+    def get_template(self) -> str | None:
+        template = self.source.get("template")
+        if not isinstance(template, dict):
+            return None
+        reaction_smarts = template.get("reaction_smarts")
+        return reaction_smarts if isinstance(reaction_smarts, str) else None
+
+
+class AskcosReactionProperties(BaseModel):
+    mapped_smiles: str | None = None
+
+
+class AskcosReactionNode(AskcosBaseNode):
+    type: Literal["reaction"]
+    reaction_properties: AskcosReactionProperties | None = None
+    model_metadata: list[AskcosModelMetadata] = Field(default_factory=list)
+
+
+AskcosNode = Annotated[AskcosChemicalNode | AskcosReactionNode, Field(discriminator="type")]
+
+
+class AskcosPathwayEdge(BaseModel):
+    source: str
+    target: str
+
+
+class AskcosUDS(BaseModel):
+    node_dict: dict[str, AskcosNode]
+    uuid2smiles: dict[str, str]
+    pathways: list[list[AskcosPathwayEdge]]
+
+
+class AskcosResults(BaseModel):
+    uds: AskcosUDS
+
+    stats: dict[str, Any] = Field(default_factory=dict)
+
+
+class AskcosOutput(BaseModel):
+    results: AskcosResults
+
+
+@dataclass(frozen=True, slots=True)
+class AskcosPathwayPayload:
+    pathway_edges: list[AskcosPathwayEdge]
+    uuid2smiles: dict[str, str]
+    node_dict: dict[str, AskcosNode]
+    annotations: dict[str, Any]
+
+
+class AskcosAdapter:
+    def __init__(self, use_full_graph: bool = False) -> None:
+        self.use_full_graph = use_full_graph
+
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        if self.use_full_graph:
+            raise UnsupportedAdapterFeatureError(
+                "ASKCOS full-graph route extraction is not implemented",
+                context={"adapter": "askcos", "feature": "full_graph"},
+            )
+
+        target_id = source_key or "<unknown>"
+        try:
+            output = AskcosOutput.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("askcos", target_id, "invalid output") from exc
+
+        annotations = _extract_run_annotations(output.results.stats)
+        uds = output.results.uds
+        for pathway_index, pathway_edges in enumerate(uds.pathways, start=1):
+            yield RawRouteEntry(
+                payload=AskcosPathwayPayload(
+                    pathway_edges=pathway_edges,
+                    uuid2smiles=uds.uuid2smiles,
+                    node_dict=uds.node_dict,
+                    annotations=annotations,
+                ),
+                source_key=source_key,
+                source_order=pathway_index,
+            )
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        if not isinstance(raw_route, AskcosPathwayPayload):
+            raise adapter_schema_error("askcos", target_id, "invalid pathway")
+
+        route_target = self._build_target_molecule(raw_route, mode=mode)
+        if route_target is None:
+            raise AdapterLogicError(
+                "ASKCOS target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "askcos", "target_id": target_id},
+            )
+
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "askcos",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=route_target.smiles,
+                )
+
+        return Route(target=route_target, annotations=raw_route.annotations)
+
+    def _build_target_molecule(self, raw_route: AskcosPathwayPayload, *, mode: AdaptMode) -> Molecule | None:
+        adj_list: dict[str, list[str]] = defaultdict(list)
+        for edge in raw_route.pathway_edges:
+            adj_list[edge.source].append(edge.target)
+
+        if ASKCOS_ROOT_UUID not in raw_route.uuid2smiles:
+            raise adapter_missing_node_error(
+                "askcos", node_id=ASKCOS_ROOT_UUID, lookup="uuid2smiles", role="root chemical"
+            )
+
+        return self._build_molecule(
+            chem_uuid=ASKCOS_ROOT_UUID,
+            adj_list=adj_list,
+            uuid2smiles=raw_route.uuid2smiles,
+            node_dict=raw_route.node_dict,
+            visited=set(),
+            mode=mode,
+        )
+
+    def _build_molecule(
+        self,
+        *,
+        chem_uuid: str,
+        adj_list: dict[str, list[str]],
+        uuid2smiles: dict[str, str],
+        node_dict: dict[str, AskcosNode],
+        visited: set[SmilesStr],
+        mode: AdaptMode,
+    ) -> Molecule | None:
+        raw_smiles = uuid2smiles.get(chem_uuid)
+        if not raw_smiles:
+            raise adapter_missing_node_error("askcos", node_id=chem_uuid, lookup="uuid2smiles", role="chemical")
+
+        node = node_dict.get(raw_smiles)
+        if not isinstance(node, AskcosChemicalNode):
+            raise adapter_missing_node_error("askcos", node_id=raw_smiles, lookup="node_dict", role="chemical")
+
+        try:
+            canon_smiles = canonicalize_smiles(node.smiles)
+        except InvalidSmilesError:
+            if mode == "prune":
+                return None
+            raise
+
+        if canon_smiles in visited:
+            raise adapter_cycle_error("askcos", canon_smiles)
+
+        if node.terminal or chem_uuid not in adj_list:
+            return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+        child_reaction_uuids = adj_list[chem_uuid]
+        if len(child_reaction_uuids) > 1:
+            logger.warning("molecule %s has multiple child reactions; only the first is used", canon_smiles)
+
+        reaction = self._build_reaction(
+            rxn_uuid=child_reaction_uuids[0],
+            adj_list=adj_list,
+            uuid2smiles=uuid2smiles,
+            node_dict=node_dict,
+            visited=visited | {canon_smiles},
+            mode=mode,
+        )
+        if reaction is None:
+            if mode == "prune":
+                return None
+            raise AdapterLogicError(
+                "ASKCOS reaction has no reactants",
+                code="adapter.reaction_empty",
+                context={"adapter": "askcos", "smiles": canon_smiles},
+            )
+
+        return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles), product_of=reaction)
+
+    def _build_reaction(
+        self,
+        *,
+        rxn_uuid: str,
+        adj_list: dict[str, list[str]],
+        uuid2smiles: dict[str, str],
+        node_dict: dict[str, AskcosNode],
+        visited: set[SmilesStr],
+        mode: AdaptMode,
+    ) -> Reaction | None:
+        raw_smiles = uuid2smiles.get(rxn_uuid)
+        if not raw_smiles:
+            raise adapter_missing_node_error("askcos", node_id=rxn_uuid, lookup="uuid2smiles", role="reaction")
+
+        node = node_dict.get(raw_smiles)
+        if not isinstance(node, AskcosReactionNode):
+            raise adapter_missing_node_error("askcos", node_id=raw_smiles, lookup="node_dict", role="reaction")
+
+        reactants: list[Molecule] = []
+        for reactant_uuid in adj_list.get(rxn_uuid, []):
+            reactant = self._build_molecule(
+                chem_uuid=reactant_uuid,
+                adj_list=adj_list,
+                uuid2smiles=uuid2smiles,
+                node_dict=node_dict,
+                visited=visited,
+                mode=mode,
+            )
+            if reactant is not None:
+                reactants.append(reactant)
+
+        if not reactants:
+            return None
+
+        mapped_reaction_smiles = None
+        if node.reaction_properties and node.reaction_properties.mapped_smiles:
+            mapped_reaction_smiles = ReactionSmilesStr(node.reaction_properties.mapped_smiles)
+
+        return Reaction(
+            reactants=reactants,
+            mapped_reaction_smiles=mapped_reaction_smiles,
+            template=node.model_metadata[0].get_template() if node.model_metadata else None,
+            annotations={"source_id": node.id},
+        )
+
+
+def _extract_run_annotations(stats: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: stats[key]
+        for key in ("total_iterations", "total_chemicals", "total_reactions", "total_templates", "total_paths")
+        if key in stats
+    }

--- a/src/retrocast/v2/adapters/askcos.py
+++ b/src/retrocast/v2/adapters/askcos.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -20,8 +20,6 @@ from retrocast.typing import ReactionSmilesStr, SmilesStr
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.v2.models.route import Molecule, Reaction, Route
 from retrocast.v2.models.task import Target
-
-logger = logging.getLogger(__name__)
 
 ASKCOS_ROOT_UUID = "00000000-0000-0000-0000-000000000000"
 
@@ -84,12 +82,12 @@ class AskcosOutput(BaseModel):
     results: AskcosResults
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class AskcosPathwayPayload:
-    pathway_edges: list[AskcosPathwayEdge]
-    uuid2smiles: dict[str, str]
-    node_dict: dict[str, AskcosNode]
-    annotations: dict[str, Any]
+    pathway_edges: tuple[AskcosPathwayEdge, ...]
+    uuid2smiles: MappingProxyType[str, str]
+    node_dict: MappingProxyType[str, AskcosNode]
+    annotations: MappingProxyType[str, Any]
 
 
 # SECTION: Adapter
@@ -122,10 +120,10 @@ class AskcosAdapter:
         for pathway_index, pathway_edges in enumerate(uds.pathways, start=1):
             yield RawRouteEntry(
                 payload=AskcosPathwayPayload(
-                    pathway_edges=pathway_edges,
-                    uuid2smiles=uds.uuid2smiles,
-                    node_dict=uds.node_dict,
-                    annotations=annotations,
+                    pathway_edges=tuple(pathway_edges),
+                    uuid2smiles=MappingProxyType(uds.uuid2smiles),
+                    node_dict=MappingProxyType(uds.node_dict),
+                    annotations=MappingProxyType(annotations),
                 ),
                 source_key=source_key,
                 source_order=pathway_index,
@@ -186,8 +184,8 @@ class AskcosAdapter:
         *,
         chem_uuid: str,
         adj_list: dict[str, list[str]],
-        uuid2smiles: dict[str, str],
-        node_dict: dict[str, AskcosNode],
+        uuid2smiles: Mapping[str, str],
+        node_dict: Mapping[str, AskcosNode],
         visited: set[SmilesStr],
         mode: AdaptMode,
     ) -> Molecule | None:
@@ -214,7 +212,15 @@ class AskcosAdapter:
 
         child_reaction_uuids = adj_list[chem_uuid]
         if len(child_reaction_uuids) > 1:
-            logger.warning("molecule %s has multiple child reactions; only the first is used", canon_smiles)
+            raise AdapterLogicError(
+                "ASKCOS pathway is not a route tree: molecule has multiple child reactions",
+                code="adapter.route_not_tree",
+                context={
+                    "adapter": "askcos",
+                    "smiles": canon_smiles,
+                    "child_reaction_count": len(child_reaction_uuids),
+                },
+            )
 
         reaction = self._build_reaction(
             rxn_uuid=child_reaction_uuids[0],
@@ -240,8 +246,8 @@ class AskcosAdapter:
         *,
         rxn_uuid: str,
         adj_list: dict[str, list[str]],
-        uuid2smiles: dict[str, str],
-        node_dict: dict[str, AskcosNode],
+        uuid2smiles: Mapping[str, str],
+        node_dict: Mapping[str, AskcosNode],
         visited: set[SmilesStr],
         mode: AdaptMode,
     ) -> Reaction | None:

--- a/tests/v2/adapters/test_askcos.py
+++ b/tests/v2/adapters/test_askcos.py
@@ -153,6 +153,8 @@ def test_askcos_cast_preserves_run_annotations(askcos_route_payload) -> None:
 
 @pytest.mark.contract
 def test_askcos_pathway_payload_uses_immutable_boundary_containers(askcos_route_payload) -> None:
+    with pytest.raises(AttributeError):
+        askcos_route_payload.annotations = {}
     with pytest.raises(TypeError):
         askcos_route_payload.uuid2smiles["new"] = "C"
     with pytest.raises(TypeError):
@@ -160,6 +162,19 @@ def test_askcos_pathway_payload_uses_immutable_boundary_containers(askcos_route_
     with pytest.raises(TypeError):
         askcos_route_payload.annotations["new"] = 1
     assert isinstance(askcos_route_payload.pathway_edges, tuple)
+
+
+@pytest.mark.contract
+def test_askcos_pathway_payload_does_not_share_raw_payload_backing(raw_askcos_output) -> None:
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_askcos_output)).payload
+    raw_askcos_output["results"]["uds"]["uuid2smiles"].pop("uuid-ethanol")
+    raw_askcos_output["results"]["uds"]["node_dict"].pop("CCO")
+    raw_askcos_output["results"]["stats"]["total_paths"] = 999
+
+    route = AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert route.annotations["total_paths"] == 2
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["CCO", "CC(=O)O"]
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_askcos.py
+++ b/tests/v2/adapters/test_askcos.py
@@ -152,6 +152,17 @@ def test_askcos_cast_preserves_run_annotations(askcos_route_payload) -> None:
 
 
 @pytest.mark.contract
+def test_askcos_pathway_payload_uses_immutable_boundary_containers(askcos_route_payload) -> None:
+    with pytest.raises(TypeError):
+        askcos_route_payload.uuid2smiles["new"] = "C"
+    with pytest.raises(TypeError):
+        askcos_route_payload.node_dict["new"] = askcos_route_payload.node_dict["CCO"]
+    with pytest.raises(TypeError):
+        askcos_route_payload.annotations["new"] = 1
+    assert isinstance(askcos_route_payload.pathway_edges, tuple)
+
+
+@pytest.mark.contract
 def test_askcos_reaction_fields_and_annotations(askcos_route_payload) -> None:
     route = AskcosAdapter().cast(askcos_route_payload, target=target_for("CCOC(C)=O"))
     reaction = route.reaction_at("rc:r:/").value
@@ -207,6 +218,26 @@ def test_askcos_rejects_cycles(raw_askcos_output) -> None:
         AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
 
     assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_askcos_rejects_multiple_child_reactions(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["node_dict"]["C>>CCOC(C)=O"] = {
+        "smiles": "C>>CCOC(C)=O",
+        "id": "rxn-2",
+        "type": "reaction",
+    }
+    raw_payload["results"]["uds"]["uuid2smiles"]["uuid-rxn-2"] = "C>>CCOC(C)=O"
+    raw_payload["results"]["uds"]["pathways"][0].append(
+        {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn-2"}
+    )
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.route_not_tree"
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_askcos.py
+++ b/tests/v2/adapters/test_askcos.py
@@ -18,6 +18,8 @@ from tests.v2.adapters.base import (
     RawExtractionContractCase,
 )
 
+# SECTION: Fixtures
+
 
 def target_for(smiles: str, target_id: str = "askcos-target") -> Target:
     canon_smiles = canonicalize_smiles(smiles)
@@ -98,6 +100,9 @@ def askcos_invalid_leaf_payload():
     return next(AskcosAdapter().iter_raw_routes(invalid_leaf_output())).payload
 
 
+# SECTION: Shared Contract Suite
+
+
 class TestAskcosAdapterContract(AdapterContractSuite):
     @pytest.fixture
     def adapter_contract_case(
@@ -128,6 +133,9 @@ class TestAskcosAdapterContract(AdapterContractSuite):
                 expected_pruned_root_reactants=["CCO"],
             ),
         )
+
+
+# SECTION: Contract Tests
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_askcos.py
+++ b/tests/v2/adapters/test_askcos.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, UnsupportedAdapterFeatureError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.askcos import AskcosAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+
+def target_for(smiles: str, target_id: str = "askcos-target") -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+def askcos_output(pathways: list[list[dict[str, str]]] | None = None) -> dict[str, Any]:
+    pathway = [
+        {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"},
+        {"source": "uuid-rxn", "target": "uuid-ethanol"},
+        {"source": "uuid-rxn", "target": "uuid-acid"},
+    ]
+    return {
+        "results": {
+            "stats": {
+                "total_iterations": 10,
+                "total_chemicals": 3,
+                "total_reactions": 1,
+                "total_templates": 1,
+                "total_paths": 2,
+            },
+            "uds": {
+                "node_dict": {
+                    "CCOC(C)=O": {"smiles": "CCOC(C)=O", "id": "chem-root", "type": "chemical", "terminal": False},
+                    "CCO": {"smiles": "CCO", "id": "chem-ethanol", "type": "chemical", "terminal": True},
+                    "CC(=O)O": {"smiles": "CC(=O)O", "id": "chem-acid", "type": "chemical", "terminal": True},
+                    "CC(=O)O.CCO>>CCOC(C)=O": {
+                        "smiles": "CC(=O)O.CCO>>CCOC(C)=O",
+                        "id": "rxn-1",
+                        "type": "reaction",
+                        "reaction_properties": {"mapped_smiles": "CC(=O)O.CCO>>CCOC(C)=O"},
+                        "model_metadata": [{"source": {"template": {"reaction_smarts": "esterification"}}}],
+                    },
+                },
+                "uuid2smiles": {
+                    "00000000-0000-0000-0000-000000000000": "CCOC(C)=O",
+                    "uuid-rxn": "CC(=O)O.CCO>>CCOC(C)=O",
+                    "uuid-ethanol": "CCO",
+                    "uuid-acid": "CC(=O)O",
+                },
+                "pathways": pathways if pathways is not None else [pathway, pathway],
+            },
+        }
+    }
+
+
+def invalid_leaf_output() -> dict[str, Any]:
+    raw_payload = askcos_output(pathways=None)
+    raw_payload["results"]["uds"]["node_dict"]["not-smiles"] = {
+        "smiles": "not-smiles",
+        "id": "bad-leaf",
+        "type": "chemical",
+        "terminal": True,
+    }
+    raw_payload["results"]["uds"]["uuid2smiles"]["uuid-bad"] = "not-smiles"
+    raw_payload["results"]["uds"]["pathways"] = [
+        [
+            {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"},
+            {"source": "uuid-rxn", "target": "uuid-ethanol"},
+            {"source": "uuid-rxn", "target": "uuid-bad"},
+        ]
+    ]
+    return raw_payload
+
+
+@pytest.fixture
+def raw_askcos_output() -> dict[str, Any]:
+    return askcos_output()
+
+
+@pytest.fixture
+def askcos_route_payload(raw_askcos_output):
+    return next(AskcosAdapter().iter_raw_routes(raw_askcos_output)).payload
+
+
+@pytest.fixture
+def askcos_invalid_leaf_payload():
+    return next(AskcosAdapter().iter_raw_routes(invalid_leaf_output())).payload
+
+
+class TestAskcosAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self,
+        raw_askcos_output,
+        askcos_route_payload,
+        askcos_invalid_leaf_payload,
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=AskcosAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_askcos_output,
+                malformed_payload={"results": {}},
+                source_key="askcos-run-1",
+                expected_entry_count=2,
+                expected_source_keys=["askcos-run-1", "askcos-run-1"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=askcos_route_payload,
+                malformed_raw_route={"not": "a pathway payload"},
+                target=target_for("CCOC(C)=O"),
+                mismatched_target=Target(id="askcos-target", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO")),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=askcos_invalid_leaf_payload,
+                expected_pruned_root_reactants=["CCO"],
+            ),
+        )
+
+
+@pytest.mark.contract
+def test_askcos_cast_preserves_run_annotations(askcos_route_payload) -> None:
+    route = AskcosAdapter().cast(askcos_route_payload, target=target_for("CCOC(C)=O"))
+
+    assert route.annotations == {
+        "total_iterations": 10,
+        "total_chemicals": 3,
+        "total_reactions": 1,
+        "total_templates": 1,
+        "total_paths": 2,
+    }
+
+
+@pytest.mark.contract
+def test_askcos_reaction_fields_and_annotations(askcos_route_payload) -> None:
+    route = AskcosAdapter().cast(askcos_route_payload, target=target_for("CCOC(C)=O"))
+    reaction = route.reaction_at("rc:r:/").value
+
+    assert reaction.mapped_reaction_smiles == "CC(=O)O.CCO>>CCOC(C)=O"
+    assert reaction.template == "esterification"
+    assert reaction.annotations == {"source_id": "rxn-1"}
+
+
+@pytest.mark.contract
+def test_askcos_use_full_graph_raises_typed_unsupported_feature(raw_askcos_output) -> None:
+    with pytest.raises(UnsupportedAdapterFeatureError) as exc_info:
+        list(AskcosAdapter(use_full_graph=True).iter_raw_routes(raw_askcos_output))
+
+    assert exc_info.value.code == "adapter.unsupported_feature"
+    assert exc_info.value.context == {"adapter": "askcos", "feature": "full_graph"}
+
+
+@pytest.mark.contract
+def test_askcos_rejects_missing_root_uuid(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["uuid2smiles"].pop("00000000-0000-0000-0000-000000000000")
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.node_missing"
+
+
+@pytest.mark.contract
+def test_askcos_rejects_missing_reaction_uuid(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["pathways"][0][0]["target"] = "missing-rxn"
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.node_missing"
+
+
+@pytest.mark.contract
+def test_askcos_rejects_cycles(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["pathways"][0] = [
+        {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"},
+        {"source": "uuid-rxn", "target": "00000000-0000-0000-0000-000000000000"},
+    ]
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_askcos_allows_duplicate_leaf_molecules(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["uuid2smiles"]["uuid-ethanol-2"] = "CCO"
+    raw_payload["results"]["uds"]["pathways"][0] = [
+        {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"},
+        {"source": "uuid-rxn", "target": "uuid-ethanol"},
+        {"source": "uuid-rxn", "target": "uuid-ethanol-2"},
+    ]
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    route = AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["CCO", "CCO"]
+
+
+@pytest.mark.contract
+def test_askcos_rejects_empty_reaction_in_strict_mode(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["pathways"][0] = [
+        {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"}
+    ]
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
+def test_askcos_iter_raw_routes_rejects_non_mapping_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(AskcosAdapter().iter_raw_routes(["not", "a", "payload"], source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"


### PR DESCRIPTION
## Why

ASKCOS still only had the legacy adapter shape, so schema-v2 adaptation could not cast ASKCOS raw pathways directly into the v2 `Route` model.

This adds the v2 trust boundary beside the migrated PaRoutes adapter without changing legacy behavior.

## What Changed

- Added `retrocast.v2.adapters.askcos.AskcosAdapter`.
- Added local Pydantic models for the raw ASKCOS `results.uds` payload.
- Implemented `iter_raw_routes(...)` over ASKCOS pathways with `source_order` preservation.
- Implemented direct v2 `Route -> Molecule.product_of -> Reaction` construction.
- Preserved ASKCOS run stats on `Route.annotations`.
- Preserved reaction `source_id`, mapped reaction SMILES, and template data on the v2 reaction.
- Kept full-graph extraction explicitly unsupported instead of guessing.
- Exported `AskcosAdapter` from `retrocast.v2.adapters`.

## Risk

The main data-shape risk is ASKCOS graph traversal from the fixed root UUID through pathway edges.

The tests cover:

- valid raw pathway extraction
- malformed schema rejection
- target mismatch
- missing root/reaction graph nodes
- strict invalid SMILES
- prune-mode invalid branch dropping
- cycle detection
- duplicate leaf molecules
- empty reactions
- unsupported full-graph mode

No reads, writes, external calls, cache invalidation, or legacy adapter behavior changes are introduced.

## Verification

- `uv run pytest tests/v2/adapters/test_askcos.py -v`
- `uv run ruff check src/retrocast/v2/adapters/askcos.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_askcos.py`
- commit hooks: `ruff`, `ruff-format`, `ty`

## Follow-Ups

Migrate the remaining legacy adapters in separate PRs by raw-shape family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ASKCOS data format is now supported for conversion and route analysis.
  * Integrated validation ensures proper molecular graph structure and reaction pathway integrity.

* **Tests**
  * Comprehensive test suite added for ASKCOS adapter functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `AskcosAdapter`, a schema-v2 adapter that converts raw ASKCOS retrosynthesis results (`results.uds`) into the v2 `Route` model, sitting alongside the existing `PaRoutesAdapter` without touching legacy behavior.

- Local Pydantic models parse the ASKCOS payload (chemical/reaction nodes, pathway edges, UUID-to-SMILES map) and the adapter walks each pathway edge-list as a depth-first tree to build `Molecule → product_of → Reaction` chains, detecting cycles and enforcing strict/prune modes.
- Previous review concerns (mutable fields on a `frozen` dataclass, aliased shared dicts across payloads, silent truncation of multiple child reactions) have all been addressed: fields now use `MappingProxyType` / `tuple`, each payload gets a `deepcopy`, and multiple child reactions are now a hard error.
- The test suite covers 11 contract cases including malformed schema, target mismatch, missing graph nodes, cycles, empty reactions, prune-mode pruning, and duplicate leaf molecules.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the adapter is read-only, adds no external I/O, and leaves all existing adapters untouched.

The three issues flagged in previous review rounds (frozen dataclass with unhashable mutable fields, aliased shared dicts across payloads, and silent multi-child-reaction truncation) are all addressed. The new implementation correctly isolates each pathway payload via deep copies and MappingProxyType boundaries, raises a typed error for non-tree pathways, and the test suite covers the full contract including edge cases like cycles, prune-mode propagation, and duplicate leaf molecules.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/askcos.py | New ASKCOS v2 adapter; correctly uses MappingProxyType + deepcopy for isolation and raises on multiple child reactions. Minor: template selection silently ignores all but the first model_metadata entry with no log warning. |
| src/retrocast/v2/adapters/__init__.py | Exports AskcosAdapter alongside existing adapters; __all__ is alphabetically ordered. No issues. |
| tests/v2/adapters/test_askcos.py | Comprehensive contract test suite covering valid paths, schema rejection, cycle detection, prune mode, duplicate leaves, empty reactions, and immutability boundaries. No issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AskcosAdapter
    participant AskcosPathwayPayload
    participant Route

    Caller->>AskcosAdapter: iter_raw_routes(raw_payload, source_key)
    AskcosAdapter->>AskcosAdapter: AskcosOutput.model_validate(raw_payload)
    AskcosAdapter->>AskcosAdapter: _extract_run_annotations(stats)
    loop for each pathway in uds.pathways
        AskcosAdapter->>AskcosPathwayPayload: deepcopy edges, uuid2smiles, node_dict, annotations
        AskcosAdapter-->>Caller: "yield RawRouteEntry(payload, source_order=N)"
    end

    Caller->>AskcosAdapter: cast(raw_route, mode, target)
    AskcosAdapter->>AskcosAdapter: _build_target_molecule(raw_route)
    AskcosAdapter->>AskcosAdapter: build adj_list from pathway_edges
    AskcosAdapter->>AskcosAdapter: "_build_molecule(ASKCOS_ROOT_UUID, visited={})"
    loop recursive DFS over graph
        AskcosAdapter->>AskcosAdapter: uuid2smiles lookup → raw_smiles
        AskcosAdapter->>AskcosAdapter: node_dict lookup → AskcosChemicalNode
        AskcosAdapter->>AskcosAdapter: canonicalize_smiles, cycle check
        alt terminal or no children
            AskcosAdapter-->>AskcosAdapter: return Molecule (leaf)
        else has one child reaction
            AskcosAdapter->>AskcosAdapter: _build_reaction(rxn_uuid)
            AskcosAdapter-->>AskcosAdapter: "return Molecule(product_of=Reaction)"
        else multiple child reactions
            AskcosAdapter-->>Caller: raise AdapterLogicError(adapter.route_not_tree)
        end
    end
    AskcosAdapter->>Route: "Route(target=root_molecule, annotations=run_stats)"
    AskcosAdapter-->>Caller: Route
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/v2/adapters/askcos.py:283-288
When `model_metadata` has more than one entry, every entry beyond the first is silently discarded. ASKCOS can return multiple model metadata entries per reaction (one per retrosynthesis model that proposed it), so this silently drops all but the primary template. Unlike the PaRoutes adapter — which only ever has one metadata block — the ASKCOS `model_metadata` field is a list by schema, making silent truncation more likely in practice. Adding a module-level logger and emitting a warning here would make the data loss visible without changing behavior.

```suggestion
        if len(node.model_metadata) > 1:
            logger.warning(
                "reaction %s has %d model_metadata entries; only the first template is used",
                node.id,
                len(node.model_metadata),
            )
        return Reaction(
            reactants=reactants,
            mapped_reaction_smiles=mapped_reaction_smiles,
            template=node.model_metadata[0].get_template() if node.model_metadata else None,
            annotations={"source_id": node.id},
        )
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Make ASKCOS pathway payload immutable"](https://github.com/ischemist/project-procrustes/commit/84b0c48474f46b589d0a3bcaae1e12c3b6d71258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34296540)</sub>

<!-- /greptile_comment -->