### PR TITLE
Add schema v2 route-string adapters

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -2,12 +2,16 @@
 
 from retrocast.v2.adapters.askcos import AskcosAdapter
 from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
+from retrocast.v2.adapters.retrostar import RetroStarAdapter
 
 __all__ = [
     "Adapter",
     "AdaptMode",
     "AskcosAdapter",
+    "DreamRetroErAdapter",
     "PaRoutesAdapter",
     "RawRouteEntry",
+    "RetroStarAdapter",
 ]

--- a/src/retrocast/v2/adapters/common.py
+++ b/src/retrocast/v2/adapters/common.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from retrocast.adapters.errors import adapter_cycle_error
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.base import AdaptMode
+from retrocast.v2.models.route import Molecule, Reaction
+
+ReactionAnnotations = Mapping[SmilesStr, Mapping[str, Any]]
+
+
+# SECTION: Precursor Map Traversal
+
+
+def build_molecule_from_precursor_map(
+    smiles: str,
+    precursor_map: Mapping[SmilesStr, Sequence[str]],
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    visited: set[SmilesStr] | None = None,
+    reaction_annotations: ReactionAnnotations | None = None,
+) -> Molecule | None:
+    if visited is None:
+        visited = set()
+
+    try:
+        canon_smiles = canonicalize_smiles(smiles)
+    except InvalidSmilesError:
+        if mode == "prune":
+            return None
+        raise
+
+    if canon_smiles in visited:
+        raise adapter_cycle_error(adapter, canon_smiles)
+
+    reactant_smiles = precursor_map.get(canon_smiles)
+    if reactant_smiles is None:
+        return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+    reactants: list[Molecule] = []
+    for reactant in reactant_smiles:
+        reactant_molecule = build_molecule_from_precursor_map(
+            reactant,
+            precursor_map,
+            adapter=adapter,
+            mode=mode,
+            visited=visited | {canon_smiles},
+            reaction_annotations=reaction_annotations,
+        )
+        if reactant_molecule is not None:
+            reactants.append(reactant_molecule)
+
+    if not reactants:
+        if mode == "prune":
+            return None
+        raise AdapterLogicError(
+            f"{adapter} reaction has no reactants",
+            code="adapter.reaction_empty",
+            context={"adapter": adapter, "smiles": canon_smiles},
+        )
+
+    annotations = dict(reaction_annotations.get(canon_smiles, {})) if reaction_annotations is not None else {}
+    return Molecule(
+        smiles=canon_smiles,
+        inchikey=get_inchi_key(canon_smiles),
+        product_of=Reaction(reactants=reactants, annotations=annotations),
+    )

--- a/src/retrocast/v2/adapters/dreamretro.py
+++ b/src/retrocast/v2/adapters/dreamretro.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass
-from types import MappingProxyType
 from typing import Any
 
 from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.common import build_molecule_from_precursor_map
@@ -18,10 +17,13 @@ from retrocast.v2.models.task import Target
 # SECTION: Raw DreamRetro Schema
 
 
-@dataclass(frozen=True, slots=True, eq=False)
+@dataclass(frozen=True, slots=True)
 class DreamRetroRoutePayload:
     route_str: str
-    annotations: MappingProxyType[str, Any]
+    annotations: tuple[tuple[str, Any], ...]
+
+    def route_annotations(self) -> dict[str, Any]:
+        return dict(self.annotations)
 
 
 @dataclass(slots=True)
@@ -58,7 +60,7 @@ class DreamRetroErAdapter:
         yield RawRouteEntry(
             payload=DreamRetroRoutePayload(
                 route_str=route_str,
-                annotations=MappingProxyType(deepcopy(annotations)),
+                annotations=tuple((key, deepcopy(value)) for key, value in annotations.items()),
             ),
             source_key=source_key,
             source_order=1,
@@ -75,7 +77,7 @@ class DreamRetroErAdapter:
         if not isinstance(raw_route, DreamRetroRoutePayload):
             raise adapter_schema_error("dreamretro", target_id, "expected a dreamretro route payload")
 
-        parsed_route = self._parse_route_string(raw_route.route_str)
+        parsed_route = self._parse_route_string(raw_route.route_str, mode=mode)
         if target is not None:
             expected_smiles = canonicalize_smiles(target.smiles)
             if parsed_route.target_smiles != expected_smiles:
@@ -98,9 +100,9 @@ class DreamRetroErAdapter:
                 code="adapter.target_pruned",
                 context={"adapter": "dreamretro", "target_id": target_id},
             )
-        return Route(target=route_target, annotations=raw_route.annotations)
+        return Route(target=route_target, annotations=raw_route.route_annotations())
 
-    def _parse_route_string(self, route_str: str) -> DreamRetroParsedRoute:
+    def _parse_route_string(self, route_str: str, *, mode: AdaptMode = "strict") -> DreamRetroParsedRoute:
         steps = route_str.split("|")
         if not steps or not steps[0]:
             raise adapter_route_string_error("dreamretro", "empty route string", empty=True)
@@ -111,19 +113,27 @@ class DreamRetroErAdapter:
         precursor_map: dict[SmilesStr, list[str]] = {}
         current_step = ""
         try:
-            target_smiles = canonicalize_smiles(steps[0].split(">")[0])
+            first_product_smiles = steps[0].split(">")[0]
+            target_smiles = canonicalize_smiles(first_product_smiles)
             for step in steps:
                 current_step = step
                 parts = step.split(">")
                 if len(parts) != 3:
                     raise ValueError("invalid step format")
                 product_smiles, _, reactants_smiles = parts
-                canon_product = canonicalize_smiles(product_smiles)
+                try:
+                    canon_product = canonicalize_smiles(product_smiles)
+                except InvalidSmilesError:
+                    if mode == "prune" and product_smiles != first_product_smiles:
+                        continue
+                    raise
                 precursor_map[canon_product] = [
                     reactant.strip() for reactant in reactants_smiles.split(".") if reactant.strip()
                 ]
             return DreamRetroParsedRoute(target_smiles=target_smiles, precursor_map=precursor_map)
         except (ValueError, IndexError) as exc:
+            if isinstance(exc, InvalidSmilesError):
+                raise
             raise adapter_route_string_error(
                 "dreamretro",
                 "expected each reaction step to split into product, reagents, and reactants",

--- a/src/retrocast/v2/adapters/dreamretro.py
+++ b/src/retrocast/v2/adapters/dreamretro.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from copy import deepcopy
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw DreamRetro Schema
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class DreamRetroRoutePayload:
+    route_str: str
+    annotations: MappingProxyType[str, Any]
+
+
+@dataclass(slots=True)
+class DreamRetroParsedRoute:
+    target_smiles: SmilesStr
+    precursor_map: dict[SmilesStr, list[str]]
+
+
+# SECTION: Adapter
+
+
+class DreamRetroErAdapter:
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        if not isinstance(raw_payload, dict):
+            raise adapter_schema_error("dreamretro", target_id, "expected a dict")
+        if not raw_payload.get("succ"):
+            return
+
+        route_str = raw_payload.get("routes")
+        if not isinstance(route_str, str) or not route_str:
+            raise adapter_schema_error("dreamretro", target_id, "no valid 'routes' string found")
+
+        annotations = {
+            key: raw_payload[key]
+            for key in ("expand_model_call", "value_model_call", "reaction_nodes_lens", "mol_nodes_lens")
+            if key in raw_payload
+        }
+        yield RawRouteEntry(
+            payload=DreamRetroRoutePayload(
+                route_str=route_str,
+                annotations=MappingProxyType(deepcopy(annotations)),
+            ),
+            source_key=source_key,
+            source_order=1,
+        )
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        if not isinstance(raw_route, DreamRetroRoutePayload):
+            raise adapter_schema_error("dreamretro", target_id, "expected a dreamretro route payload")
+
+        parsed_route = self._parse_route_string(raw_route.route_str)
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if parsed_route.target_smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "dreamretro",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=parsed_route.target_smiles,
+                )
+
+        route_target = build_molecule_from_precursor_map(
+            parsed_route.target_smiles,
+            parsed_route.precursor_map,
+            adapter="dreamretro",
+            mode=mode,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "DreamRetro target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "dreamretro", "target_id": target_id},
+            )
+        return Route(target=route_target, annotations=raw_route.annotations)
+
+    def _parse_route_string(self, route_str: str) -> DreamRetroParsedRoute:
+        steps = route_str.split("|")
+        if not steps or not steps[0]:
+            raise adapter_route_string_error("dreamretro", "empty route string", empty=True)
+
+        if len(steps) == 1 and ">" not in steps[0]:
+            return DreamRetroParsedRoute(target_smiles=canonicalize_smiles(steps[0]), precursor_map={})
+
+        precursor_map: dict[SmilesStr, list[str]] = {}
+        current_step = ""
+        try:
+            target_smiles = canonicalize_smiles(steps[0].split(">")[0])
+            for step in steps:
+                current_step = step
+                parts = step.split(">")
+                if len(parts) != 3:
+                    raise ValueError("invalid step format")
+                product_smiles, _, reactants_smiles = parts
+                canon_product = canonicalize_smiles(product_smiles)
+                precursor_map[canon_product] = [
+                    reactant.strip() for reactant in reactants_smiles.split(".") if reactant.strip()
+                ]
+            return DreamRetroParsedRoute(target_smiles=target_smiles, precursor_map=precursor_map)
+        except (ValueError, IndexError) as exc:
+            raise adapter_route_string_error(
+                "dreamretro",
+                "expected each reaction step to split into product, reagents, and reactants",
+                fragment=current_step[:70],
+            ) from exc

--- a/src/retrocast/v2/adapters/retrostar.py
+++ b/src/retrocast/v2/adapters/retrostar.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import suppress
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any
+
+from retrocast.adapters.errors import (
+    adapter_route_string_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw RetroStar Schema
+
+
+@dataclass(frozen=True, slots=True)
+class RetroStarRoutePayload:
+    route_str: str
+    route_cost: float | None
+
+
+@dataclass(slots=True)
+class RetroStarParsedRoute:
+    target_smiles: SmilesStr
+    precursor_map: dict[SmilesStr, list[str]]
+    step_scores: dict[SmilesStr, float]
+
+
+# SECTION: Adapter
+
+
+class RetroStarAdapter:
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        if not isinstance(raw_payload, dict):
+            raise adapter_schema_error("retrostar", target_id, "expected a dict")
+
+        if not raw_payload.get("succ"):
+            return
+
+        route_str = raw_payload.get("routes")
+        if not isinstance(route_str, str) or not route_str:
+            raise adapter_schema_error("retrostar", target_id, "no valid 'routes' string found")
+
+        route_cost = raw_payload.get("route_cost")
+        if isinstance(route_cost, bool) or not isinstance(route_cost, Real):
+            route_cost = None
+        yield RawRouteEntry(
+            payload=RetroStarRoutePayload(
+                route_str=route_str,
+                route_cost=float(route_cost) if route_cost is not None else None,
+            ),
+            source_key=source_key,
+            source_order=1,
+        )
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        if not isinstance(raw_route, RetroStarRoutePayload):
+            raise adapter_schema_error("retrostar", target_id, "expected a retrostar route payload")
+
+        parsed_route = self._parse_route_string(raw_route.route_str)
+
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if parsed_route.target_smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "retrostar",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=parsed_route.target_smiles,
+                )
+
+        route_target = build_molecule_from_precursor_map(
+            parsed_route.target_smiles,
+            parsed_route.precursor_map,
+            adapter="retrostar",
+            mode=mode,
+            reaction_annotations={
+                product_smiles: {"step_score": step_score}
+                for product_smiles, step_score in parsed_route.step_scores.items()
+            },
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "RetroStar target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "retrostar", "target_id": target_id},
+            )
+
+        annotations: dict[str, Any] = {}
+        if raw_route.route_cost is not None:
+            annotations["route_cost"] = raw_route.route_cost
+        return Route(target=route_target, annotations=annotations)
+
+    def _parse_route_string(self, route_str: str) -> RetroStarParsedRoute:
+        steps = route_str.split("|")
+        if not steps or not steps[0]:
+            raise adapter_route_string_error("retrostar", "empty route string", empty=True)
+
+        if len(steps) == 1 and ">" not in steps[0]:
+            return RetroStarParsedRoute(target_smiles=canonicalize_smiles(steps[0]), precursor_map={}, step_scores={})
+
+        precursor_map: dict[SmilesStr, list[str]] = {}
+        step_scores: dict[SmilesStr, float] = {}
+        current_step = ""
+        try:
+            first_product_smiles = steps[0].split(">")[0]
+            target_smiles = canonicalize_smiles(first_product_smiles)
+
+            for step in steps:
+                current_step = step
+                parts = step.split(">")
+                if len(parts) != 3:
+                    raise ValueError("invalid step format")
+                product_smiles, score_text, reactants_smiles = parts
+                canon_product = canonicalize_smiles(product_smiles)
+                reactants = [reactant.strip() for reactant in reactants_smiles.split(".") if reactant.strip()]
+                precursor_map[canon_product] = reactants
+                with suppress(ValueError):
+                    step_scores[canon_product] = float(score_text)
+
+            return RetroStarParsedRoute(
+                target_smiles=target_smiles,
+                precursor_map=precursor_map,
+                step_scores=step_scores,
+            )
+        except (ValueError, IndexError) as exc:
+            raise adapter_route_string_error(
+                "retrostar",
+                "expected each reaction step to split into product, reagents, and reactants",
+                fragment=current_step[:70],
+            ) from exc

--- a/src/retrocast/v2/adapters/retrostar.py
+++ b/src/retrocast/v2/adapters/retrostar.py
@@ -12,7 +12,7 @@ from retrocast.adapters.errors import (
     adapter_target_mismatch,
 )
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.common import build_molecule_from_precursor_map
@@ -79,7 +79,7 @@ class RetroStarAdapter:
         if not isinstance(raw_route, RetroStarRoutePayload):
             raise adapter_schema_error("retrostar", target_id, "expected a retrostar route payload")
 
-        parsed_route = self._parse_route_string(raw_route.route_str)
+        parsed_route = self._parse_route_string(raw_route.route_str, mode=mode)
 
         if target is not None:
             expected_smiles = canonicalize_smiles(target.smiles)
@@ -113,7 +113,7 @@ class RetroStarAdapter:
             annotations["route_cost"] = raw_route.route_cost
         return Route(target=route_target, annotations=annotations)
 
-    def _parse_route_string(self, route_str: str) -> RetroStarParsedRoute:
+    def _parse_route_string(self, route_str: str, *, mode: AdaptMode = "strict") -> RetroStarParsedRoute:
         steps = route_str.split("|")
         if not steps or not steps[0]:
             raise adapter_route_string_error("retrostar", "empty route string", empty=True)
@@ -134,7 +134,12 @@ class RetroStarAdapter:
                 if len(parts) != 3:
                     raise ValueError("invalid step format")
                 product_smiles, score_text, reactants_smiles = parts
-                canon_product = canonicalize_smiles(product_smiles)
+                try:
+                    canon_product = canonicalize_smiles(product_smiles)
+                except InvalidSmilesError:
+                    if mode == "prune" and product_smiles != first_product_smiles:
+                        continue
+                    raise
                 reactants = [reactant.strip() for reactant in reactants_smiles.split(".") if reactant.strip()]
                 precursor_map[canon_product] = reactants
                 with suppress(ValueError):
@@ -146,6 +151,8 @@ class RetroStarAdapter:
                 step_scores=step_scores,
             )
         except (ValueError, IndexError) as exc:
+            if isinstance(exc, InvalidSmilesError):
+                raise
             raise adapter_route_string_error(
                 "retrostar",
                 "expected each reaction step to split into product, reagents, and reactants",

--- a/tests/v2/adapters/test_dreamretro.py
+++ b/tests/v2/adapters/test_dreamretro.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
 from retrocast.v2.models.task import Target
@@ -103,12 +103,22 @@ def test_dreamretro_payload_annotations_are_immutable_and_private(raw_dreamretro
     raw_route = next(DreamRetroErAdapter().iter_raw_routes(raw_dreamretro_payload)).payload
     raw_dreamretro_payload["expand_model_call"] = 999
 
-    with pytest.raises(TypeError):
-        raw_route.annotations["new"] = 1
+    with pytest.raises(AttributeError):
+        raw_route.annotations = ()
 
     route = DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
 
     assert route.annotations["expand_model_call"] == 4
+
+
+@pytest.mark.contract
+def test_dreamretro_payloads_use_value_equality() -> None:
+    payloads = [
+        next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO", "expand_model_call": 4})).payload,
+        next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO", "expand_model_call": 4})).payload,
+    ]
+
+    assert payloads[0] == payloads[1]
 
 
 @pytest.mark.contract
@@ -144,6 +154,29 @@ def test_dreamretro_rejects_malformed_route_step() -> None:
 
 
 @pytest.mark.contract
+def test_dreamretro_strict_rejects_invalid_intermediate_product_smiles() -> None:
+    raw_route = next(
+        DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.not-smiles|not-smiles>0.8>C"})
+    ).payload
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"), mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_dreamretro_prune_skips_invalid_intermediate_product_smiles() -> None:
+    raw_route = next(
+        DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.not-smiles|not-smiles>0.8>C"})
+    ).payload
+
+    route = DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]
+
+
+@pytest.mark.contract
 def test_dreamretro_rejects_cycles_after_smiles_canonicalization() -> None:
     raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C|C>0.8>OCC"})).payload
 
@@ -170,6 +203,16 @@ def test_dreamretro_prune_rejects_route_when_all_reactants_are_invalid() -> None
         DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
 
     assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_dreamretro_rejects_empty_reaction_in_strict_mode() -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_dreamretro.py
+++ b/tests/v2/adapters/test_dreamretro.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str, target_id: str = "dreamretro-target") -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_dreamretro_payload() -> dict:
+    return {
+        "succ": True,
+        "routes": "CCO>0.9>CC=O.[H][H]",
+        "expand_model_call": 4,
+        "value_model_call": 2,
+        "reaction_nodes_lens": [1],
+        "mol_nodes_lens": [3],
+    }
+
+
+@pytest.fixture
+def dreamretro_route_payload(raw_dreamretro_payload):
+    return next(DreamRetroErAdapter().iter_raw_routes(raw_dreamretro_payload, source_key="dreamretro-run-1")).payload
+
+
+@pytest.fixture
+def dreamretro_invalid_leaf_payload():
+    raw_payload = {"succ": True, "routes": "CCO>0.9>C.not-smiles"}
+    return next(DreamRetroErAdapter().iter_raw_routes(raw_payload)).payload
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestDreamRetroAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self,
+        raw_dreamretro_payload,
+        dreamretro_route_payload,
+        dreamretro_invalid_leaf_payload,
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=DreamRetroErAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_dreamretro_payload,
+                malformed_payload={"succ": True, "routes": 123},
+                source_key="dreamretro-run-1",
+                expected_entry_count=1,
+                expected_source_keys=["dreamretro-run-1"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=dreamretro_route_payload,
+                malformed_raw_route={"not": "a route payload"},
+                target=target_for("CCO"),
+                mismatched_target=Target(
+                    id="dreamretro-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")
+                ),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=dreamretro_invalid_leaf_payload,
+                expected_pruned_root_reactants=["C"],
+            ),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_dreamretro_preserves_run_annotations(dreamretro_route_payload) -> None:
+    route = DreamRetroErAdapter().cast(dreamretro_route_payload, target=target_for("CCO"))
+
+    assert route.annotations == {
+        "expand_model_call": 4,
+        "value_model_call": 2,
+        "reaction_nodes_lens": [1],
+        "mol_nodes_lens": [3],
+    }
+
+
+@pytest.mark.contract
+def test_dreamretro_payload_annotations_are_immutable_and_private(raw_dreamretro_payload) -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes(raw_dreamretro_payload)).payload
+    raw_dreamretro_payload["expand_model_call"] = 999
+
+    with pytest.raises(TypeError):
+        raw_route.annotations["new"] = 1
+
+    route = DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert route.annotations["expand_model_call"] == 4
+
+
+@pytest.mark.contract
+def test_dreamretro_iter_raw_routes_skips_unsuccessful_runs() -> None:
+    entries = list(DreamRetroErAdapter().iter_raw_routes({"succ": False, "routes": "CCO>0.9>C"}))
+
+    assert entries == []
+
+
+@pytest.mark.contract
+def test_dreamretro_accepts_purchasable_target_route() -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO"})).payload
+
+    route = DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert route.target.product_of is None
+
+
+@pytest.mark.contract
+def test_dreamretro_rejects_empty_route_string() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DreamRetroErAdapter()._parse_route_string("")
+
+    assert exc_info.value.code == "adapter.route_string_empty"
+
+
+@pytest.mark.contract
+def test_dreamretro_rejects_malformed_route_step() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DreamRetroErAdapter()._parse_route_string("CCO>CC=O")
+
+    assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_dreamretro_rejects_cycles_after_smiles_canonicalization() -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C|C>0.8>OCC"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_dreamretro_allows_duplicate_leaf_molecules() -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.C"})).payload
+
+    route = DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_dreamretro_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = next(DreamRetroErAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>not-smiles"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DreamRetroErAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_dreamretro_iter_raw_routes_rejects_non_mapping_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(DreamRetroErAdapter().iter_raw_routes(["not", "a", "payload"], source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"

--- a/tests/v2/adapters/test_retrostar.py
+++ b/tests/v2/adapters/test_retrostar.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.retrostar import RetroStarAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str, target_id: str = "retrostar-target") -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_retrostar_payload() -> dict:
+    return {"succ": True, "routes": "CCO>0.9>CC=O.[H][H]", "route_cost": 1.25}
+
+
+@pytest.fixture
+def retrostar_route_payload(raw_retrostar_payload):
+    return next(RetroStarAdapter().iter_raw_routes(raw_retrostar_payload, source_key="retrostar-run-1")).payload
+
+
+@pytest.fixture
+def retrostar_invalid_leaf_payload():
+    raw_payload = {"succ": True, "routes": "CCO>0.9>C.not-smiles", "route_cost": 2.0}
+    return next(RetroStarAdapter().iter_raw_routes(raw_payload)).payload
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestRetroStarAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self,
+        raw_retrostar_payload,
+        retrostar_route_payload,
+        retrostar_invalid_leaf_payload,
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=RetroStarAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_retrostar_payload,
+                malformed_payload={"succ": True, "routes": 123},
+                source_key="retrostar-run-1",
+                expected_entry_count=1,
+                expected_source_keys=["retrostar-run-1"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=retrostar_route_payload,
+                malformed_raw_route={"not": "a route payload"},
+                target=target_for("CCO"),
+                mismatched_target=Target(id="retrostar-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=retrostar_invalid_leaf_payload,
+                expected_pruned_root_reactants=["C"],
+            ),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_retrostar_cast_preserves_route_cost_and_step_score(retrostar_route_payload) -> None:
+    route = RetroStarAdapter().cast(retrostar_route_payload, target=target_for("CCO"))
+
+    assert route.annotations["route_cost"] == 1.25
+    assert route.reaction_at("rc:r:/").value.annotations == {"step_score": 0.9}
+
+
+@pytest.mark.contract
+def test_retrostar_iter_raw_routes_skips_unsuccessful_runs() -> None:
+    entries = list(RetroStarAdapter().iter_raw_routes({"succ": False, "routes": "CCO>0.9>C"}))
+
+    assert entries == []
+
+
+@pytest.mark.contract
+def test_retrostar_accepts_purchasable_target_route() -> None:
+    raw_route = next(RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO", "route_cost": 0.0})).payload
+
+    route = RetroStarAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert route.target.product_of is None
+    assert route.annotations["route_cost"] == 0.0
+
+
+@pytest.mark.contract
+def test_retrostar_rejects_empty_route_string() -> None:
+    adapter = RetroStarAdapter()
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter._parse_route_string("")
+
+    assert exc_info.value.code == "adapter.route_string_empty"
+
+
+@pytest.mark.contract
+def test_retrostar_rejects_malformed_route_step() -> None:
+    adapter = RetroStarAdapter()
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter._parse_route_string("CCO>CC=O")
+
+    assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_retrostar_rejects_malformed_later_route_step() -> None:
+    adapter = RetroStarAdapter()
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        adapter._parse_route_string("CCO>0.9>CC=O|CC=O>0.8")
+
+    assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_retrostar_rejects_cycles_after_smiles_canonicalization() -> None:
+    raw_route = next(RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C|C>0.8>OCC"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroStarAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_retrostar_allows_duplicate_leaf_molecules() -> None:
+    raw_route = next(RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.C"})).payload
+
+    route = RetroStarAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_retrostar_rejects_empty_reaction_in_strict_mode() -> None:
+    raw_route = next(RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroStarAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
+def test_retrostar_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = next(RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>not-smiles"})).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroStarAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_retrostar_iter_raw_routes_rejects_non_mapping_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(RetroStarAdapter().iter_raw_routes(["not", "a", "payload"], source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"

--- a/tests/v2/adapters/test_retrostar.py
+++ b/tests/v2/adapters/test_retrostar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
 from retrocast.v2.models.task import Target
@@ -130,6 +130,29 @@ def test_retrostar_rejects_malformed_later_route_step() -> None:
         adapter._parse_route_string("CCO>0.9>CC=O|CC=O>0.8")
 
     assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_retrostar_strict_rejects_invalid_intermediate_product_smiles() -> None:
+    raw_route = next(
+        RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.not-smiles|not-smiles>0.8>C"})
+    ).payload
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        RetroStarAdapter().cast(raw_route, target=target_for("CCO"), mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_retrostar_prune_skips_invalid_intermediate_product_smiles() -> None:
+    raw_route = next(
+        RetroStarAdapter().iter_raw_routes({"succ": True, "routes": "CCO>0.9>C.not-smiles|not-smiles>0.8>C"})
+    ).payload
+
+    route = RetroStarAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]
 
 
 @pytest.mark.contract


### PR DESCRIPTION
## Why

RetroStar and DreamRetro still only had legacy adapter implementations. Both encode routes as compact product/score/reactants strings, so schema-v2 adaptation needed a direct trust boundary for that raw shape.

## What Changed

- Added `retrocast.v2.adapters.retrostar.RetroStarAdapter`.
- Added `retrocast.v2.adapters.dreamretro.DreamRetroErAdapter`.
- Added a small shared `build_molecule_from_precursor_map(...)` helper for route-string precursor-map traversal.
- Exported both adapters from `retrocast.v2.adapters`.
- Preserved RetroStar `route_cost` on route annotations and per-step scores on reaction annotations.
- Preserved DreamRetro run metadata on route annotations with immutable/private payload backing.

## Risk

The main risk is turning flat route strings into a truthful v2 `Route` tree.

The tests cover:

- valid raw route extraction
- malformed raw schema rejection
- valid v2 route casting
- target mismatch
- purchasable target routes
- malformed route strings
- strict invalid SMILES
- prune-mode invalid leaf dropping
- cycle detection after canonicalization
- duplicate leaf molecules
- empty reaction handling where representable
- planner-specific annotation preservation

No legacy adapter behavior, filesystem I/O, external calls, caches, or workflow orchestration are changed.

## Verification

- `uv run pytest tests/v2/adapters/test_retrostar.py tests/v2/adapters/test_dreamretro.py -v`
- `uv run pytest tests/v2/adapters -q`
- `uv run ruff check src/retrocast/v2/adapters/common.py src/retrocast/v2/adapters/retrostar.py src/retrocast/v2/adapters/dreamretro.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_retrostar.py tests/v2/adapters/test_dreamretro.py`
- commit hooks: `ruff`, `ruff-format`, `ty`

## Follow-Ups

Migrate the remaining v2 adapters in later PRs by raw-shape family.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782571326&installation_id=125602297&pr_number=104&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F104&signature=212694f80370310947fffbe58b34d69412976060502e9bdd114e704aa60f3705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds schema-v2 adapters for RetroStar and DreamRetro planners, both of which encode routes as compact pipe-delimited product/score/reactants strings. It also introduces a shared `build_molecule_from_precursor_map` helper that handles cycle detection, prune-mode invalid-SMILES dropping, and empty-reaction guards.

- `RetroStarAdapter` parses route strings, preserves `route_cost` at the route level and per-step scores as reaction annotations, and correctly propagates `InvalidSmilesError` vs. `adapter.route_string_invalid` using the inner/outer exception guard pattern.
- `DreamRetroErAdapter` follows the same parse/cast structure but preserves only run-level metadata (expand/value model calls, node lens arrays); per-step scores in the route string are intentionally dropped per the PR description.
- `DreamRetroRoutePayload` is `frozen=True` with default `eq=True`, which generates a field-based `__hash__` — but its `annotations` tuple stores list values (`reaction_nodes_lens`, `mol_nodes_lens`) that are unhashable, meaning any `hash()` call on a real-data payload (including via a containing `RawRouteEntry`) will raise `TypeError`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: DreamRetroRoutePayload stores list-valued annotation entries inside a frozen dataclass, which will cause TypeError when any code tries to hash a DreamRetro RawRouteEntry.

The route-string parsing, precursor-map tree building, cycle detection, prune mode, and annotation preservation are all correct and well-tested. The one defect is in DreamRetroRoutePayload: frozen=True with default eq=True generates a field-based __hash__, but the annotations tuple contains Python lists (reaction_nodes_lens, mol_nodes_lens) that are not hashable. The existing AskcosPathwayPayload explicitly uses eq=False to sidestep exactly this concern, so the pattern for safe handling is established in the codebase.

src/retrocast/v2/adapters/dreamretro.py — specifically the DreamRetroRoutePayload dataclass declaration and how annotation values are stored.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/dreamretro.py | New DreamRetroErAdapter with correct parse/cast logic and prune-mode handling; DreamRetroRoutePayload is frozen=True with value equality but stores list-valued annotation entries, making hash() fail for typical real payloads. |
| src/retrocast/v2/adapters/retrostar.py | New RetroStarAdapter with correct parse/cast logic; RetroStarRoutePayload fields are all hashable (str + float|None), so frozen=True is safe here. |
| src/retrocast/v2/adapters/common.py | New shared build_molecule_from_precursor_map helper; path-based cycle detection, prune-mode handling for invalid SMILES, and empty-reactant guard all look correct. |
| src/retrocast/v2/adapters/__init__.py | Adds DreamRetroErAdapter and RetroStarAdapter to public exports; no issues. |
| tests/v2/adapters/test_retrostar.py | Comprehensive RetroStar adapter tests covering extraction, casting, prune mode, cycle detection, invalid SMILES handling, and annotation preservation. |
| tests/v2/adapters/test_dreamretro.py | Comprehensive DreamRetro adapter tests including the previously-noted missing empty-reaction strict-mode case; good coverage of edge cases. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["iter_raw_routes(raw_payload)"] --> B{dict with succ=True?}
    B -- No --> C["return / raise schema_error"]
    B -- Yes --> D["Create RoutePayload"]
    D --> E["yield RawRouteEntry(payload)"]
    E --> F["cast(raw_route, mode, target)"]
    F --> G["_parse_route_string(route_str, mode)"]
    G --> H["Split steps on pipe character"]
    H --> I["Canonicalize first product as target_smiles"]
    I --> J["For each step: product/score/reactants"]
    J --> K{canon product valid SMILES?}
    K -- No + prune + non-target --> L["skip step"]
    K -- No + strict --> M["raise InvalidSmilesError"]
    K -- Yes --> N["precursor_map[canon_product] = reactants"]
    N --> J
    J -- done --> O["Return ParsedRoute"]
    O --> P["build_molecule_from_precursor_map"]
    P --> Q{canon_smiles in visited?}
    Q -- Yes --> R["raise adapter.cycle_detected"]
    Q -- No --> S{in precursor_map?}
    S -- No --> T["return Molecule leaf"]
    S -- Yes --> U["recurse for each reactant"]
    U --> V{all reactants pruned?}
    V -- Yes + prune --> W["return None => target_pruned"]
    V -- Yes + strict --> X["raise adapter.reaction_empty"]
    V -- No --> Y["return Molecule with Reaction"]
    Y --> Z["Route(target, annotations)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/v2/adapters/dreamretro.py:20-23
**`frozen=True` with list-valued annotations makes `DreamRetroRoutePayload` unhashable in practice**

`frozen=True` + the default `eq=True` causes Python to generate a field-based `__hash__` that calls `hash((route_str, annotations))`. When `annotations` contains a tuple like `("reaction_nodes_lens", [1])`, the nested list makes `hash()` raise `TypeError: unhashable type: 'list'`. Since `RawRouteEntry` is also `frozen=True`, any code that hashes a DreamRetro `RawRouteEntry` (e.g., storing entries in a set or using them as dict keys) will fail at runtime for any payload that includes `reaction_nodes_lens` or `mol_nodes_lens`.

The existing `AskcosPathwayPayload` explicitly avoids this with `eq=False` — which gives safe identity-based hashing while still allowing `frozen=True`. Either adopt the same `eq=False` pattern here, or ensure all annotation values stored in the tuple are converted to hashable types (e.g., deep-convert lists to tuples) during construction.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix route-string adapter review issues"](https://github.com/ischemist/project-procrustes/commit/9294f66ea467d3fb3c4294909ece57094ff2ee54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34377770)</sub>

<!-- /greptile_comment -->