### PR TITLE
Add schema v2 bipartite adapters

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -1,17 +1,23 @@
 """Schema v2 adapters."""
 
+from retrocast.v2.adapters.aizynth import AiZynthFinderAdapter
 from retrocast.v2.adapters.askcos import AskcosAdapter
 from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
+from retrocast.v2.adapters.synplanner import SynPlannerAdapter
+from retrocast.v2.adapters.syntheseus import SyntheseusAdapter
 
 __all__ = [
     "Adapter",
     "AdaptMode",
+    "AiZynthFinderAdapter",
     "AskcosAdapter",
     "DreamRetroErAdapter",
     "PaRoutesAdapter",
     "RawRouteEntry",
     "RetroStarAdapter",
+    "SynPlannerAdapter",
+    "SyntheseusAdapter",
 ]

--- a/src/retrocast/v2/adapters/aizynth.py
+++ b/src/retrocast/v2/adapters/aizynth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_bipartite_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw AiZynthFinder Schema
+
+
+class AizynthBaseNode(BaseModel):
+    smiles: str
+    children: list[AizynthNode] = Field(default_factory=list)
+
+
+class AizynthMoleculeInput(AizynthBaseNode):
+    type: Literal["mol"]
+    in_stock: bool = False
+    scores: dict[str, float] = Field(default_factory=dict)
+
+
+class AizynthReactionInput(AizynthBaseNode):
+    type: Literal["reaction"]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+AizynthNode = Annotated[AizynthMoleculeInput | AizynthReactionInput, Field(discriminator="type")]
+
+
+class AizynthRouteList(RootModel[list[AizynthMoleculeInput]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class AiZynthFinderAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = AizynthRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("aizynth", target_id, "invalid route list") from exc
+        for source_order, route_root in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route_root = AizynthMoleculeInput.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("aizynth", target_id, "invalid molecule route root") from exc
+
+        route_target = build_bipartite_molecule(
+            route_root,
+            adapter="aizynth",
+            mode=mode,
+            reaction_fields=_reaction_fields,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "AiZynthFinder target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "aizynth", "target_id": target_id},
+            )
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "aizynth",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=route_target.smiles,
+                )
+
+        annotations: dict[str, Any] = {}
+        if route_root.scores:
+            annotations["scores"] = route_root.scores
+            if "state score" in route_root.scores:
+                annotations["state_score"] = route_root.scores["state score"]
+        return Route(target=route_target, annotations=annotations)
+
+
+# SECTION: Helpers
+
+
+def _reaction_fields(node: AizynthReactionInput) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    if "mapped_reaction_smiles" in node.metadata:
+        fields["mapped_reaction_smiles"] = node.metadata["mapped_reaction_smiles"]
+    if "template" in node.metadata:
+        fields["template"] = node.metadata["template"]
+    fields["annotations"] = dict(node.metadata)
+    return fields

--- a/src/retrocast/v2/adapters/common.py
+++ b/src/retrocast/v2/adapters/common.py
@@ -83,11 +83,26 @@ def build_bipartite_molecule(
     mode: AdaptMode,
     reaction_fields: Callable[[Any], ReactionFields] | None = None,
     remove_mapping: bool = False,
-    visited: set[SmilesStr] | None = None,
 ) -> Molecule | None:
-    if visited is None:
-        visited = set()
+    return _build_bipartite_molecule(
+        node,
+        adapter=adapter,
+        mode=mode,
+        reaction_fields=reaction_fields,
+        remove_mapping=remove_mapping,
+        visited=set(),
+    )
 
+
+def _build_bipartite_molecule(
+    node: Any,
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    reaction_fields: Callable[[Any], ReactionFields] | None,
+    remove_mapping: bool,
+    visited: set[SmilesStr],
+) -> Molecule | None:
     if getattr(node, "type", None) != "mol":
         actual = getattr(node, "type", type(node).__name__)
         raise adapter_node_type_error(adapter, expected="mol", actual=actual, role="molecule")
@@ -122,7 +137,7 @@ def build_bipartite_molecule(
         if getattr(child, "type", None) != "mol":
             actual = getattr(child, "type", type(child).__name__)
             raise adapter_node_type_error(adapter, expected="mol", actual=actual, role="reaction child")
-        reactant = build_bipartite_molecule(
+        reactant = _build_bipartite_molecule(
             child,
             adapter=adapter,
             mode=mode,

--- a/src/retrocast/v2/adapters/common.py
+++ b/src/retrocast/v2/adapters/common.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from retrocast.adapters.errors import adapter_cycle_error
+from retrocast.adapters.errors import adapter_cycle_error, adapter_node_type_error
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
 from retrocast.typing import SmilesStr
@@ -11,6 +11,7 @@ from retrocast.v2.adapters.base import AdaptMode
 from retrocast.v2.models.route import Molecule, Reaction
 
 ReactionAnnotations = Mapping[SmilesStr, Mapping[str, Any]]
+ReactionFields = Mapping[str, Any]
 
 
 # SECTION: Precursor Map Traversal
@@ -69,4 +70,81 @@ def build_molecule_from_precursor_map(
         smiles=canon_smiles,
         inchikey=get_inchi_key(canon_smiles),
         product_of=Reaction(reactants=reactants, annotations=annotations),
+    )
+
+
+# SECTION: Bipartite Molecule-Reaction Traversal
+
+
+def build_bipartite_molecule(
+    node: Any,
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    reaction_fields: Callable[[Any], ReactionFields] | None = None,
+    remove_mapping: bool = False,
+    visited: set[SmilesStr] | None = None,
+) -> Molecule | None:
+    if visited is None:
+        visited = set()
+
+    if getattr(node, "type", None) != "mol":
+        actual = getattr(node, "type", type(node).__name__)
+        raise adapter_node_type_error(adapter, expected="mol", actual=actual, role="molecule")
+
+    try:
+        canon_smiles = canonicalize_smiles(node.smiles, remove_mapping=remove_mapping)
+    except InvalidSmilesError:
+        if mode == "prune":
+            return None
+        raise
+
+    if canon_smiles in visited:
+        raise adapter_cycle_error(adapter, canon_smiles)
+
+    if getattr(node, "in_stock", False) or not node.children:
+        return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+    if len(node.children) > 1:
+        raise AdapterLogicError(
+            f"{adapter} route is not a tree: molecule has multiple child reactions",
+            code="adapter.route_not_tree",
+            context={"adapter": adapter, "smiles": canon_smiles, "child_reaction_count": len(node.children)},
+        )
+
+    reaction_node = node.children[0]
+    if getattr(reaction_node, "type", None) != "reaction":
+        actual = getattr(reaction_node, "type", type(reaction_node).__name__)
+        raise adapter_node_type_error(adapter, expected="reaction", actual=actual, role="molecule child")
+
+    reactants: list[Molecule] = []
+    for child in reaction_node.children:
+        if getattr(child, "type", None) != "mol":
+            actual = getattr(child, "type", type(child).__name__)
+            raise adapter_node_type_error(adapter, expected="mol", actual=actual, role="reaction child")
+        reactant = build_bipartite_molecule(
+            child,
+            adapter=adapter,
+            mode=mode,
+            reaction_fields=reaction_fields,
+            remove_mapping=remove_mapping,
+            visited=visited | {canon_smiles},
+        )
+        if reactant is not None:
+            reactants.append(reactant)
+
+    if not reactants:
+        if mode == "prune":
+            return None
+        raise AdapterLogicError(
+            f"{adapter} reaction has no reactants",
+            code="adapter.reaction_empty",
+            context={"adapter": adapter, "smiles": canon_smiles},
+        )
+
+    fields = dict(reaction_fields(reaction_node)) if reaction_fields is not None else {}
+    return Molecule(
+        smiles=canon_smiles,
+        inchikey=get_inchi_key(canon_smiles),
+        product_of=Reaction(reactants=reactants, **fields),
     )

--- a/src/retrocast/v2/adapters/synplanner.py
+++ b/src/retrocast/v2/adapters/synplanner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_bipartite_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw SynPlanner Schema
+
+
+class SynPlannerBaseNode(BaseModel):
+    smiles: str
+    children: list[SynPlannerNode] = Field(default_factory=list)
+
+
+class SynPlannerMoleculeInput(SynPlannerBaseNode):
+    type: Literal["mol"]
+    in_stock: bool = False
+
+
+class SynPlannerReactionInput(SynPlannerBaseNode):
+    type: Literal["reaction"]
+
+
+SynPlannerNode = Annotated[SynPlannerMoleculeInput | SynPlannerReactionInput, Field(discriminator="type")]
+
+
+class SynPlannerRouteList(RootModel[list[SynPlannerMoleculeInput]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class SynPlannerAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = SynPlannerRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("synplanner", target_id, "invalid route list") from exc
+        for source_order, route_root in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route_root = SynPlannerMoleculeInput.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("synplanner", target_id, "invalid molecule route root") from exc
+        route_target = build_bipartite_molecule(
+            route_root,
+            adapter="synplanner",
+            mode=mode,
+            reaction_fields=_reaction_fields,
+            remove_mapping=True,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "SynPlanner target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "synplanner", "target_id": target_id},
+            )
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles, remove_mapping=True)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "synplanner", target.id, expected_smiles=expected_smiles, actual_smiles=route_target.smiles
+                )
+        return Route(target=route_target)
+
+
+# SECTION: Helpers
+
+
+def _reaction_fields(node: SynPlannerReactionInput) -> dict[str, Any]:
+    return {"mapped_reaction_smiles": node.smiles, "annotations": {"source_smiles": node.smiles}}

--- a/src/retrocast/v2/adapters/syntheseus.py
+++ b/src/retrocast/v2/adapters/syntheseus.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_bipartite_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw Syntheseus Schema
+
+
+class SyntheseusBaseNode(BaseModel):
+    smiles: str
+    children: list[SyntheseusNode] = Field(default_factory=list)
+
+
+class SyntheseusMoleculeInput(SyntheseusBaseNode):
+    type: Literal["mol"]
+    in_stock: bool = False
+
+
+class SyntheseusReactionInput(SyntheseusBaseNode):
+    type: Literal["reaction"]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+SyntheseusNode = Annotated[SyntheseusMoleculeInput | SyntheseusReactionInput, Field(discriminator="type")]
+
+
+class SyntheseusRouteList(RootModel[list[SyntheseusMoleculeInput]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class SyntheseusAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = SyntheseusRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("syntheseus", target_id, "invalid route list") from exc
+        for source_order, route_root in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route_root = SyntheseusMoleculeInput.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("syntheseus", target_id, "invalid molecule route root") from exc
+        route_target = build_bipartite_molecule(
+            route_root,
+            adapter="syntheseus",
+            mode=mode,
+            reaction_fields=_reaction_fields,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "Syntheseus target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "syntheseus", "target_id": target_id},
+            )
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "syntheseus", target.id, expected_smiles=expected_smiles, actual_smiles=route_target.smiles
+                )
+        return Route(target=route_target)
+
+
+# SECTION: Helpers
+
+
+def _reaction_fields(node: SyntheseusReactionInput) -> dict[str, Any]:
+    fields: dict[str, Any] = {"annotations": dict(node.metadata)}
+    if "mapped_reaction_smiles" in node.metadata:
+        fields["mapped_reaction_smiles"] = node.metadata["mapped_reaction_smiles"]
+    if "template" in node.metadata:
+        fields["template"] = node.metadata["template"]
+    return fields

--- a/tests/v2/adapters/test_aizynth.py
+++ b/tests/v2/adapters/test_aizynth.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.aizynth import AiZynthFinderAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="aizynth-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_aizynth_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "scores": {"state score": 0.75},
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"template": "tmpl-1", "mapped_reaction_smiles": "CC=O.[H][H]>>CCO"},
+                "children": [
+                    {"type": "mol", "smiles": "CC=O", "in_stock": True},
+                    {"type": "mol", "smiles": "[H][H]", "in_stock": True},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def raw_aizynth_payload(raw_aizynth_route) -> list[dict]:
+    return [raw_aizynth_route, {"type": "mol", "smiles": "CCC", "in_stock": True}]
+
+
+@pytest.fixture
+def raw_aizynth_invalid_leaf_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True},
+                    {"type": "mol", "smiles": "not-smiles", "in_stock": True},
+                ],
+            }
+        ],
+    }
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestAiZynthAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_aizynth_payload, raw_aizynth_route, raw_aizynth_invalid_leaf_route
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=AiZynthFinderAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_aizynth_payload, {"type": "mol"}, "aizynth-run", 2, ["aizynth-run", "aizynth-run"], 1
+            ),
+            casting=CastContractCase(
+                raw_aizynth_route,
+                {"type": "mol"},
+                target_for("CCO"),
+                Target(id="aizynth-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(raw_aizynth_invalid_leaf_route, ["C"]),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_aizynth_preserves_scores_and_reaction_metadata(raw_aizynth_route) -> None:
+    route = AiZynthFinderAdapter().cast(raw_aizynth_route, target=target_for("CCO"))
+    reaction = route.reaction_at("rc:r:/").value
+
+    assert route.annotations == {"scores": {"state score": 0.75}, "state_score": 0.75}
+    assert reaction.template == "tmpl-1"
+    assert reaction.mapped_reaction_smiles == "CC=O.[H][H]>>CCO"
+    assert reaction.annotations["template"] == "tmpl-1"
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(AiZynthFinderAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [{"type": "reaction", "smiles": "CCO", "children": [{"type": "mol", "smiles": "OCC"}]}],
+    }
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_aizynth_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "C"}, {"type": "mol", "smiles": "C"}],
+            }
+        ],
+    }
+    route = AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_multiple_child_reactions() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {"type": "reaction", "smiles": "CCO", "children": [{"type": "mol", "smiles": "C"}]},
+            {"type": "reaction", "smiles": "CCO", "children": [{"type": "mol", "smiles": "CC"}]},
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.route_not_tree"

--- a/tests/v2/adapters/test_aizynth.py
+++ b/tests/v2/adapters/test_aizynth.py
@@ -141,6 +141,36 @@ def test_aizynth_allows_duplicate_leaf_molecules() -> None:
 
 
 @pytest.mark.contract
+def test_aizynth_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "not-smiles", "in_stock": True}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_empty_reaction_in_strict_mode() -> None:
+    raw_route = {"type": "mol", "smiles": "CCO", "children": [{"type": "reaction", "smiles": "CCO"}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
 def test_aizynth_rejects_multiple_child_reactions() -> None:
     raw_route = {
         "type": "mol",
@@ -155,3 +185,33 @@ def test_aizynth_rejects_multiple_child_reactions() -> None:
         AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
 
     assert exc_info.value.code == "adapter.route_not_tree"
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_molecule_child_under_molecule() -> None:
+    raw_route = {"type": "mol", "smiles": "CCO", "children": [{"type": "mol", "smiles": "C"}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.node_type_invalid"
+
+
+@pytest.mark.contract
+def test_aizynth_rejects_reaction_child_under_reaction() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "reaction", "smiles": "C>>CCO"}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AiZynthFinderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.node_type_invalid"

--- a/tests/v2/adapters/test_askcos.py
+++ b/tests/v2/adapters/test_askcos.py
@@ -221,6 +221,42 @@ def test_askcos_rejects_missing_reaction_uuid(raw_askcos_output) -> None:
 
 
 @pytest.mark.contract
+def test_askcos_rejects_missing_chemical_uuid(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["uuid2smiles"].pop("uuid-ethanol")
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.node_missing"
+
+
+@pytest.mark.contract
+def test_askcos_rejects_missing_chemical_node(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["node_dict"].pop("CCO")
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.node_missing"
+
+
+@pytest.mark.contract
+def test_askcos_rejects_missing_reaction_node(raw_askcos_output) -> None:
+    raw_payload = deepcopy(raw_askcos_output)
+    raw_payload["results"]["uds"]["node_dict"].pop("CC(=O)O.CCO>>CCOC(C)=O")
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
+
+    assert exc_info.value.code == "adapter.node_missing"
+
+
+@pytest.mark.contract
 def test_askcos_rejects_cycles(raw_askcos_output) -> None:
     raw_payload = deepcopy(raw_askcos_output)
     raw_payload["results"]["uds"]["pathways"][0] = [
@@ -283,6 +319,23 @@ def test_askcos_rejects_empty_reaction_in_strict_mode(raw_askcos_output) -> None
         AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"))
 
     assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
+def test_askcos_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_payload = invalid_leaf_output()
+    raw_payload["results"]["uds"]["pathways"] = [
+        [
+            {"source": "00000000-0000-0000-0000-000000000000", "target": "uuid-rxn"},
+            {"source": "uuid-rxn", "target": "uuid-bad"},
+        ]
+    ]
+    raw_route = next(AskcosAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        AskcosAdapter().cast(raw_route, target=target_for("CCOC(C)=O"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_synplanner.py
+++ b/tests/v2/adapters/test_synplanner.py
@@ -129,3 +129,23 @@ def test_synplanner_allows_duplicate_leaf_molecules() -> None:
     }
     route = SynPlannerAdapter().cast(raw_route, target=target_for("CCO"))
     assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_synplanner_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "C>>CCO",
+                "children": [{"type": "mol", "smiles": "not-smiles"}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynPlannerAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"

--- a/tests/v2/adapters/test_synplanner.py
+++ b/tests/v2/adapters/test_synplanner.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.synplanner import SynPlannerAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles, remove_mapping=True)
+    return Target(id="synplanner-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_synplanner_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "[CH3:1].[CH3:2]>>[CH3:1][CH2:2]O",
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True},
+                    {"type": "mol", "smiles": "CC", "in_stock": True},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def raw_synplanner_payload(raw_synplanner_route) -> list[dict]:
+    return [raw_synplanner_route, {"type": "mol", "smiles": "CCC", "in_stock": True}]
+
+
+@pytest.fixture
+def raw_synplanner_invalid_leaf_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "C.C>>CCO",
+                "children": [{"type": "mol", "smiles": "C"}, {"type": "mol", "smiles": "not-smiles"}],
+            }
+        ],
+    }
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestSynPlannerAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_synplanner_payload, raw_synplanner_route, raw_synplanner_invalid_leaf_route
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=SynPlannerAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_synplanner_payload, {"type": "mol"}, "synplanner-run", 2, ["synplanner-run", "synplanner-run"], 1
+            ),
+            casting=CastContractCase(
+                raw_synplanner_route,
+                {"type": "mol"},
+                target_for("CCO"),
+                Target(id="synplanner-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(raw_synplanner_invalid_leaf_route, ["C"]),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_synplanner_preserves_reaction_smiles_annotation(raw_synplanner_route) -> None:
+    reaction = SynPlannerAdapter().cast(raw_synplanner_route, target=target_for("CCO")).reaction_at("rc:r:/").value
+    assert reaction.mapped_reaction_smiles == "[CH3:1].[CH3:2]>>[CH3:1][CH2:2]O"
+    assert reaction.annotations == {"source_smiles": "[CH3:1].[CH3:2]>>[CH3:1][CH2:2]O"}
+
+
+@pytest.mark.contract
+def test_synplanner_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(SynPlannerAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_synplanner_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [{"type": "reaction", "smiles": "CCO", "children": [{"type": "mol", "smiles": "OCC"}]}],
+    }
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynPlannerAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_synplanner_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "C"}, {"type": "mol", "smiles": "C"}],
+            }
+        ],
+    }
+    route = SynPlannerAdapter().cast(raw_route, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]

--- a/tests/v2/adapters/test_syntheseus.py
+++ b/tests/v2/adapters/test_syntheseus.py
@@ -131,3 +131,23 @@ def test_syntheseus_allows_duplicate_leaf_molecules() -> None:
     }
     route = SyntheseusAdapter().cast(raw_route, target=target_for("CCO"))
     assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_syntheseus_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "not-smiles"}],
+            }
+        ],
+    }
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SyntheseusAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"

--- a/tests/v2/adapters/test_syntheseus.py
+++ b/tests/v2/adapters/test_syntheseus.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.syntheseus import SyntheseusAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="syntheseus-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_syntheseus_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"template": "tmpl", "mapped_reaction_smiles": "C.C>>CCO"},
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True},
+                    {"type": "mol", "smiles": "CC", "in_stock": True},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def raw_syntheseus_payload(raw_syntheseus_route) -> list[dict]:
+    return [raw_syntheseus_route, {"type": "mol", "smiles": "CCC", "in_stock": True}]
+
+
+@pytest.fixture
+def raw_syntheseus_invalid_leaf_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "C"}, {"type": "mol", "smiles": "not-smiles"}],
+            }
+        ],
+    }
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestSyntheseusAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_syntheseus_payload, raw_syntheseus_route, raw_syntheseus_invalid_leaf_route
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=SyntheseusAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_syntheseus_payload, {"type": "mol"}, "syntheseus-run", 2, ["syntheseus-run", "syntheseus-run"], 1
+            ),
+            casting=CastContractCase(
+                raw_syntheseus_route,
+                {"type": "mol"},
+                target_for("CCO"),
+                Target(id="syntheseus-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(raw_syntheseus_invalid_leaf_route, ["C"]),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_syntheseus_preserves_reaction_metadata(raw_syntheseus_route) -> None:
+    reaction = SyntheseusAdapter().cast(raw_syntheseus_route, target=target_for("CCO")).reaction_at("rc:r:/").value
+    assert reaction.template == "tmpl"
+    assert reaction.mapped_reaction_smiles == "C.C>>CCO"
+    assert reaction.annotations["template"] == "tmpl"
+
+
+@pytest.mark.contract
+def test_syntheseus_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(SyntheseusAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_syntheseus_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [{"type": "reaction", "smiles": "CCO", "children": [{"type": "mol", "smiles": "OCC"}]}],
+    }
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SyntheseusAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_syntheseus_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "children": [{"type": "mol", "smiles": "C"}, {"type": "mol", "smiles": "C"}],
+            }
+        ],
+    }
+    route = SyntheseusAdapter().cast(raw_route, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]


### PR DESCRIPTION
why: continue the schema v2 adapter migration for providers that use the same molecule/reaction bipartite tree shape. Keeping these together lets the shared traversal logic be reviewed with all of its immediate consumers, without mixing in unrelated plain-tree or route-string formats.

what changed:
- Added v2 adapters for AiZynthFinder, SynPlanner, and Syntheseus.
- Added `build_bipartite_molecule(...)` for the shared molecule -> reaction -> molecule tree traversal.
- Preserved provider-specific reaction metadata: AiZynthFinder/Syntheseus metadata and SynPlanner mapped reaction SMILES.
- Added adapter-boundary contract tests for extraction, casting, target mismatch, invalid SMILES pruning, cycles, duplicate leaves, and non-tree molecule nodes.

risk:
- The main invariant is that a molecule node maps to at most one child reaction in schema v2 route trees. Multiple child reactions now fail with `adapter.route_not_tree` instead of silently picking one.
- SynPlanner canonicalizes with `remove_mapping=True` because its raw reaction/molecule strings may carry atom mapping.
- This is additive v2 adapter code; legacy adapters and workflow wiring are not changed.

verification:
- `uv run pytest tests/v2/adapters/test_aizynth.py tests/v2/adapters/test_synplanner.py tests/v2/adapters/test_syntheseus.py -q`
- `uv run pytest tests/v2/adapters -q`
- `uv run ruff check src/retrocast/v2/adapters/common.py src/retrocast/v2/adapters/aizynth.py src/retrocast/v2/adapters/synplanner.py src/retrocast/v2/adapters/syntheseus.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_aizynth.py tests/v2/adapters/test_synplanner.py tests/v2/adapters/test_syntheseus.py`
- `uv run ty check src/retrocast/v2/adapters/common.py src/retrocast/v2/adapters/aizynth.py src/retrocast/v2/adapters/synplanner.py src/retrocast/v2/adapters/syntheseus.py tests/v2/adapters/test_aizynth.py tests/v2/adapters/test_synplanner.py tests/v2/adapters/test_syntheseus.py`

follow-ups:
- DirectMultiStep, MolBuilder, MultiStepTTL, RetroChimera, SynLlama, and URSA remain in the migration stash for later focused PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782573554&installation_id=125602297&pr_number=105&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F105&signature=3ce0d5b260e2bbfdab366e5ebfd689a5f7b7f587e2bab7c78b52c7219c50338a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting synthesis routes from three additional planning tools: AiZynthFinder, SynPlanner, and Syntheseus into the internal Route format.
  * Each adapter validates route payloads, preserves metadata and annotations, and enforces target SMILES consistency.

* **Tests**
  * Comprehensive test coverage for all new adapters, including validation, casting, cycle detection, and metadata preservation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds schema v2 adapters for AiZynthFinder, SynPlanner, and Syntheseus — three synthesis planning tools that share the same bipartite (mol → reaction → mol) tree shape. A shared `build_bipartite_molecule` traversal helper in `common.py` drives all three, with each adapter supplying a `reaction_fields` callback for provider-specific metadata.

- `common.py` gains `build_bipartite_molecule` / `_build_bipartite_molecule` with consistent cycle detection (path-based `visited` set), SMILES prune/strict mode, and structural invariant checks; the `visited` accumulator is correctly hidden behind the private helper, addressing the concern from the previous review.
- Three new adapters (`aizynth.py`, `synplanner.py`, `syntheseus.py`) and their corresponding test suites are additive; `synplanner` canonicalizes mol nodes with `remove_mapping=True` to handle atom-mapped molecule SMILES from that tool's output.
- `test_askcos.py` gains three new edge-case tests (missing UUID, missing chemical/reaction node, all-reactants-pruned) for consistency with the new adapter contract suite.

<h3>Confidence Score: 5/5</h3>

This PR is additive adapter code with no changes to existing adapters or workflow wiring; safe to merge.

The shared bipartite traversal in common.py is correct: cycle detection is path-based, prune/strict mode is consistently applied, and structural invariants raise unconditionally as documented. The public/private split on build_bipartite_molecule addressed the concern from the previous review. Test coverage is thorough across all adapters.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/common.py | Adds build_bipartite_molecule with correct path-based cycle detection, prune/strict mode, and structural validation; public/private split addresses previous review comment. |
| src/retrocast/v2/adapters/aizynth.py | New AiZynthFinder adapter: delegates traversal to build_bipartite_molecule, extracts mapped_reaction_smiles/template from metadata, stores full metadata as annotations. |
| src/retrocast/v2/adapters/synplanner.py | New SynPlanner adapter: uses remove_mapping=True throughout for molecule SMILES; stores the raw reaction-node SMILES as mapped_reaction_smiles (intended — SynPlanner emits atom-mapped reaction strings). |
| src/retrocast/v2/adapters/syntheseus.py | New Syntheseus adapter: mirrors AiZynthFinder structure; conditionally extracts mapped_reaction_smiles and template from metadata while always passing full metadata as annotations. |
| tests/v2/adapters/test_aizynth.py | Comprehensive contract tests covering extraction, casting, target mismatch, cycle detection, duplicate leaves, prune/strict modes, and structural node-type errors. |
| tests/v2/adapters/test_synplanner.py | Contract tests for SynPlanner including atom-mapped reaction SMILES annotation preservation and canonicalization of mapped molecule SMILES. |
| tests/v2/adapters/test_syntheseus.py | Contract tests for Syntheseus mirroring the AiZynthFinder suite; metadata preservation verified for template and mapped_reaction_smiles fields. |
| tests/v2/adapters/test_askcos.py | Adds missing-UUID, missing-node, and all-reactants-pruned edge-case tests for the existing ASKCOS adapter for consistency with the new contract suite. |
| src/retrocast/v2/adapters/__init__.py | Registers AiZynthFinderAdapter, SynPlannerAdapter, and SyntheseusAdapter in the public API; __all__ is updated correctly. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["build_bipartite_molecule(node)"] --> B["_build_bipartite_molecule(node, visited=set())"]
    B --> C{"node.type == mol?"}
    C -- No --> ERR1["raise adapter.node_type_invalid"]
    C -- Yes --> D["canonicalize_smiles(node.smiles)"]
    D -- InvalidSmilesError --> E{"mode == prune?"}
    E -- Yes --> RN["return None"]
    E -- No --> ERR2["re-raise"]
    D -- OK --> F{"canon_smiles in visited?"}
    F -- Yes --> ERR3["raise adapter.cycle_detected"]
    F -- No --> G{"in_stock=True OR no children?"}
    G -- Yes --> L["return Molecule - leaf"]
    G -- No --> H{"len(children) > 1?"}
    H -- Yes --> ERR4["raise adapter.route_not_tree"]
    H -- No --> I["reaction_node = children[0]"]
    I --> J{"reaction_node.type == reaction?"}
    J -- No --> ERR5["raise adapter.node_type_invalid"]
    J -- Yes --> K["recurse each reaction child with visited union canon_smiles"]
    K --> M{"any reactants built?"}
    M -- No, strict --> ERR7["raise adapter.reaction_empty"]
    M -- No, prune --> RN
    M -- Yes --> N["call reaction_fields(reaction_node)"]
    N --> O["return Molecule with product_of Reaction"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/retrocast/v2/adapters/common.py`, line 199-204 ([link](https://github.com/ischemist/project-procrustes/blob/dee7189d3f9269bca46eefdb8bbbfa729810f3a0/src/retrocast/v2/adapters/common.py#L199-L204)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`adapter.route_not_tree` is always raised regardless of `mode`**

   In `prune` mode every SMILES error is silently swallowed, but a molecule node with multiple child reactions raises unconditionally. If the intent is that structural invariants (non-tree shape) should always be hard errors this is fine, but it's worth documenting explicitly — especially because a caller who sets `mode="prune"` expecting all malformed nodes to be quietly skipped will be surprised when this raises instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/retrocast/v2/adapters/common.py
   Line: 199-204

   Comment:
   **`adapter.route_not_tree` is always raised regardless of `mode`**

   In `prune` mode every SMILES error is silently swallowed, but a molecule node with multiple child reactions raises unconditionally. If the intent is that structural invariants (non-tree shape) should always be hard errors this is fine, but it's worth documenting explicitly — especially because a caller who sets `mode="prune"` expecting all malformed nodes to be quietly skipped will be surprised when this raises instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Cover v2 adapter edge cases"](https://github.com/ischemist/project-procrustes/commit/8828bf53af76207a99aa97bd89ec5c0e2ad5c21f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34386064)</sub>

<!-- /greptile_comment -->