### PR TITLE
Add schema v2 plain-tree adapters

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -3,7 +3,9 @@
 from retrocast.v2.adapters.aizynth import AiZynthFinderAdapter
 from retrocast.v2.adapters.askcos import AskcosAdapter
 from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.dms import DirectMultiStepAdapter
 from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
+from retrocast.v2.adapters.molbuilder import MolBuilderAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
 from retrocast.v2.adapters.synplanner import SynPlannerAdapter
@@ -14,7 +16,9 @@ __all__ = [
     "AdaptMode",
     "AiZynthFinderAdapter",
     "AskcosAdapter",
+    "DirectMultiStepAdapter",
     "DreamRetroErAdapter",
+    "MolBuilderAdapter",
     "PaRoutesAdapter",
     "RawRouteEntry",
     "RetroStarAdapter",

--- a/src/retrocast/v2/adapters/common.py
+++ b/src/retrocast/v2/adapters/common.py
@@ -12,6 +12,7 @@ from retrocast.v2.models.route import Molecule, Reaction
 
 ReactionAnnotations = Mapping[SmilesStr, Mapping[str, Any]]
 ReactionFields = Mapping[str, Any]
+MoleculeAnnotations = Mapping[str, Any]
 
 
 # SECTION: Precursor Map Traversal
@@ -162,4 +163,82 @@ def _build_bipartite_molecule(
         smiles=canon_smiles,
         inchikey=get_inchi_key(canon_smiles),
         product_of=Reaction(reactants=reactants, **fields),
+    )
+
+
+# SECTION: Plain Molecule Tree Traversal
+
+
+def build_plain_tree_molecule(
+    node: Any,
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    get_smiles: Callable[[Any], str],
+    get_children: Callable[[Any], Sequence[Any]],
+    get_molecule_annotations: Callable[[Any], MoleculeAnnotations] | None = None,
+    get_reaction_fields: Callable[[Any], ReactionFields] | None = None,
+) -> Molecule | None:
+    return _build_plain_tree_molecule(
+        node,
+        adapter=adapter,
+        mode=mode,
+        get_smiles=get_smiles,
+        get_children=get_children,
+        get_molecule_annotations=get_molecule_annotations,
+        get_reaction_fields=get_reaction_fields,
+        visited=set(),
+    )
+
+
+def _build_plain_tree_molecule(
+    node: Any,
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    get_smiles: Callable[[Any], str],
+    get_children: Callable[[Any], Sequence[Any]],
+    get_molecule_annotations: Callable[[Any], MoleculeAnnotations] | None,
+    get_reaction_fields: Callable[[Any], ReactionFields] | None,
+    visited: set[SmilesStr],
+) -> Molecule | None:
+    try:
+        canon_smiles = canonicalize_smiles(get_smiles(node))
+    except InvalidSmilesError:
+        if mode == "prune":
+            return None
+        raise
+
+    if canon_smiles in visited:
+        raise adapter_cycle_error(adapter, canon_smiles)
+
+    annotations = dict(get_molecule_annotations(node)) if get_molecule_annotations is not None else {}
+    children = list(get_children(node))
+    if not children:
+        return Molecule(smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles), annotations=annotations)
+
+    reactants: list[Molecule] = []
+    for child in children:
+        reactant = _build_plain_tree_molecule(
+            child,
+            adapter=adapter,
+            mode=mode,
+            get_smiles=get_smiles,
+            get_children=get_children,
+            get_molecule_annotations=get_molecule_annotations,
+            get_reaction_fields=get_reaction_fields,
+            visited=visited | {canon_smiles},
+        )
+        if reactant is not None:
+            reactants.append(reactant)
+
+    if not reactants:
+        return None
+
+    fields = dict(get_reaction_fields(node)) if get_reaction_fields is not None else {}
+    return Molecule(
+        smiles=canon_smiles,
+        inchikey=get_inchi_key(canon_smiles),
+        product_of=Reaction(reactants=reactants, **fields),
+        annotations=annotations,
     )

--- a/src/retrocast/v2/adapters/common.py
+++ b/src/retrocast/v2/adapters/common.py
@@ -24,12 +24,27 @@ def build_molecule_from_precursor_map(
     *,
     adapter: str,
     mode: AdaptMode,
-    visited: set[SmilesStr] | None = None,
     reaction_annotations: ReactionAnnotations | None = None,
 ) -> Molecule | None:
-    if visited is None:
-        visited = set()
+    return _build_molecule_from_precursor_map(
+        smiles,
+        precursor_map,
+        adapter=adapter,
+        mode=mode,
+        visited=set(),
+        reaction_annotations=reaction_annotations,
+    )
 
+
+def _build_molecule_from_precursor_map(
+    smiles: str,
+    precursor_map: Mapping[SmilesStr, Sequence[str]],
+    *,
+    adapter: str,
+    mode: AdaptMode,
+    visited: set[SmilesStr],
+    reaction_annotations: ReactionAnnotations | None,
+) -> Molecule | None:
     try:
         canon_smiles = canonicalize_smiles(smiles)
     except InvalidSmilesError:
@@ -46,7 +61,7 @@ def build_molecule_from_precursor_map(
 
     reactants: list[Molecule] = []
     for reactant in reactant_smiles:
-        reactant_molecule = build_molecule_from_precursor_map(
+        reactant_molecule = _build_molecule_from_precursor_map(
             reactant,
             precursor_map,
             adapter=adapter,
@@ -233,7 +248,13 @@ def _build_plain_tree_molecule(
             reactants.append(reactant)
 
     if not reactants:
-        return None
+        if mode == "prune":
+            return None
+        raise AdapterLogicError(
+            f"{adapter} reaction has no reactants",
+            code="adapter.reaction_empty",
+            context={"adapter": adapter, "smiles": canon_smiles},
+        )
 
     fields = dict(get_reaction_fields(node)) if get_reaction_fields is not None else {}
     return Molecule(

--- a/src/retrocast/v2/adapters/dms.py
+++ b/src/retrocast/v2/adapters/dms.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_plain_tree_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw DMS Schema
+
+
+class DMSTree(BaseModel):
+    smiles: str
+    children: list[DMSTree] = Field(default_factory=list)
+
+
+class DMSRouteList(RootModel[list[DMSTree]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class DirectMultiStepAdapter:
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = DMSRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("dms", target_id, "invalid route list") from exc
+
+        for source_order, route_root in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route_root = DMSTree.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("dms", target_id, "invalid route root") from exc
+
+        route_target = build_plain_tree_molecule(
+            route_root,
+            adapter="dms",
+            mode=mode,
+            get_smiles=lambda node: node.smiles,
+            get_children=lambda node: node.children,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "DMS target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "dms", "target_id": target_id},
+            )
+
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "dms",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=route_target.smiles,
+                )
+        return Route(target=route_target)
+
+    @staticmethod
+    def calculate_route_length(dms_node: DMSTree) -> int:
+        if not dms_node.children:
+            return 0
+        return max(DirectMultiStepAdapter.calculate_route_length(child) for child in dms_node.children) + 1

--- a/src/retrocast/v2/adapters/molbuilder.py
+++ b/src/retrocast/v2/adapters/molbuilder.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_plain_tree_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw MolBuilder Schema
+
+
+class MolBuilderPrecursor(BaseModel):
+    smiles: str
+    name: str = ""
+    cost_per_kg: float = 0.0
+
+
+class MolBuilderDisconnection(BaseModel):
+    reaction_name: str
+    named_reaction: str | None = None
+    category: str = ""
+    score: float = 0.0
+    precursors: list[MolBuilderPrecursor] = Field(default_factory=list)
+
+
+class MolBuilderNode(BaseModel):
+    smiles: str
+    is_purchasable: bool = False
+    functional_groups: list[str] = Field(default_factory=list)
+    best_disconnection: MolBuilderDisconnection | None = None
+    children: list[MolBuilderNode] = Field(default_factory=list)
+
+
+class MolBuilderRouteList(RootModel[list[MolBuilderNode]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class MolBuilderAdapter:
+    def iter_raw_routes(
+        self,
+        raw_payload: Any,
+        *,
+        source_key: str | None = None,
+    ) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = MolBuilderRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("molbuilder", target_id, "invalid route list") from exc
+
+        for source_order, route_root in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+    def cast(
+        self,
+        raw_route: Any,
+        *,
+        mode: AdaptMode = "strict",
+        target: Target | None = None,
+    ) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route_root = MolBuilderNode.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("molbuilder", target_id, "invalid route root") from exc
+
+        route_target = build_plain_tree_molecule(
+            route_root,
+            adapter="molbuilder",
+            mode=mode,
+            get_smiles=lambda node: node.smiles,
+            get_children=lambda node: [] if node.is_purchasable else node.children,
+            get_molecule_annotations=_molecule_annotations,
+            get_reaction_fields=_reaction_fields,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "MolBuilder target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "molbuilder", "target_id": target_id},
+            )
+
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if route_target.smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "molbuilder",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=route_target.smiles,
+                )
+
+        annotations: dict[str, Any] = {}
+        if route_root.best_disconnection is not None:
+            annotations["score"] = route_root.best_disconnection.score
+        return Route(target=route_target, annotations=annotations)
+
+
+# SECTION: Helpers
+
+
+def _molecule_annotations(node: MolBuilderNode) -> dict[str, Any]:
+    if not node.functional_groups:
+        return {}
+    return {"functional_groups": node.functional_groups}
+
+
+def _reaction_fields(node: MolBuilderNode) -> dict[str, Any]:
+    disconnection = node.best_disconnection
+    if disconnection is None:
+        return {}
+
+    annotations: dict[str, Any] = {"score": disconnection.score}
+    reaction_name = disconnection.reaction_name.strip()
+    if reaction_name:
+        annotations["reaction_name"] = reaction_name
+    if disconnection.named_reaction:
+        annotations["named_reaction"] = disconnection.named_reaction
+    if disconnection.category:
+        annotations["category"] = disconnection.category
+    if disconnection.precursors:
+        annotations["precursors"] = [precursor.model_dump() for precursor in disconnection.precursors]
+
+    return {"template": reaction_name or None, "annotations": annotations}

--- a/src/retrocast/v2/adapters/molbuilder.py
+++ b/src/retrocast/v2/adapters/molbuilder.py
@@ -100,10 +100,7 @@ class MolBuilderAdapter:
                     actual_smiles=route_target.smiles,
                 )
 
-        annotations: dict[str, Any] = {}
-        if route_root.best_disconnection is not None:
-            annotations["score"] = route_root.best_disconnection.score
-        return Route(target=route_target, annotations=annotations)
+        return Route(target=route_target)
 
 
 # SECTION: Helpers

--- a/tests/v2/adapters/test_dms.py
+++ b/tests/v2/adapters/test_dms.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.dms import DirectMultiStepAdapter, DMSTree
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str, target_id: str = "dms-target") -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_dms_payload() -> list[dict]:
+    return [
+        {"smiles": "CCO", "children": [{"smiles": "CC=O", "children": []}, {"smiles": "[H][H]", "children": []}]},
+        {"smiles": "CCC", "children": []},
+    ]
+
+
+@pytest.fixture
+def raw_dms_route(raw_dms_payload):
+    return raw_dms_payload[0]
+
+
+@pytest.fixture
+def raw_dms_invalid_leaf_route() -> dict:
+    return {"smiles": "CCO", "children": [{"smiles": "C", "children": []}, {"smiles": "not-smiles", "children": []}]}
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestDMSAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(self, raw_dms_payload, raw_dms_route, raw_dms_invalid_leaf_route) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=DirectMultiStepAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_dms_payload,
+                malformed_payload={"smiles": "CCO"},
+                source_key="dms-run-1",
+                expected_entry_count=2,
+                expected_source_keys=["dms-run-1", "dms-run-1"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=raw_dms_route,
+                malformed_raw_route={"children": []},
+                target=target_for("CCO"),
+                mismatched_target=Target(id="dms-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=raw_dms_invalid_leaf_route,
+                expected_pruned_root_reactants=["C"],
+            ),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_dms_iter_raw_routes_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(DirectMultiStepAdapter().iter_raw_routes({"not": "a list"}, source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_dms_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "OCC", "children": []}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DirectMultiStepAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_dms_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "C", "children": []}, {"smiles": "C", "children": []}]}
+
+    route = DirectMultiStepAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_dms_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "not-smiles", "children": []}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        DirectMultiStepAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_dms_calculates_route_length() -> None:
+    tree = DMSTree.model_validate({"smiles": "CCO", "children": [{"smiles": "CC", "children": [{"smiles": "C"}]}]})
+
+    assert DirectMultiStepAdapter.calculate_route_length(tree) == 2

--- a/tests/v2/adapters/test_molbuilder.py
+++ b/tests/v2/adapters/test_molbuilder.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.molbuilder import MolBuilderAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str, target_id: str = "molbuilder-target") -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_molbuilder_route() -> dict:
+    return {
+        "smiles": "CCO",
+        "is_purchasable": False,
+        "functional_groups": ["alcohol"],
+        "best_disconnection": {
+            "reaction_name": "Reduction",
+            "named_reaction": "NaBH4 Reduction",
+            "category": "reduction",
+            "score": 0.85,
+            "precursors": [{"smiles": "CC=O", "name": "acetaldehyde", "cost_per_kg": 15.0}],
+        },
+        "children": [{"smiles": "CC=O", "is_purchasable": True, "children": []}, {"smiles": "[H][H]", "children": []}],
+    }
+
+
+@pytest.fixture
+def raw_molbuilder_payload(raw_molbuilder_route) -> list[dict]:
+    return [raw_molbuilder_route, {"smiles": "CCC", "is_purchasable": True, "children": []}]
+
+
+@pytest.fixture
+def raw_molbuilder_invalid_leaf_route() -> dict:
+    return {
+        "smiles": "CCO",
+        "best_disconnection": {"reaction_name": "Reduction"},
+        "children": [{"smiles": "C", "children": []}, {"smiles": "not-smiles", "children": []}],
+    }
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestMolBuilderAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self,
+        raw_molbuilder_payload,
+        raw_molbuilder_route,
+        raw_molbuilder_invalid_leaf_route,
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=MolBuilderAdapter(),
+            extraction=RawExtractionContractCase(
+                valid_payload=raw_molbuilder_payload,
+                malformed_payload={"smiles": "CCO"},
+                source_key="molbuilder-run-1",
+                expected_entry_count=2,
+                expected_source_keys=["molbuilder-run-1", "molbuilder-run-1"],
+                expected_source_order=1,
+            ),
+            casting=CastContractCase(
+                valid_raw_route=raw_molbuilder_route,
+                malformed_raw_route={"children": []},
+                target=target_for("CCO"),
+                mismatched_target=Target(
+                    id="molbuilder-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")
+                ),
+                expected_root_reactant_count=2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(
+                invalid_leaf_raw_route=raw_molbuilder_invalid_leaf_route,
+                expected_pruned_root_reactants=["C"],
+            ),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_molbuilder_preserves_route_molecule_and_reaction_annotations(raw_molbuilder_route) -> None:
+    route = MolBuilderAdapter().cast(raw_molbuilder_route, target=target_for("CCO"))
+    reaction = route.reaction_at("rc:r:/").value
+
+    assert route.annotations["score"] == 0.85
+    assert route.target.annotations == {"functional_groups": ["alcohol"]}
+    assert reaction.template == "Reduction"
+    assert reaction.annotations["reaction_name"] == "Reduction"
+    assert reaction.annotations["named_reaction"] == "NaBH4 Reduction"
+    assert reaction.annotations["category"] == "reduction"
+    assert reaction.annotations["precursors"] == [{"smiles": "CC=O", "name": "acetaldehyde", "cost_per_kg": 15.0}]
+
+
+@pytest.mark.contract
+def test_molbuilder_iter_raw_routes_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(MolBuilderAdapter().iter_raw_routes({"not": "a list"}, source_key="bad"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_molbuilder_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "OCC", "children": []}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MolBuilderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_molbuilder_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "C", "children": []}, {"smiles": "C", "children": []}]}
+
+    route = MolBuilderAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_molbuilder_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {"smiles": "CCO", "children": [{"smiles": "not-smiles", "children": []}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MolBuilderAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"

--- a/tests/v2/adapters/test_molbuilder.py
+++ b/tests/v2/adapters/test_molbuilder.py
@@ -99,7 +99,7 @@ def test_molbuilder_preserves_route_molecule_and_reaction_annotations(raw_molbui
     route = MolBuilderAdapter().cast(raw_molbuilder_route, target=target_for("CCO"))
     reaction = route.reaction_at("rc:r:/").value
 
-    assert route.annotations["score"] == 0.85
+    assert route.annotations == {}
     assert route.target.annotations == {"functional_groups": ["alcohol"]}
     assert reaction.template == "Reduction"
     assert reaction.annotations["reaction_name"] == "Reduction"


### PR DESCRIPTION
why: continue the schema v2 adapter migration for providers whose raw route shape is a recursive molecule tree. DMS and MolBuilder share the same traversal semantics, so this PR adds one narrow helper rather than duplicating recursion.

what changed:
- Added v2 DirectMultiStep/DMS adapter.
- Added v2 MolBuilder adapter.
- Added `build_plain_tree_molecule(...)` for recursive molecule-tree traversal with private cycle state.
- Preserved MolBuilder route score, molecule functional groups, and disconnection metadata on v2 route/reaction annotations.
- Added adapter-boundary contract tests for extraction, casting, target mismatch, invalid SMILES pruning, cycles, duplicate leaves, and provider-specific annotations.

risk:
- Plain-tree routes do not have explicit reaction nodes. A childless molecule is treated as a leaf; if prune mode drops every child under a non-leaf molecule, the branch is pruned and the adapter raises `adapter.target_pruned` at the root.
- MolBuilder `is_purchasable` intentionally terminates traversal even if children are present, matching the legacy meaning of purchasable molecules as leaves.
- This is additive v2 adapter code; legacy adapters and workflow wiring are not changed.

verification:
- `uv run pytest tests/v2/adapters/test_dms.py tests/v2/adapters/test_molbuilder.py -q`
- `uv run pytest tests/v2/adapters -q`
- `uv run pytest tests/v2/adapters --cov=src/retrocast/v2/adapters --cov-report=term-missing -q`
- `uv run ruff check src/retrocast/v2/adapters/common.py src/retrocast/v2/adapters/dms.py src/retrocast/v2/adapters/molbuilder.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_dms.py tests/v2/adapters/test_molbuilder.py`
- `uv run ty check src/retrocast/v2/adapters/common.py src/retrocast/v2/adapters/dms.py src/retrocast/v2/adapters/molbuilder.py tests/v2/adapters/test_dms.py tests/v2/adapters/test_molbuilder.py`

follow-ups:
- MultiStepTTL, RetroChimera, SynLlama, and URSA remain for later focused PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782575686&installation_id=125602297&pr_number=106&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F106&signature=6032f36feb2e5bf29a63c3111230438e7ff73b20a9c6e71cfffea14c800ee065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds v2 adapter implementations for DirectMultiStep (DMS) and MolBuilder, both of which share a plain-tree traversal shape. Rather than duplicating the recursive traversal logic, the PR extracts `build_plain_tree_molecule` in `common.py`, following the same private-helper/`visited`-set pattern already established for precursor-map and bipartite traversals.

- `common.py`: new `build_plain_tree_molecule` / `_build_plain_tree_molecule` pair with pluggable `get_smiles`, `get_children`, `get_molecule_annotations`, and `get_reaction_fields` callbacks; the existing `build_molecule_from_precursor_map` is also split into a public/private pair to match the pattern.
- `dms.py` / `molbuilder.py`: thin adapters over the shared traversal; MolBuilder adds purchasable-leaf semantics, functional-group annotations, and disconnection metadata (`score`, `reaction_name`, `named_reaction`, `category`, `precursors`).
- Tests cover extraction, schema validation, target mismatch, cycle detection, duplicate leaves, prune-mode propagation, and provider-specific annotation preservation.

<h3>Confidence Score: 5/5</h3>

Additive-only change introducing two new adapters and a shared traversal helper; no existing adapters or workflow wiring are modified.

All core traversal paths (cycle detection, prune/strict mode, leaf vs. non-leaf, target mismatch) are covered by contract tests and the logic matches the established pattern in common.py. The only gap is a missing score assertion in one test function, which does not affect runtime correctness.

tests/v2/adapters/test_molbuilder.py — the annotation preservation test is missing the score assertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/common.py | Refactors precursor-map traversal to private helper pattern and adds build_plain_tree_molecule / _build_plain_tree_molecule for plain-tree adapters; cycle detection, prune/strict mode, and leaf/non-leaf handling all look correct. |
| src/retrocast/v2/adapters/dms.py | New DMS adapter delegating traversal to build_plain_tree_molecule; schema validation, target-mismatch check, and calculate_route_length all look correct. |
| src/retrocast/v2/adapters/molbuilder.py | New MolBuilder adapter; purchasable-leaf semantics, functional-group annotations, and disconnection fields are correctly wired. _reaction_fields stores reaction_name in both Reaction.template and annotations["reaction_name"] which is intentional per the PR description. |
| src/retrocast/v2/adapters/__init__.py | Adds DirectMultiStepAdapter and MolBuilderAdapter to the package exports correctly. |
| tests/v2/adapters/test_dms.py | Contract + unit tests for DMS covering extraction, casting, cycle detection, duplicate leaves, prune mode, and route length calculation. |
| tests/v2/adapters/test_molbuilder.py | Contract + unit tests for MolBuilder; missing assertion for reaction.annotations["score"] in the annotation preservation test despite score being unconditionally populated by _reaction_fields. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw JSON Payload] --> B["iter_raw_routes()\nValidate as RootModel list"]
    B -->|ValidationError| C[raise adapter.schema_invalid]
    B -->|ok| D[yield RawRouteEntry per tree root]
    D --> E["cast()\nValidate root as Pydantic tree node"]
    E -->|ValidationError| F[raise adapter.schema_invalid]
    E -->|ok| G["build_plain_tree_molecule()\nvisited = ∅"]
    G --> H["_build_plain_tree_molecule()\ncanonicalize SMILES"]
    H -->|InvalidSmilesError + prune| I[return None]
    H -->|InvalidSmilesError + strict| J[raise chem.invalid_smiles]
    H -->|canon in visited| K[raise adapter.cycle_detected]
    H --> L{get_children = ∅?}
    L -->|Yes — leaf| M["Molecule(smiles, inchikey, annotations)"]
    L -->|No — recurse| N[Process each child\nvisited ∪ current]
    N --> O{any reactants remain?}
    O -->|prune + none| P[return None]
    O -->|strict + none| Q[raise adapter.reaction_empty]
    O -->|some remain| R["Molecule with Reaction"]
    R --> S{target mismatch?}
    M --> S
    S -->|Yes| T[raise adapter.target_mismatch]
    S -->|No| U["Route(target=…)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/v2/adapters/test_molbuilder.py:107-108
The `score` field is unconditionally written to `reaction.annotations` in `_reaction_fields` (it's the first key set: `annotations = {"score": disconnection.score}`), but this test never asserts its value. A bug that changes the key or drops `score` would pass silently. The fixture supplies `"score": 0.85`, so the expected value is concrete and testable.

```suggestion
    assert reaction.annotations["category"] == "reduction"
    assert reaction.annotations["precursors"] == [{"smiles": "CC=O", "name": "acetaldehyde", "cost_per_kg": 15.0}]
    assert reaction.annotations["score"] == pytest.approx(0.85)
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix plain-tree adapter review issues"](https://github.com/ischemist/project-procrustes/commit/a1d68fe28abed5c7c39586922b5515e334894536) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34392954)</sub>

<!-- /greptile_comment -->