### PR TITLE
Add schema v2 precursor-map adapters

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -6,7 +6,9 @@ from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.dms import DirectMultiStepAdapter
 from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
 from retrocast.v2.adapters.molbuilder import MolBuilderAdapter
+from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
+from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
 from retrocast.v2.adapters.synplanner import SynPlannerAdapter
 from retrocast.v2.adapters.syntheseus import SyntheseusAdapter
@@ -19,8 +21,10 @@ __all__ = [
     "DirectMultiStepAdapter",
     "DreamRetroErAdapter",
     "MolBuilderAdapter",
+    "MultiStepTTLAdapter",
     "PaRoutesAdapter",
     "RawRouteEntry",
+    "RetroChimeraAdapter",
     "RetroStarAdapter",
     "SynPlannerAdapter",
     "SyntheseusAdapter",

--- a/src/retrocast/v2/adapters/multistepttl.py
+++ b/src/retrocast/v2/adapters/multistepttl.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import BaseModel, Field, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Molecule, Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw MultiStepTTL Schema
+
+
+class TtlReaction(BaseModel):
+    product: str
+    reactants: list[str]
+
+
+class TtlRoute(BaseModel):
+    reactions: list[TtlReaction]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TtlRouteList(RootModel[list[TtlRoute]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class MultiStepTTLAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = TtlRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("multistepttl", target_id, "invalid pre-processed route list") from exc
+        for source_order, route in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route, source_key=source_key, source_order=source_order)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route = TtlRoute.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("multistepttl", target_id, "invalid route") from exc
+
+        if not route.reactions:
+            if target is None:
+                raise AdapterLogicError(
+                    "MultiStepTTL zero-reaction route needs a target",
+                    code="adapter.route_transform_failed",
+                    context={"adapter": "multistepttl", "target_id": target_id},
+                )
+            target_smiles = canonicalize_smiles(target.smiles)
+            return Route(
+                target=Molecule(smiles=target_smiles, inchikey=get_inchi_key(target_smiles)),
+                annotations=route.metadata,
+            )
+
+        root_smiles = canonicalize_smiles(route.reactions[0].product)
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if root_smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "multistepttl", target.id, expected_smiles=expected_smiles, actual_smiles=root_smiles
+                )
+        precursor_map = {canonicalize_smiles(reaction.product): reaction.reactants for reaction in route.reactions}
+        route_target = build_molecule_from_precursor_map(root_smiles, precursor_map, adapter="multistepttl", mode=mode)
+        if route_target is None:
+            raise AdapterLogicError(
+                "MultiStepTTL target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "multistepttl", "target_id": target_id},
+            )
+        return Route(target=route_target, annotations=route.metadata)

--- a/src/retrocast/v2/adapters/multistepttl.py
+++ b/src/retrocast/v2/adapters/multistepttl.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, RootModel, ValidationError
 
 from retrocast.adapters.errors import adapter_schema_error, adapter_target_mismatch
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.common import build_molecule_from_precursor_map
 from retrocast.v2.models.route import Molecule, Route
@@ -63,14 +63,31 @@ class MultiStepTTLAdapter:
                 annotations=route.metadata,
             )
 
-        root_smiles = canonicalize_smiles(route.reactions[0].product)
+        try:
+            root_smiles = canonicalize_smiles(route.reactions[0].product)
+        except InvalidSmilesError:
+            if mode == "prune":
+                raise AdapterLogicError(
+                    "MultiStepTTL target molecule was pruned",
+                    code="adapter.target_pruned",
+                    context={"adapter": "multistepttl", "target_id": target_id},
+                ) from None
+            raise
         if target is not None:
             expected_smiles = canonicalize_smiles(target.smiles)
             if root_smiles != expected_smiles:
                 raise adapter_target_mismatch(
                     "multistepttl", target.id, expected_smiles=expected_smiles, actual_smiles=root_smiles
                 )
-        precursor_map = {canonicalize_smiles(reaction.product): reaction.reactants for reaction in route.reactions}
+        precursor_map = {}
+        for reaction in route.reactions:
+            try:
+                product_smiles = canonicalize_smiles(reaction.product)
+            except InvalidSmilesError:
+                if mode == "strict":
+                    raise
+                continue
+            precursor_map[product_smiles] = reaction.reactants
         route_target = build_molecule_from_precursor_map(root_smiles, precursor_map, adapter="multistepttl", mode=mode)
         if route_target is None:
             raise AdapterLogicError(

--- a/src/retrocast/v2/adapters/retrochimera.py
+++ b/src/retrocast/v2/adapters/retrochimera.py
@@ -13,7 +13,7 @@ from retrocast.adapters.errors import (
     adapter_target_mismatch,
 )
 from retrocast.chem import canonicalize_smiles
-from retrocast.exceptions import AdapterLogicError
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.v2.adapters.common import build_molecule_from_precursor_map
 from retrocast.v2.models.route import Route
@@ -109,7 +109,16 @@ class RetroChimeraAdapter:
         target_id = target.id if target is not None else "<unknown>"
         if not isinstance(raw_route, RetrochimeraRoutePayload):
             raise adapter_schema_error("retrochimera", target_id, "expected a retrochimera route payload")
-        root_smiles = canonicalize_smiles(raw_route.target_smiles)
+        try:
+            root_smiles = canonicalize_smiles(raw_route.target_smiles)
+        except InvalidSmilesError:
+            if mode == "prune":
+                raise AdapterLogicError(
+                    "RetroChimera target molecule was pruned",
+                    code="adapter.target_pruned",
+                    context={"adapter": "retrochimera", "target_id": target_id},
+                ) from None
+            raise
         if target is not None:
             expected_smiles = canonicalize_smiles(target.smiles)
             if root_smiles != expected_smiles:
@@ -119,13 +128,17 @@ class RetroChimeraAdapter:
                     expected_smiles=expected_smiles,
                     actual_smiles=root_smiles,
                 )
-        precursor_map = {
-            canonicalize_smiles(reaction.product): reaction.reactants for reaction in raw_route.route.reactions
-        }
-        reaction_annotations = {
-            canonicalize_smiles(reaction.product): {"probability": reaction.probability, **reaction.metadata}
-            for reaction in raw_route.route.reactions
-        }
+        precursor_map = {}
+        reaction_annotations = {}
+        for reaction in raw_route.route.reactions:
+            try:
+                product_smiles = canonicalize_smiles(reaction.product)
+            except InvalidSmilesError:
+                if mode == "strict":
+                    raise
+                continue
+            precursor_map[product_smiles] = reaction.reactants
+            reaction_annotations[product_smiles] = {"probability": reaction.probability, **reaction.metadata}
         route_target = build_molecule_from_precursor_map(
             root_smiles,
             precursor_map,

--- a/src/retrocast/v2/adapters/retrochimera.py
+++ b/src/retrocast/v2/adapters/retrochimera.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+from retrocast.adapters.errors import (
+    adapter_route_transform_error,
+    adapter_schema_error,
+    adapter_target_mismatch,
+)
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw RetroChimera Schema
+
+
+@dataclass(frozen=True, slots=True)
+class RetrochimeraRoutePayload:
+    route: RetrochimeraRoute
+    target_smiles: str
+    annotations: tuple[tuple[str, Any], ...]
+
+    def route_annotations(self) -> dict[str, Any]:
+        return dict(self.annotations)
+
+
+class RetrochimeraReaction(BaseModel):
+    reactants: list[str]
+    product: str
+    probability: float
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RetrochimeraRoute(BaseModel):
+    reactions: list[RetrochimeraReaction]
+    num_steps: int
+    step_probability_min: float
+    step_probability_product: float
+
+
+class RetrochimeraOutput(BaseModel):
+    routes: list[RetrochimeraRoute]
+    num_routes: int
+    num_routes_initial_extraction: int = 0
+    target_is_purchasable: bool = False
+    num_model_calls_total: int = 0
+    num_model_calls_new: int = 0
+    num_model_calls_cached: int = 0
+    num_nodes_explored: int = 0
+    time_taken_s_search: float = 0.0
+    time_taken_s_extraction: float = 0.0
+
+
+class RetrochimeraResult(BaseModel):
+    request: dict[str, Any] | None = None
+    outputs: list[RetrochimeraOutput] | None = None
+    error: dict[str, Any] | None = None
+    time_taken_s: float = 0.0
+
+
+class RetrochimeraData(BaseModel):
+    smiles: str
+    result: RetrochimeraResult
+
+
+# SECTION: Adapter
+
+
+class RetroChimeraAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            data = RetrochimeraData.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("retrochimera", target_id, "invalid output") from exc
+        if data.result.error is not None:
+            error_type = data.result.error.get("type", "unknown")
+            error_msg = data.result.error.get("message", "unknown error")
+            raise adapter_route_transform_error("retrochimera", target_id, f"model reported {error_type}: {error_msg}")
+        if data.result.outputs is None:
+            raise adapter_route_transform_error(
+                "retrochimera", target_id, "validated payload is missing result outputs"
+            )
+
+        source_order = 1
+        for output in data.result.outputs:
+            annotations = output.model_dump(exclude={"routes"})
+            for route in output.routes:
+                yield RawRouteEntry(
+                    payload=RetrochimeraRoutePayload(
+                        route=route.model_copy(deep=True),
+                        target_smiles=data.smiles,
+                        annotations=tuple((key, deepcopy(value)) for key, value in annotations.items()),
+                    ),
+                    source_key=source_key,
+                    source_order=source_order,
+                )
+                source_order += 1
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        if not isinstance(raw_route, RetrochimeraRoutePayload):
+            raise adapter_schema_error("retrochimera", target_id, "expected a retrochimera route payload")
+        root_smiles = canonicalize_smiles(raw_route.target_smiles)
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if root_smiles != expected_smiles:
+                raise adapter_target_mismatch(
+                    "retrochimera",
+                    target.id,
+                    expected_smiles=expected_smiles,
+                    actual_smiles=root_smiles,
+                )
+        precursor_map = {
+            canonicalize_smiles(reaction.product): reaction.reactants for reaction in raw_route.route.reactions
+        }
+        reaction_annotations = {
+            canonicalize_smiles(reaction.product): {"probability": reaction.probability, **reaction.metadata}
+            for reaction in raw_route.route.reactions
+        }
+        route_target = build_molecule_from_precursor_map(
+            root_smiles,
+            precursor_map,
+            adapter="retrochimera",
+            mode=mode,
+            reaction_annotations=reaction_annotations,
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "RetroChimera target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "retrochimera", "target_id": target_id},
+            )
+        return Route(target=route_target, annotations=raw_route.route_annotations())

--- a/tests/v2/adapters/test_multistepttl.py
+++ b/tests/v2/adapters/test_multistepttl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
 from retrocast.v2.models.task import Target
@@ -123,3 +123,52 @@ def test_multistepttl_prune_rejects_route_when_all_reactants_are_invalid() -> No
         MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
 
     assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_multistepttl_strict_rejects_invalid_root_product_smiles() -> None:
+    raw_route = {"reactions": [{"product": "not-smiles", "reactants": ["C"]}]}
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_multistepttl_prune_rejects_invalid_root_product_smiles() -> None:
+    raw_route = {"reactions": [{"product": "not-smiles", "reactants": ["C"]}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_multistepttl_strict_rejects_invalid_intermediate_product_smiles() -> None:
+    raw_route = {
+        "reactions": [
+            {"product": "CCO", "reactants": ["C", "not-smiles"]},
+            {"product": "not-smiles", "reactants": ["C"]},
+        ]
+    }
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"), mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_multistepttl_prune_skips_invalid_intermediate_product_smiles() -> None:
+    raw_route = {
+        "reactions": [
+            {"product": "CCO", "reactants": ["C", "not-smiles"]},
+            {"product": "not-smiles", "reactants": ["C"]},
+        ]
+    }
+
+    route = MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]

--- a/tests/v2/adapters/test_multistepttl.py
+++ b/tests/v2/adapters/test_multistepttl.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="ttl-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_ttl_route() -> dict:
+    return {"reactions": [{"product": "CCO", "reactants": ["C", "CC"]}], "metadata": {"score": 0.7}}
+
+
+@pytest.fixture
+def raw_ttl_payload(raw_ttl_route) -> list[dict]:
+    return [raw_ttl_route, {"reactions": [], "metadata": {}}]
+
+
+@pytest.fixture
+def raw_ttl_invalid_leaf_route() -> dict:
+    return {"reactions": [{"product": "CCO", "reactants": ["C", "not-smiles"]}], "metadata": {}}
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestMultiStepTTLAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(self, raw_ttl_payload, raw_ttl_route, raw_ttl_invalid_leaf_route) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=MultiStepTTLAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_ttl_payload, {"reactions": "bad"}, "ttl-run", 2, ["ttl-run", "ttl-run"], 1
+            ),
+            casting=CastContractCase(
+                raw_ttl_route,
+                {"metadata": {}},
+                target_for("CCO"),
+                Target(id="ttl-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(raw_ttl_invalid_leaf_route, ["C"]),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_multistepttl_preserves_route_metadata(raw_ttl_route) -> None:
+    route = MultiStepTTLAdapter().cast(raw_ttl_route, target=target_for("CCO"))
+    assert route.annotations == {"score": 0.7}
+
+
+@pytest.mark.contract
+def test_multistepttl_accepts_zero_reaction_route_with_target() -> None:
+    route = MultiStepTTLAdapter().cast({"reactions": [], "metadata": {"rank": 1}}, target=target_for("CCO"))
+    assert route.target.product_of is None
+    assert route.annotations == {"rank": 1}
+
+
+@pytest.mark.contract
+def test_multistepttl_rejects_zero_reaction_route_without_target() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MultiStepTTLAdapter().cast({"reactions": []})
+    assert exc_info.value.code == "adapter.route_transform_failed"
+
+
+@pytest.mark.contract
+def test_multistepttl_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(MultiStepTTLAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_multistepttl_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {"reactions": [{"product": "CCO", "reactants": ["C"]}, {"product": "C", "reactants": ["OCC"]}]}
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_multistepttl_allows_duplicate_leaf_molecules() -> None:
+    raw_route = {"reactions": [{"product": "CCO", "reactants": ["C", "C"]}]}
+    route = MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]
+
+
+@pytest.mark.contract
+def test_multistepttl_rejects_empty_reaction_in_strict_mode() -> None:
+    raw_route = {"reactions": [{"product": "CCO", "reactants": []}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
+def test_multistepttl_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    raw_route = {"reactions": [{"product": "CCO", "reactants": ["not-smiles"]}]}
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        MultiStepTTLAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"

--- a/tests/v2/adapters/test_retrochimera.py
+++ b/tests/v2/adapters/test_retrochimera.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
 from retrocast.typing import SmilesStr
 from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
 from retrocast.v2.models.task import Target
@@ -187,6 +187,67 @@ def test_retrochimera_prune_rejects_route_when_all_reactants_are_invalid() -> No
         RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
 
     assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_retrochimera_strict_rejects_invalid_target_smiles(raw_retrochimera_route) -> None:
+    raw_payload = raw_output(raw_retrochimera_route)
+    raw_payload["smiles"] = "not-smiles"
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_retrochimera_prune_rejects_invalid_target_smiles(raw_retrochimera_route) -> None:
+    raw_payload = raw_output(raw_retrochimera_route)
+    raw_payload["smiles"] = "not-smiles"
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_payload)).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_retrochimera_strict_rejects_invalid_intermediate_product_smiles() -> None:
+    route = {
+        "reactions": [
+            {"product": "CCO", "reactants": ["C", "not-smiles"], "probability": 0.8},
+            {"product": "not-smiles", "reactants": ["C"], "probability": 0.7},
+        ],
+        "num_steps": 2,
+        "step_probability_min": 0.7,
+        "step_probability_product": 0.56,
+    }
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"), mode="strict")
+
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_retrochimera_prune_skips_invalid_intermediate_product_smiles() -> None:
+    route = {
+        "reactions": [
+            {"product": "CCO", "reactants": ["C", "not-smiles"], "probability": 0.8},
+            {"product": "not-smiles", "reactants": ["C"], "probability": 0.7},
+        ],
+        "num_steps": 2,
+        "step_probability_min": 0.7,
+        "step_probability_product": 0.56,
+    }
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+
+    route = RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_retrochimera.py
+++ b/tests/v2/adapters/test_retrochimera.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+# SECTION: Fixtures
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="retrochimera-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+def raw_output(route: dict) -> dict:
+    return {
+        "smiles": "CCO",
+        "result": {
+            "outputs": [
+                {
+                    "routes": [route, route],
+                    "num_routes": 2,
+                    "num_nodes_explored": 5,
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def raw_retrochimera_route() -> dict:
+    return {
+        "reactions": [{"product": "CCO", "reactants": ["C", "CC"], "probability": 0.8, "metadata": {"model": "x"}}],
+        "num_steps": 1,
+        "step_probability_min": 0.8,
+        "step_probability_product": 0.8,
+    }
+
+
+@pytest.fixture
+def raw_retrochimera_payload(raw_retrochimera_route) -> dict:
+    return raw_output(raw_retrochimera_route)
+
+
+@pytest.fixture
+def retrochimera_route_payload(raw_retrochimera_payload):
+    return next(RetroChimeraAdapter().iter_raw_routes(raw_retrochimera_payload, source_key="retrochimera-run")).payload
+
+
+@pytest.fixture
+def retrochimera_invalid_leaf_payload():
+    route = {
+        "reactions": [{"product": "CCO", "reactants": ["C", "not-smiles"], "probability": 0.8}],
+        "num_steps": 1,
+        "step_probability_min": 0.8,
+        "step_probability_product": 0.8,
+    }
+    return next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+
+
+# SECTION: Shared Contract Suite
+
+
+class TestRetroChimeraAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_retrochimera_payload, retrochimera_route_payload, retrochimera_invalid_leaf_payload
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=RetroChimeraAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_retrochimera_payload,
+                {"result": {}},
+                "retrochimera-run",
+                2,
+                ["retrochimera-run", "retrochimera-run"],
+                1,
+            ),
+            casting=CastContractCase(
+                retrochimera_route_payload,
+                {"not": "payload"},
+                target_for("CCO"),
+                Target(id="retrochimera-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(retrochimera_invalid_leaf_payload, ["C"]),
+        )
+
+
+# SECTION: Contract Tests
+
+
+@pytest.mark.contract
+def test_retrochimera_preserves_output_and_reaction_annotations(retrochimera_route_payload) -> None:
+    route = RetroChimeraAdapter().cast(retrochimera_route_payload, target=target_for("CCO"))
+    assert route.annotations["num_routes"] == 2
+    assert route.annotations["num_nodes_explored"] == 5
+    assert route.reaction_at("rc:r:/").value.annotations == {"probability": 0.8, "model": "x"}
+
+
+@pytest.mark.contract
+def test_retrochimera_payload_annotations_are_immutable_and_private(raw_retrochimera_payload) -> None:
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_retrochimera_payload)).payload
+    raw_retrochimera_payload["result"]["outputs"][0]["num_nodes_explored"] = 999
+
+    with pytest.raises(AttributeError):
+        raw_route.annotations = ()
+
+    route = RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert route.annotations["num_nodes_explored"] == 5
+
+
+@pytest.mark.contract
+def test_retrochimera_rejects_model_error() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        list(
+            RetroChimeraAdapter().iter_raw_routes(
+                {"smiles": "CCO", "result": {"error": {"type": "boom", "message": "bad"}}}
+            )
+        )
+    assert exc_info.value.code == "adapter.route_transform_failed"
+
+
+@pytest.mark.contract
+def test_retrochimera_rejects_missing_outputs() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        list(RetroChimeraAdapter().iter_raw_routes({"smiles": "CCO", "result": {}}))
+    assert exc_info.value.code == "adapter.route_transform_failed"
+
+
+@pytest.mark.contract
+def test_retrochimera_rejects_cycles_after_canonicalization() -> None:
+    route = {
+        "reactions": [
+            {"product": "CCO", "reactants": ["C"], "probability": 0.8},
+            {"product": "C", "reactants": ["OCC"], "probability": 0.8},
+        ],
+        "num_steps": 2,
+        "step_probability_min": 0.8,
+        "step_probability_product": 0.64,
+    }
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_retrochimera_rejects_empty_reaction_in_strict_mode() -> None:
+    route = {
+        "reactions": [{"product": "CCO", "reactants": [], "probability": 0.8}],
+        "num_steps": 1,
+        "step_probability_min": 0.8,
+        "step_probability_product": 0.8,
+    }
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"))
+
+    assert exc_info.value.code == "adapter.reaction_empty"
+
+
+@pytest.mark.contract
+def test_retrochimera_prune_rejects_route_when_all_reactants_are_invalid() -> None:
+    route = {
+        "reactions": [{"product": "CCO", "reactants": ["not-smiles"], "probability": 0.8}],
+        "num_steps": 1,
+        "step_probability_min": 0.8,
+        "step_probability_product": 0.8,
+    }
+    raw_route = next(RetroChimeraAdapter().iter_raw_routes(raw_output(route))).payload
+
+    with pytest.raises(AdapterLogicError) as exc_info:
+        RetroChimeraAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_retrochimera_iter_raw_routes_rejects_malformed_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(RetroChimeraAdapter().iter_raw_routes({"result": {}}))
+    assert exc_info.value.code == "adapter.schema_invalid"


### PR DESCRIPTION
why: continue the schema v2 adapter migration for providers whose raw route shape can be normalized to product -> reactants precursor maps. MultiStepTTL and RetroChimera both fit the existing traversal helper, so this PR adds adapters without introducing new shared traversal code.

what changed:
- Added v2 MultiStepTTL adapter.
- Added v2 RetroChimera adapter.
- Exported both adapters from `retrocast.v2.adapters`.
- Preserved MultiStepTTL route metadata and RetroChimera run/reaction annotations.
- Added adapter-boundary contract tests for extraction, casting, target mismatch, invalid SMILES pruning, cycles, duplicate leaves, empty reactions, target pruning, zero-reaction TTL routes, RetroChimera model errors, and RetroChimera payload immutability/private backing.

risk:
- MultiStepTTL zero-reaction routes require an explicit target because the raw route has no product to infer.
- RetroChimera model-reported errors are surfaced as adapter transform errors before route extraction.
- This is additive v2 adapter code; legacy adapters and workflow wiring are not changed.

verification:
- `uv run pytest tests/v2/adapters/test_multistepttl.py tests/v2/adapters/test_retrochimera.py -q`
- `uv run pytest tests/v2/adapters -q`
- `uv run pytest tests/v2/adapters --cov=src/retrocast/v2/adapters --cov-report=term-missing -q`
- `uv run ruff check src/retrocast/v2/adapters/multistepttl.py src/retrocast/v2/adapters/retrochimera.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_multistepttl.py tests/v2/adapters/test_retrochimera.py`
- `uv run ty check src/retrocast/v2/adapters/multistepttl.py src/retrocast/v2/adapters/retrochimera.py tests/v2/adapters/test_multistepttl.py tests/v2/adapters/test_retrochimera.py`

follow-ups:
- SynLlama and URSA remain for later focused PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782576838&installation_id=125602297&pr_number=107&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F107&signature=72d18ec98e64139f2941ec3a1bd0e9cefd56f11341da0b9c53c1c6277f11f2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MultiStepTTL adapter for processing multi-step routes with reaction sequences and metadata.
  * Added RetroChimera adapter for converting RetroChimera model outputs into route objects.
  * Both adapters support strict and prune error-handling modes for flexible route processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new v2 schema adapters — `MultiStepTTLAdapter` and `RetroChimeraAdapter` — both of which normalize their provider's raw flat reaction list into a product→reactants precursor map and delegate tree construction to the existing `build_molecule_from_precursor_map` helper.

- `MultiStepTTLAdapter` infers the route root from `reactions[0].product`, requires an explicit `target` for zero-reaction routes, and preserves route-level metadata as `Route.annotations`.
- `RetroChimeraAdapter` embeds the target SMILES in an immutable frozen-dataclass payload (`RetrochimeraRoutePayload`) built during `iter_raw_routes`, surfaces model-reported errors before route extraction, and stores per-reaction `probability`/`metadata` as reaction annotations.
- Both adapters are exported from `retrocast.v2.adapters` and backed by adapter-boundary contract tests covering extraction, casting, strict/prune SMILES handling, cycles, duplicates, and annotation preservation.

<h3>Confidence Score: 5/5</h3>

Additive-only change that wires two new providers into the established adapter contract; no existing code is modified.

Both adapters follow the same validated patterns used by existing adapters, delegate to the well-tested shared traversal helper, and are covered by thorough contract test suites. The only gap is that duplicate canonical product SMILES within a single route silently overwrites earlier entries rather than raising, but valid retrosynthesis output from either provider never produces such routes in practice.

The precursor-map building loops in multistepttl.py and retrochimera.py — specifically the absence of a duplicate-product guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/__init__.py | Alphabetically exports MultiStepTTLAdapter and RetroChimeraAdapter alongside existing adapters; no issues. |
| src/retrocast/v2/adapters/multistepttl.py | New adapter that converts a flat list of reactions to a precursor-map and delegates to the shared traversal helper; duplicate product SMILES entries in a single route are silently overwritten. |
| src/retrocast/v2/adapters/retrochimera.py | New adapter with immutable frozen-dataclass payload; model errors are surfaced early, target SMILES carried in payload rather than inferred from reactions; same silent-overwrite risk on duplicate product SMILES as the MultiStepTTL adapter. |
| tests/v2/adapters/test_multistepttl.py | Thorough contract test suite covering zero-reaction, cycles, duplicates, prune/strict, and metadata preservation. |
| tests/v2/adapters/test_retrochimera.py | Comprehensive tests including immutability verification, model-error surfacing, annotation preservation, and target SMILES isolation; no issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw payload] --> B[iter_raw_routes]
    B --> C{Schema valid?}
    C -- No --> D[AdapterSchemaError]
    C -- Yes --> E[Yield RawRouteEntry]
    E --> F[cast]
    F --> G{RetroChimera?}
    G -- Yes --> H{isinstance RetrochimeraRoutePayload?}
    H -- No --> D2[AdapterSchemaError]
    H -- Yes --> I[canonicalize target_smiles from payload]
    G -- No MultiStepTTL --> J{reactions empty?}
    J -- Yes no target --> K[AdapterLogicError: needs target]
    J -- Yes target provided --> L[Return leaf Route]
    J -- No --> M[canonicalize reactions-0 product as root]
    I --> N[Target mismatch check]
    M --> N
    N -- mismatch --> O[AdapterLogicError: target_mismatch]
    N -- OK --> P[Build precursor_map loop]
    P --> T[build_molecule_from_precursor_map]
    T --> U{route_target nil?}
    U -- Yes --> V[AdapterLogicError: target_pruned]
    U -- No --> W[Return Route]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/retrocast/v2/adapters/multistepttl.py:90-91
Duplicate product SMILES silently overwrites earlier entries in `precursor_map`. If a provider sends two reactions whose products canonicalize to the same SMILES, only the last reactant set is retained and the earlier decomposition path is lost without any error. The same pattern exists in `retrochimera.py`. A duplicate guard would either surface the anomaly or make the "last-wins" choice explicit.

```suggestion
            if product_smiles in precursor_map:
                raise AdapterLogicError(
                    "MultiStepTTL route contains duplicate product SMILES",
                    code="adapter.duplicate_product",
                    context={"adapter": "multistepttl", "smiles": product_smiles, "target_id": target_id},
                )
            precursor_map[product_smiles] = reaction.reactants
        route_target = build_molecule_from_precursor_map(root_smiles, precursor_map, adapter="multistepttl", mode=mode)
```

### Issue 2 of 2
src/retrocast/v2/adapters/retrochimera.py:140-141
Same silent overwrite of duplicate product SMILES as in the MultiStepTTL adapter: if two reactions in a RetroChimera route resolve to the same canonical product, the second entry wins for both `precursor_map` and `reaction_annotations`, and the first decomposition path is lost without any error or warning.

```suggestion
            if product_smiles in precursor_map:
                raise AdapterLogicError(
                    "RetroChimera route contains duplicate product SMILES",
                    code="adapter.duplicate_product",
                    context={"adapter": "retrochimera", "smiles": product_smiles, "target_id": target_id},
                )
            precursor_map[product_smiles] = reaction.reactants
            reaction_annotations[product_smiles] = {"probability": reaction.probability, **reaction.metadata}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix precursor-map product pruning"](https://github.com/ischemist/project-procrustes/commit/e1c76fba430dc0de8b764529a8d8e39daae74689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34396799)</sub>

<!-- /greptile_comment -->