### PR TITLE
Add schema v2 SynLlama and URSA adapters

### DIFF
--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -10,8 +10,10 @@ from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
 from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
+from retrocast.v2.adapters.synllama import SynLlamaAdapter
 from retrocast.v2.adapters.synplanner import SynPlannerAdapter
 from retrocast.v2.adapters.syntheseus import SyntheseusAdapter
+from retrocast.v2.adapters.ursa import UrsaAdapter
 
 __all__ = [
     "Adapter",
@@ -26,6 +28,8 @@ __all__ = [
     "RawRouteEntry",
     "RetroChimeraAdapter",
     "RetroStarAdapter",
+    "SynLlamaAdapter",
     "SynPlannerAdapter",
     "SyntheseusAdapter",
+    "UrsaAdapter",
 ]

--- a/src/retrocast/v2/adapters/synllama.py
+++ b/src/retrocast/v2/adapters/synllama.py
@@ -94,6 +94,7 @@ class SynLlamaAdapter:
             except InvalidSmilesError:
                 if mode == "strict":
                     raise
+                last_product_smiles = None
                 reactant_start = product_index + 1
                 continue
             reactants = parts[reactant_start:template_index]

--- a/src/retrocast/v2/adapters/synllama.py
+++ b/src/retrocast/v2/adapters/synllama.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import BaseModel, RootModel, ValidationError
+
+from retrocast.adapters.errors import adapter_route_string_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: Raw SynLlama Schema
+
+
+class SynLlamaRouteInput(BaseModel):
+    synthesis_string: str
+
+
+class SynLlamaRouteList(RootModel[list[SynLlamaRouteInput]]):
+    pass
+
+
+# SECTION: Adapter
+
+
+class SynLlamaAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        try:
+            routes = SynLlamaRouteList.model_validate(raw_payload)
+        except ValidationError as exc:
+            raise adapter_schema_error("synllama", target_id, "invalid route list") from exc
+        for source_order, route in enumerate(routes.root, start=1):
+            yield RawRouteEntry(payload=route, source_key=source_key, source_order=source_order)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        target_id = target.id if target is not None else "<unknown>"
+        try:
+            route = SynLlamaRouteInput.model_validate(raw_route)
+        except ValidationError as exc:
+            raise adapter_schema_error("synllama", target_id, "invalid route") from exc
+        parts = [part.strip() for part in route.synthesis_string.split(";") if part.strip()]
+        if not parts:
+            raise adapter_route_string_error("synllama", "empty synthesis string", empty=True)
+        try:
+            parsed_target = canonicalize_smiles(parts[-1])
+        except InvalidSmilesError:
+            if mode == "prune":
+                raise AdapterLogicError(
+                    "SynLlama target molecule was pruned",
+                    code="adapter.target_pruned",
+                    context={"adapter": "synllama", "target_id": target_id},
+                ) from None
+            raise
+        if target is not None:
+            expected_smiles = canonicalize_smiles(target.smiles)
+            if parsed_target != expected_smiles:
+                raise adapter_target_mismatch(
+                    "synllama", target.id, expected_smiles=expected_smiles, actual_smiles=parsed_target
+                )
+        precursor_map = self._parse_synthesis_string(route.synthesis_string, mode=mode)
+        route_target = build_molecule_from_precursor_map(parsed_target, precursor_map, adapter="synllama", mode=mode)
+        if route_target is None:
+            raise AdapterLogicError(
+                "SynLlama target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": "synllama", "target_id": target_id},
+            )
+        return Route(target=route_target)
+
+    def _parse_synthesis_string(self, synthesis_str: str, *, mode: AdaptMode = "strict") -> dict[SmilesStr, list[str]]:
+        parts = [part.strip() for part in synthesis_str.split(";") if part.strip()]
+        if not parts:
+            raise adapter_route_string_error("synllama", "empty synthesis string", empty=True)
+
+        template_indices = [index for index, part in enumerate(parts) if part.startswith("R") and part[1:].isdigit()]
+        if not template_indices:
+            return {}
+
+        precursor_map: dict[SmilesStr, list[str]] = {}
+        last_product_smiles: SmilesStr | None = None
+        reactant_start = 0
+        for template_index in template_indices:
+            product_index = template_index + 1
+            if product_index >= len(parts):
+                raise adapter_route_string_error("synllama", "template has no product", fragment=parts[template_index])
+            try:
+                product_smiles = canonicalize_smiles(parts[product_index])
+            except InvalidSmilesError:
+                if mode == "strict":
+                    raise
+                reactant_start = product_index + 1
+                continue
+            reactants = parts[reactant_start:template_index]
+            if last_product_smiles is not None:
+                reactants.append(last_product_smiles)
+            if not reactants:
+                raise adapter_route_string_error(
+                    "synllama", "no reactants found for product", fragment=parts[product_index]
+                )
+            precursor_map[product_smiles] = reactants
+            last_product_smiles = product_smiles
+            reactant_start = product_index + 1
+        return precursor_map

--- a/src/retrocast/v2/adapters/ursa.py
+++ b/src/retrocast/v2/adapters/ursa.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from typing import Any, cast
+
+from retrocast.adapters.errors import adapter_route_transform_error, adapter_schema_error, adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles
+from retrocast.exceptions import AdapterLogicError, InvalidSmilesError, RetroCastException
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_molecule_from_precursor_map
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+# SECTION: URSA Completion Parsing
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
+_SYNTHESIS_STEP_RE = re.compile(r"<synthesis_step>(.*?)</synthesis_step>", re.DOTALL)
+_PRODUCT_RE = re.compile(r"<product>(.*?)</product>", re.DOTALL)
+_REACTANT_RE = re.compile(r"<reactant>(.*?)</reactant>", re.DOTALL)
+_SMILES_RE = re.compile(r"<smiles>(.*?)</smiles>", re.DOTALL)
+_SM_TOKEN_RE = re.compile(r"<sm_([^>]+)>")
+
+
+# SECTION: Adapter
+
+
+class UrsaAdapter:
+    adapter_key = "ursa"
+
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        target_id = source_key or "<unknown>"
+        if not isinstance(raw_payload, list):
+            raise adapter_schema_error(self.adapter_key, target_id, "expected a list of completion records")
+        for row_index, raw_record in enumerate(raw_payload, start=1):
+            if not isinstance(raw_record, dict):
+                raise adapter_schema_error(
+                    self.adapter_key,
+                    target_id,
+                    "each completion record must be a dict with a string 'completion' field",
+                    record_index=row_index - 1,
+                )
+            raw_record = cast("dict[str, Any]", raw_record)
+            if not isinstance(raw_record.get("completion"), str):
+                raise adapter_schema_error(
+                    self.adapter_key,
+                    target_id,
+                    "each completion record must be a dict with a string 'completion' field",
+                    record_index=row_index - 1,
+                )
+            target_hint_smiles = _extract_target_hint(
+                raw_record, self.adapter_key, target_id, row_index - 1, source_key
+            )
+            yield RawRouteEntry(
+                payload=raw_record["completion"],
+                source_key=source_key,
+                source_row_index=row_index,
+                target_hint_smiles=target_hint_smiles,
+                source_order=row_index,
+            )
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        if not isinstance(raw_route, str):
+            raise adapter_schema_error(
+                self.adapter_key, target.id if target is not None else "<unknown>", "expected completion text"
+            )
+        if target is None:
+            raise adapter_route_transform_error(self.adapter_key, "<unknown>", "ursa llm adaptation requires a target")
+
+        expected_smiles = canonicalize_smiles(target.smiles)
+        precursor_map = self._parse_completion(raw_route, mode=mode)
+        if expected_smiles not in precursor_map:
+            raise adapter_target_mismatch(
+                self.adapter_key,
+                target.id,
+                expected_smiles=expected_smiles,
+                actual_smiles=f"missing:{expected_smiles}",
+            )
+        route_target = build_molecule_from_precursor_map(
+            expected_smiles, precursor_map, adapter=self.adapter_key, mode=mode
+        )
+        if route_target is None:
+            raise AdapterLogicError(
+                "URSA target molecule was pruned",
+                code="adapter.target_pruned",
+                context={"adapter": self.adapter_key, "target_id": target.id},
+            )
+        return Route(target=route_target)
+
+    def _parse_completion(self, completion: str, *, mode: AdaptMode) -> dict[SmilesStr, list[str]]:
+        cleaned = _THINK_BLOCK_RE.sub("", completion)
+        precursor_map: dict[SmilesStr, list[str]] = {}
+        for step_text in _SYNTHESIS_STEP_RE.findall(cleaned):
+            product_match = _PRODUCT_RE.search(step_text)
+            if product_match is None:
+                continue
+            product_raw = _extract_smiles(product_match.group(1))
+            if product_raw is None:
+                continue
+            try:
+                product_smiles = canonicalize_smiles(product_raw)
+            except InvalidSmilesError:
+                if mode == "strict":
+                    raise
+                continue
+            reactants = [_extract_smiles(block) for block in _REACTANT_RE.findall(step_text)]
+            valid_reactants = [reactant for reactant in reactants if reactant]
+            if valid_reactants:
+                precursor_map[product_smiles] = valid_reactants
+        return precursor_map
+
+
+# SECTION: Raw Helpers
+
+
+def _extract_smiles(block: str) -> str | None:
+    match = _SMILES_RE.search(block)
+    if match is None:
+        return None
+    inner = match.group(1).strip()
+    if "<sm_" in inner:
+        tokens = _SM_TOKEN_RE.findall(inner)
+        return "".join(tokens) if tokens else None
+    return inner or None
+
+
+def _extract_target_hint(
+    raw_record: dict[str, Any],
+    adapter_key: str,
+    target_id: str,
+    record_index: int,
+    source_key: str | None,
+) -> str | None:
+    meta = raw_record.get("meta")
+    if not isinstance(meta, dict) or not isinstance(meta.get("product_smiles"), str):
+        if source_key is None:
+            raise adapter_schema_error(
+                adapter_key,
+                target_id,
+                "completion records must include meta.product_smiles",
+                record_index=record_index,
+            )
+        return None
+    try:
+        return canonicalize_smiles(meta["product_smiles"])
+    except RetroCastException as exc:
+        raise adapter_schema_error(
+            adapter_key,
+            target_id,
+            "completion record has invalid meta.product_smiles",
+            record_index=record_index,
+        ) from exc

--- a/src/retrocast/v2/adapters/ursa.py
+++ b/src/retrocast/v2/adapters/ursa.py
@@ -49,9 +49,7 @@ class UrsaAdapter:
                     "each completion record must be a dict with a string 'completion' field",
                     record_index=row_index - 1,
                 )
-            target_hint_smiles = _extract_target_hint(
-                raw_record, self.adapter_key, target_id, row_index - 1, source_key
-            )
+            target_hint_smiles = _extract_target_hint(raw_record, self.adapter_key, target_id, row_index - 1)
             yield RawRouteEntry(
                 payload=raw_record["completion"],
                 source_key=source_key,
@@ -130,20 +128,24 @@ def _extract_target_hint(
     adapter_key: str,
     target_id: str,
     record_index: int,
-    source_key: str | None,
 ) -> str | None:
     meta = raw_record.get("meta")
-    if not isinstance(meta, dict) or not isinstance(meta.get("product_smiles"), str):
-        if source_key is None:
-            raise adapter_schema_error(
-                adapter_key,
-                target_id,
-                "completion records must include meta.product_smiles",
-                record_index=record_index,
-            )
+    if meta is None:
         return None
+    if not isinstance(meta, dict):
+        return None
+    product_smiles = meta.get("product_smiles")
+    if product_smiles is None:
+        return None
+    if not isinstance(product_smiles, str):
+        raise adapter_schema_error(
+            adapter_key,
+            target_id,
+            "completion record has non-string meta.product_smiles",
+            record_index=record_index,
+        )
     try:
-        return canonicalize_smiles(meta["product_smiles"])
+        return canonicalize_smiles(product_smiles)
     except RetroCastException as exc:
         raise adapter_schema_error(
             adapter_key,

--- a/tests/v2/adapters/test_synllama.py
+++ b/tests/v2/adapters/test_synllama.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.synllama import SynLlamaAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="synllama-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+@pytest.fixture
+def raw_synllama_payload() -> list[dict]:
+    return [{"synthesis_string": "C;CC;R1;CCO"}, {"synthesis_string": "CCC"}]
+
+
+@pytest.fixture
+def raw_synllama_route(raw_synllama_payload) -> dict:
+    return raw_synllama_payload[0]
+
+
+@pytest.fixture
+def raw_synllama_invalid_leaf_route() -> dict:
+    return {"synthesis_string": "C;not-smiles;R1;CCO"}
+
+
+class TestSynLlamaAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_synllama_payload, raw_synllama_route, raw_synllama_invalid_leaf_route
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=SynLlamaAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_synllama_payload,
+                {"synthesis_string": "CCO"},
+                "synllama-run",
+                2,
+                ["synllama-run", "synllama-run"],
+                1,
+            ),
+            casting=CastContractCase(
+                raw_synllama_route,
+                {"bad": "route"},
+                target_for("CCO"),
+                Target(id="synllama-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(raw_synllama_invalid_leaf_route, ["C"]),
+        )
+
+
+@pytest.mark.contract
+def test_synllama_accepts_purchasable_target_route() -> None:
+    route = SynLlamaAdapter().cast({"synthesis_string": "CCO"}, target=target_for("CCO"))
+    assert route.target.product_of is None
+
+
+@pytest.mark.contract
+def test_synllama_rejects_empty_synthesis_string() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynLlamaAdapter().cast({"synthesis_string": " ; "}, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.route_string_empty"
+
+
+@pytest.mark.contract
+def test_synllama_rejects_template_without_product() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynLlamaAdapter()._parse_synthesis_string("C;R1")
+    assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_synllama_rejects_reaction_without_reactants() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynLlamaAdapter()._parse_synthesis_string("R1;CCO")
+    assert exc_info.value.code == "adapter.route_string_invalid"
+
+
+@pytest.mark.contract
+def test_synllama_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(SynLlamaAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_synllama_rejects_cycles_after_canonicalization() -> None:
+    raw_route = {"synthesis_string": "CCO;R1;C;R2;CCO"}
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynLlamaAdapter().cast(raw_route, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"
+
+
+@pytest.mark.contract
+def test_synllama_strict_rejects_invalid_target_product() -> None:
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        SynLlamaAdapter().cast({"synthesis_string": "C;R1;not-smiles"}, target=target_for("CCO"))
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_synllama_prune_rejects_invalid_target_product_as_pruned() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        SynLlamaAdapter().cast({"synthesis_string": "C;R1;not-smiles"}, target=target_for("CCO"), mode="prune")
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_synllama_prune_skips_invalid_intermediate_product() -> None:
+    raw_route = {"synthesis_string": "C;R1;not-smiles;CC;R2;CCO"}
+
+    route = SynLlamaAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["CC"]
+
+
+@pytest.mark.contract
+def test_synllama_allows_duplicate_leaf_molecules() -> None:
+    route = SynLlamaAdapter().cast({"synthesis_string": "C;C;R1;CCO"}, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]

--- a/tests/v2/adapters/test_synllama.py
+++ b/tests/v2/adapters/test_synllama.py
@@ -128,6 +128,15 @@ def test_synllama_prune_skips_invalid_intermediate_product() -> None:
 
 
 @pytest.mark.contract
+def test_synllama_prune_does_not_carry_over_product_after_failure() -> None:
+    raw_route = {"synthesis_string": "C;R1;CC;C;R2;not-smiles;CCC;R3;CCO"}
+
+    route = SynLlamaAdapter().cast(raw_route, target=target_for("CCO"), mode="prune")
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["CCC"]
+
+
+@pytest.mark.contract
 def test_synllama_allows_duplicate_leaf_molecules() -> None:
     route = SynLlamaAdapter().cast({"synthesis_string": "C;C;R1;CCO"}, target=target_for("CCO"))
     assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C", "C"]

--- a/tests/v2/adapters/test_ursa.py
+++ b/tests/v2/adapters/test_ursa.py
@@ -73,10 +73,10 @@ def test_ursa_iter_raw_routes_preserves_row_index_and_target_hint(raw_ursa_paylo
 
 
 @pytest.mark.contract
-def test_ursa_iter_raw_routes_requires_meta_product_without_source_key() -> None:
-    with pytest.raises(AdapterSchemaError) as exc_info:
-        list(UrsaAdapter().iter_raw_routes([{"completion": completion("C")}]))
-    assert exc_info.value.code == "adapter.schema_invalid"
+def test_ursa_iter_raw_routes_allows_missing_target_hint() -> None:
+    entries = list(UrsaAdapter().iter_raw_routes([{"completion": completion("C")}]))
+
+    assert entries[0].target_hint_smiles is None
 
 
 @pytest.mark.contract

--- a/tests/v2/adapters/test_ursa.py
+++ b/tests/v2/adapters/test_ursa.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError, InvalidSmilesError
+from retrocast.typing import SmilesStr
+from retrocast.v2.adapters.ursa import UrsaAdapter
+from retrocast.v2.models.task import Target
+from tests.v2.adapters.base import (
+    AdapterContractCase,
+    AdapterContractSuite,
+    CastContractCase,
+    InvalidSmilesContractCase,
+    RawExtractionContractCase,
+)
+
+
+def target_for(smiles: str) -> Target:
+    canon_smiles = canonicalize_smiles(smiles)
+    return Target(id="ursa-target", smiles=canon_smiles, inchikey=get_inchi_key(canon_smiles))
+
+
+def completion(*reactants: str, product: str = "CCO") -> str:
+    reactant_blocks = "".join(f"<reactant><smiles>{reactant}</smiles></reactant>" for reactant in reactants)
+    return f"<synthesis_step><product><smiles>{product}</smiles></product>{reactant_blocks}</synthesis_step>"
+
+
+@pytest.fixture
+def raw_ursa_payload() -> list[dict]:
+    return [
+        {"completion": completion("C", "CC"), "meta": {"product_smiles": "CCO"}},
+        {"completion": completion("C"), "meta": {"product_smiles": "CCO"}},
+    ]
+
+
+@pytest.fixture
+def ursa_route_payload(raw_ursa_payload):
+    return next(UrsaAdapter().iter_raw_routes(raw_ursa_payload, source_key="ursa-run")).payload
+
+
+@pytest.fixture
+def ursa_invalid_leaf_payload():
+    return completion("C", "not-smiles")
+
+
+class TestUrsaAdapterContract(AdapterContractSuite):
+    @pytest.fixture
+    def adapter_contract_case(
+        self, raw_ursa_payload, ursa_route_payload, ursa_invalid_leaf_payload
+    ) -> AdapterContractCase:
+        return AdapterContractCase(
+            adapter=UrsaAdapter(),
+            extraction=RawExtractionContractCase(
+                raw_ursa_payload, [{"completion": 123}], "ursa-run", 2, ["ursa-run", "ursa-run"], 1
+            ),
+            casting=CastContractCase(
+                ursa_route_payload,
+                {"not": "completion"},
+                target_for("CCO"),
+                Target(id="ursa-target", smiles=SmilesStr("CCC"), inchikey=get_inchi_key("CCC")),
+                2,
+            ),
+            invalid_smiles=InvalidSmilesContractCase(ursa_invalid_leaf_payload, ["C"]),
+        )
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_preserves_row_index_and_target_hint(raw_ursa_payload) -> None:
+    entries = list(UrsaAdapter().iter_raw_routes(raw_ursa_payload, source_key="ursa-run"))
+    assert [entry.source_row_index for entry in entries] == [1, 2]
+    assert [entry.target_hint_smiles for entry in entries] == ["CCO", "CCO"]
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_requires_meta_product_without_source_key() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(UrsaAdapter().iter_raw_routes([{"completion": completion("C")}]))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_rejects_invalid_meta_product() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(UrsaAdapter().iter_raw_routes([{"completion": completion("C"), "meta": {"product_smiles": "bad"}}]))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_ursa_rejects_missing_target() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        UrsaAdapter().cast(completion("C"))
+    assert exc_info.value.code == "adapter.route_transform_failed"
+
+
+@pytest.mark.contract
+def test_ursa_rejects_completion_without_target_step() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        UrsaAdapter().cast(completion("C", product="CCC"), target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.target_mismatch"
+
+
+@pytest.mark.contract
+def test_ursa_strict_rejects_invalid_product_smiles() -> None:
+    with pytest.raises(InvalidSmilesError) as exc_info:
+        UrsaAdapter().cast(completion("C", product="not-smiles"), target=target_for("CCO"))
+    assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_ursa_parses_tokenized_smiles() -> None:
+    raw_completion = "<synthesis_step><product><smiles><sm_C><sm_C><sm_O></smiles></product><reactant><smiles><sm_C></smiles></reactant></synthesis_step>"
+    route = UrsaAdapter().cast(raw_completion, target=target_for("CCO"))
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]
+
+
+@pytest.mark.contract
+def test_ursa_rejects_cycles_after_canonicalization() -> None:
+    raw_completion = completion("OCC")
+    with pytest.raises(AdapterLogicError) as exc_info:
+        UrsaAdapter().cast(raw_completion, target=target_for("CCO"))
+    assert exc_info.value.code == "adapter.cycle_detected"


### PR DESCRIPTION
why: SynLlama and URSA were the remaining legacy model-output adapters without schema v2 casting coverage. This completes the adapter migration in the same narrow adapter-boundary shape as the preceding v2 PRs.

what changed: Added v2 SynLlama and URSA adapters, exported them from the v2 adapter package, and added contract tests for raw extraction, target matching, invalid SMILES handling, pruning behavior, cycle detection, and URSA target hints.

risk: The important boundary shape is adapter input parsing. SynLlama stays a semicolon-delimited precursor-map parser; URSA stays a list of completion records whose emitted entries preserve row index and optional canonical target hints. Both adapters reuse `build_molecule_from_precursor_map(...)`, so route construction, cycle detection, and strict/prune semantics stay owned by shared traversal code. The only cast is at the URSA external-input boundary after an explicit `dict` runtime check, to make the untyped raw record shape truthful to the type checker.

verification:
- `uv run pytest tests/v2/adapters/test_synllama.py tests/v2/adapters/test_ursa.py -q`
- `uv run pytest tests/v2/adapters -q`
- `uv run pytest tests/v2/adapters --cov=src/retrocast/v2/adapters --cov-report=term-missing -q`
- `uv run ruff check src/retrocast/v2/adapters/synllama.py src/retrocast/v2/adapters/ursa.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_synllama.py tests/v2/adapters/test_ursa.py`
- `uv run ty check src/retrocast/v2/adapters/synllama.py src/retrocast/v2/adapters/ursa.py src/retrocast/v2/adapters/__init__.py tests/v2/adapters/test_synllama.py tests/v2/adapters/test_ursa.py`

follow-ups: None for this migration chunk.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782578720&installation_id=125602297&pr_number=108&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F108&signature=a724c7441f9e0e37a633a9b2c32fcd413cbe381fa07ed3dfd66e957a4e659aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds schema v2 adapters for the SynLlama and URSA models, completing the remaining adapter migration. The SynLlama adapter parses semicolon-delimited synthesis strings into a precursor map; the URSA adapter parses XML-structured LLM completions, including optional `meta.product_smiles` target hints. Both delegate route construction, cycle detection, and prune semantics to the shared `build_molecule_from_precursor_map` traversal utility.

- **SynLlama**: Parses `reactants;Rn;product` sequences; correctly resets `last_product_smiles` to `None` on pruned intermediate steps, with the new `test_synllama_prune_does_not_carry_over_product_after_failure` test covering the middle-step case.
- **URSA**: Parses `<synthesis_step>` XML blocks from LLM completions, handles `<sm_X>` tokenized SMILES, extracts and validates optional `meta.product_smiles` target hints, and enforces that a target is always supplied.
- Both adapters are exported from `v2/adapters/__init__.py` and tested with the shared contract suite plus adapter-specific edge-case tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both adapters correctly delegate to shared traversal code, handle strict/prune mode boundaries, and are covered by contract and edge-case tests.

Both adapters follow the established adapter pattern precisely. The last_product_smiles reset-on-prune path is correctly implemented with last_product_smiles = None in the except block, and the new middle-step test validates it. Error boundaries (schema errors, target mismatches, cycle detection, target-pruned) are all exercised. No incorrect data, broken contracts, or unsafe input paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/adapters/synllama.py | New SynLlama adapter: correctly resets last_product_smiles to None on pruned steps, validates target canonicalization, delegates route traversal to shared common.py utility. |
| src/retrocast/v2/adapters/ursa.py | New URSA adapter: parses XML-structured LLM completions, handles tokenized SMILES (<sm_X>), validates meta.product_smiles target hints, and enforces that a target is always supplied. |
| tests/v2/adapters/test_synllama.py | Contract and unit tests for SynLlama; includes pruning edge cases (first step, middle step), cycle detection, target mismatch, and duplicate leaf molecules. |
| tests/v2/adapters/test_ursa.py | Contract and unit tests for URSA; covers row index/target-hint preservation, missing target hints, invalid meta.product_smiles, missing target, tokenized SMILES, and cycle detection. |
| src/retrocast/v2/adapters/__init__.py | Exports SynLlamaAdapter and UrsaAdapter, following the existing alphabetical pattern in both imports and __all__. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[iter_raw_routes payload] --> B{SynLlama or URSA?}

    B -->|SynLlama| C[Pydantic validate SynLlamaRouteList]
    C --> D[yield RawRouteEntry per synthesis_string]

    B -->|URSA| E[isinstance list check]
    E --> F[foreach dict record]
    F --> G[extract meta.product_smiles target hint]
    G --> H[yield RawRouteEntry with row_index & hint]

    D --> I[cast raw_route]
    H --> I

    I -->|SynLlama| J[canonicalize parts last = target]
    J --> K[_parse_synthesis_string]
    K --> L{invalid product?}
    L -->|strict| M[raise InvalidSmilesError]
    L -->|prune| N[reset last_product_smiles=None, skip step]
    N --> K
    L -->|valid| O[build precursor_map]

    I -->|URSA| P[require target not None]
    P --> Q[_parse_completion XML parse]
    Q --> R{invalid product?}
    R -->|strict| M
    R -->|prune| S[skip step, continue]
    S --> Q
    R -->|valid| O

    O --> T[build_molecule_from_precursor_map]
    T --> U{cycle?}
    U -->|yes| V[raise adapter.cycle_detected]
    U -->|no| W[Route target Molecule]
```

<sub>Reviews (2): Last reviewed commit: ["Address SynLlama and URSA review feedbac..."](https://github.com/ischemist/project-procrustes/commit/3664167aecdcf8ea4f10cb75cd2b7929a1748f8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34402887)</sub>

<!-- /greptile_comment -->