### PR TITLE
Add schema v2 adapt workflow

### DIFF
--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -1,0 +1,9 @@
+"""Schema v2 workflow APIs."""
+
+from retrocast.v2.workflow.adapt import adapt_candidates, adapt_route, adapt_routes
+
+__all__ = [
+    "adapt_candidates",
+    "adapt_route",
+    "adapt_routes",
+]

--- a/src/retrocast/v2/workflow/adapt.py
+++ b/src/retrocast/v2/workflow/adapt.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ValidationError
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterError, ChemError, RetroCastException
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.adapters.base import Adapter, AdaptMode, RawRouteEntry
+from retrocast.v2.models.candidates import Candidate, FailureRecord
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+
+
+def adapt_route(
+    raw_route_payload: Any,
+    adapter: Adapter,
+    *,
+    mode: AdaptMode = "strict",
+    target: Target | None = None,
+) -> Route | None:
+    """Adapt one raw route payload into one canonical route, or None on failure."""
+    try:
+        return adapter.cast(raw_route_payload, mode=mode, target=target)
+    except (AdapterError, ChemError, ValidationError):
+        return None
+
+
+def adapt_routes(
+    raw_payload: Any,
+    adapter: Adapter,
+    *,
+    mode: AdaptMode = "strict",
+    target: Target | None = None,
+    source_key: str | None = None,
+) -> list[Route]:
+    """Adapt raw planner output into valid canonical routes."""
+    routes: list[Route] = []
+    for entry in adapter.iter_raw_routes(raw_payload, source_key=source_key):
+        route = adapt_route(entry.payload, adapter, mode=mode, target=target or _target_from_entry(entry))
+        if route is not None:
+            routes.append(route)
+    return routes
+
+
+def adapt_candidates(
+    raw_payload: Any,
+    adapter: Adapter,
+    *,
+    mode: AdaptMode = "strict",
+    target: Target | None = None,
+    source_key: str | None = None,
+) -> list[Candidate]:
+    """Adapt raw planner output while preserving failed candidate rank slots."""
+    candidates: list[Candidate] = []
+    next_rank = 1
+    for entry in adapter.iter_raw_routes(raw_payload, source_key=source_key):
+        rank = entry.source_order if entry.source_order is not None else next_rank
+        next_rank += 1
+        entry_target = target or _target_from_entry(entry)
+        try:
+            route = adapter.cast(entry.payload, mode=mode, target=entry_target)
+        except (AdapterError, ChemError, ValidationError) as exc:
+            candidates.append(
+                Candidate(rank=rank, failure=_failure_from_exception(exc, target=entry_target, entry=entry))
+            )
+            continue
+        candidates.append(Candidate(rank=rank, route=route))
+    return candidates
+
+
+def _target_from_entry(entry: RawRouteEntry) -> Target | None:
+    if entry.target_hint_smiles is None:
+        return None
+
+    try:
+        smiles = canonicalize_smiles(entry.target_hint_smiles)
+        inchikey = get_inchi_key(smiles)
+    except ChemError:
+        return None
+    return Target(
+        id=entry.target_hint_id or entry.source_key or smiles,
+        smiles=SmilesStr(smiles),
+        inchikey=InChIKeyStr(inchikey),
+    )
+
+
+def _failure_from_exception(
+    exc: AdapterError | ChemError | ValidationError,
+    *,
+    target: Target | None,
+    entry: RawRouteEntry | None,
+) -> FailureRecord:
+    """Convert a per-candidate failure into a record that keeps target identity.
+
+    Adapter and chemistry exceptions carry a stable code plus optional structured
+    context, e.g. adapter name, bad node type, or offending SMILES. Pydantic
+    validation errors do not, so they become generic adapter schema failures.
+    """
+    code = exc.code if isinstance(exc, RetroCastException) else "adapter.schema_invalid"
+    context = dict(exc.context) if isinstance(exc, RetroCastException) else {}
+    if target is not None:
+        target_id, target_smiles, target_inchikey = target.id, target.smiles, target.inchikey
+    else:
+        target_id = entry.target_hint_id if entry is not None else None
+        target_smiles = target_inchikey = None
+
+    return FailureRecord(
+        code=ErrorCode(code),
+        message=str(exc),
+        target_id=target_id,
+        target_smiles=target_smiles,
+        target_inchikey=target_inchikey,
+        context=context,
+    )

--- a/src/retrocast/v2/workflow/adapt.py
+++ b/src/retrocast/v2/workflow/adapt.py
@@ -54,10 +54,8 @@ def adapt_candidates(
 ) -> list[Candidate]:
     """Adapt raw planner output while preserving failed candidate rank slots."""
     candidates: list[Candidate] = []
-    next_rank = 1
-    for entry in adapter.iter_raw_routes(raw_payload, source_key=source_key):
-        rank = entry.source_order if entry.source_order is not None else next_rank
-        next_rank += 1
+    for fallback_rank, entry in enumerate(adapter.iter_raw_routes(raw_payload, source_key=source_key), start=1):
+        rank = entry.source_order if entry.source_order is not None else fallback_rank
         entry_target = target or _target_from_entry(entry)
         try:
             route = adapter.cast(entry.payload, mode=mode, target=entry_target)

--- a/tests/v2/workflow/test_adapt.py
+++ b/tests/v2/workflow/test_adapt.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from retrocast.adapters.errors import adapter_target_mismatch
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import AdapterLogicError, AdapterSchemaError
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.adapters.common import build_plain_tree_molecule
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Target
+from retrocast.v2.workflow.adapt import adapt_candidates, adapt_route, adapt_routes
+
+
+class TreeAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        if not isinstance(raw_payload, list):
+            raise AdapterSchemaError("expected list", code="adapter.schema_invalid")
+        for index, raw_route in enumerate(raw_payload, start=1):
+            if not isinstance(raw_route, dict):
+                raise AdapterSchemaError("expected route dict", code="adapter.schema_invalid")
+            yield RawRouteEntry(
+                payload=raw_route,
+                source_key=source_key,
+                source_row_index=index,
+                source_order=raw_route.get("rank"),
+                target_hint_id=raw_route.get("target_id"),
+                target_hint_smiles=raw_route.get("target_smiles"),
+            )
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        if not isinstance(raw_route, dict):
+            raise AdapterSchemaError("expected route dict", code="adapter.schema_invalid")
+        molecule = build_plain_tree_molecule(
+            raw_route,
+            adapter="tree",
+            mode=mode,
+            get_smiles=lambda node: node["smiles"],
+            get_children=lambda node: node.get("children", []),
+        )
+        if molecule is None:
+            raise AdapterLogicError("target was pruned", code="adapter.target_pruned")
+        if target is not None and molecule.smiles != canonicalize_smiles(target.smiles):
+            raise adapter_target_mismatch(
+                "tree",
+                target.id,
+                expected_smiles=target.smiles,
+                actual_smiles=molecule.smiles,
+            )
+        return Route(target=molecule)
+
+
+class FailingExtractionAdapter(TreeAdapter):
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        yield RawRouteEntry(payload=valid_route(), source_key=source_key)
+        raise AdapterSchemaError("bad raw record", code="adapter.schema_invalid")
+
+
+def make_target(smiles: str = "CC(=O)O", *, target_id: str = "target-1") -> Target:
+    canonical = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=canonical, inchikey=get_inchi_key(canonical))
+
+
+def valid_route(rank: int = 1) -> dict[str, Any]:
+    return {
+        "rank": rank,
+        "smiles": "CC(=O)O",
+        "children": [{"smiles": "CCO"}, {"smiles": "O"}],
+    }
+
+
+def test_adapt_route_returns_route_for_valid_raw_route() -> None:
+    route = adapt_route(valid_route(), TreeAdapter(), target=make_target())
+
+    assert isinstance(route, Route)
+    assert route.target.smiles == "CC(=O)O"
+
+
+def test_adapt_routes_filters_failed_raw_routes() -> None:
+    routes = adapt_routes([valid_route(), {"rank": 2, "smiles": "not-a-smiles"}], TreeAdapter(), target=make_target())
+
+    assert len(routes) == 1
+    assert routes[0].target.smiles == "CC(=O)O"
+
+
+def test_adapt_candidates_preserves_rank_and_failed_candidate() -> None:
+    candidates = adapt_candidates(
+        [valid_route(rank=7), {"rank": 8, "smiles": "not-a-smiles"}],
+        TreeAdapter(),
+        target=make_target(),
+    )
+
+    assert [candidate.rank for candidate in candidates] == [7, 8]
+    assert candidates[0].route is not None
+    assert candidates[0].failure is None
+    assert candidates[1].route is None
+    assert candidates[1].failure is not None
+    assert candidates[1].failure.code == "chem.invalid_smiles"
+
+
+def test_adapt_candidates_records_failed_target_identity_from_entry_hint() -> None:
+    candidates = adapt_candidates(
+        [{"rank": 3, "target_id": "target-1", "target_smiles": "CC(=O)O", "smiles": "not-a-smiles"}],
+        TreeAdapter(),
+    )
+
+    failure = candidates[0].failure
+    assert failure is not None
+    assert failure.target_id == "target-1"
+    assert failure.target_smiles == "CC(=O)O"
+    assert failure.target_inchikey == get_inchi_key("CC(=O)O")
+
+
+def test_prune_mode_drops_invalid_branch() -> None:
+    candidates = adapt_candidates(
+        [
+            {
+                "rank": 1,
+                "smiles": "CC(=O)O",
+                "children": [{"smiles": "CCO"}, {"smiles": "not-a-smiles"}],
+            }
+        ],
+        TreeAdapter(),
+        mode="prune",
+        target=make_target(),
+    )
+
+    assert len(candidates) == 1
+    route = candidates[0].route
+    assert route is not None
+    assert not hasattr(route, "rank")
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["CCO"]
+
+
+def test_raw_payload_schema_failure_propagates() -> None:
+    with pytest.raises(AdapterSchemaError):
+        adapt_candidates({"not": "a-list"}, TreeAdapter(), target=make_target())
+
+
+def test_extraction_failure_after_yield_propagates() -> None:
+    with pytest.raises(AdapterSchemaError):
+        adapt_candidates([], FailingExtractionAdapter(), target=make_target())


### PR DESCRIPTION
why: schema v2 adapters now share a common `iter_raw_routes` / `cast` seam, but there was no workflow API implementing the planned `adapt_route`, `adapt_routes`, and `adapt_candidates` boundary. This adds the clean workflow layer needed before collect/ingest work.

what changed: added `retrocast.v2.workflow.adapt` with route-first adaptation, candidate adaptation that preserves failed rank slots, target-hint handling from `RawRouteEntry`, and failure conversion into v2 `FailureRecord`. Added focused workflow tests using a small in-test adapter.

risk: the important boundary is extraction vs candidate casting. Extraction/schema failures from `iter_raw_routes` propagate because there is no candidate slot yet. Per-entry `cast` failures become failed `Candidate`s for benchmarking accounting. `adapt_routes` remains route-first and filters failed casts.

verification: `uv run pytest tests/v2`; `uv run ruff check src/retrocast/v2/workflow tests/v2/workflow`; `uv run ruff format --check src/retrocast/v2/workflow tests/v2/workflow` after formatting.

follow-ups: collect and ingest workflow APIs are still intentionally left for the next schema-v2 slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782582101&installation_id=125602297&pr_number=109&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F109&signature=42210b84bcbf0b665aa179b6a06c5b57d5f71cdb518f6a09305314a382f506c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow adaptation functionality to convert planner outputs into domain models with robust error handling and multiple adaptation modes.

* **Tests**
  * Added comprehensive test suite for the workflow adaptation layer, covering successful conversions, failure handling, and error propagation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces the `retrocast.v2.workflow.adapt` module with three public functions (`adapt_route`, `adapt_routes`, `adapt_candidates`) that bridge the v2 adapter protocol to canonical `Route`/`Candidate` domain objects, plus a focused test suite backed by a small in-test adapter.

- `adapt_route` / `adapt_routes` provide simple single-route and batch adaptation with silent failure filtering; `adapt_candidates` preserves per-rank failure slots as `FailureRecord` objects, making cast errors visible for benchmarking accounting.
- `_target_from_entry` resolves per-entry target hints, and `_failure_from_exception` normalises `AdapterError`, `ChemError`, and pydantic `ValidationError` into a stable `FailureRecord` shape; the extraction-vs-cast error boundary is intentional and tested.

<h3>Confidence Score: 4/5</h3>

The new workflow module is a thin, well-structured layer over the existing adapter protocol; the logic is straightforward and the test coverage is solid.

Two edge cases worth attention: `Target(...)` construction in `_target_from_entry` sits outside both the local ChemError guard and the per-entry try/except in `adapt_candidates`, so a pydantic ValidationError there would escape as an unhandled exception rather than a FailureRecord. And the `fallback_rank` counter increments on every iteration including entries that already supply `source_order`, which can produce duplicate ranks when the two are mixed. Neither is triggered by the current tests or typical adapter usage, but both are latent misbehaviours that could surface with unusual adapter implementations.

src/retrocast/v2/workflow/adapt.py — specifically `_target_from_entry` and the rank-assignment logic in `adapt_candidates`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/workflow/adapt.py | Core adaptation layer: adapt_route, adapt_routes, adapt_candidates plus two private helpers. Latent ValidationError escape in _target_from_entry and a rank-collision edge case in adapt_candidates under mixed source_order presence. |
| src/retrocast/v2/workflow/__init__.py | Package init re-exporting adapt_candidates, adapt_route, adapt_routes — straightforward and correct. |
| tests/v2/workflow/test_adapt.py | Focused test suite with a minimal in-test adapter covering success paths, filtering, rank preservation, failure-record identity, prune mode, and extraction-failure propagation; good coverage of the intended boundaries. |
| tests/v2/workflow/__init__.py | Empty test package marker — no changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant adapt_candidates
    participant Adapter
    participant _target_from_entry
    participant _failure_from_exception

    Caller->>adapt_candidates: raw_payload, adapter, mode, target
    adapt_candidates->>Adapter: iter_raw_routes(raw_payload)
    loop for each RawRouteEntry
        Adapter-->>adapt_candidates: entry (or raises propagates)
        adapt_candidates->>_target_from_entry: entry (if target is None)
        _target_from_entry-->>adapt_candidates: "Target | None"
        adapt_candidates->>Adapter: cast(entry.payload, mode, entry_target)
        alt cast succeeds
            Adapter-->>adapt_candidates: Route
            adapt_candidates->>adapt_candidates: "append Candidate(rank, route=Route)"
        else "AdapterError | ChemError | ValidationError"
            Adapter-->>adapt_candidates: raises exc
            adapt_candidates->>_failure_from_exception: "exc, target=entry_target, entry=entry"
            _failure_from_exception-->>adapt_candidates: FailureRecord
            adapt_candidates->>adapt_candidates: "append Candidate(rank, failure=FailureRecord)"
        end
    end
    adapt_candidates-->>Caller: list[Candidate]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/retrocast/v2/workflow/adapt.py:66-77
**`Target` construction escapes the ChemError guard**

`Target(...)` is called after the `try/except ChemError` block exits. `Target._validate_identity` internally calls `get_inchi_key(self.smiles)` and wraps any `ChemError` as a `ValueError`, which Pydantic re-raises as a `ValidationError`. If that path were ever hit, the `ValidationError` would escape `_target_from_entry` entirely and — since `_target_from_entry` is invoked before the per-entry `try` block in `adapt_candidates` — would propagate out of the loop as an unhandled error rather than being converted to a `FailureRecord`. Moving the `Target(...)` call inside the `try` block (and broadening the `except` to include `ValidationError`) would close this gap.

### Issue 2 of 2
src/retrocast/v2/workflow/adapt.py:57-58
**Rank collision when `source_order` is partially set**

`fallback_rank` increments on every iteration, including iterations where `entry.source_order` is used instead. So if entry 1 has `source_order=None` (→ rank 1) and entry 2 has `source_order=1` (→ rank 1), both candidates receive rank 1. The counter needs to be independent of whether `source_order` is present — either by tracking the next fallback position separately, or by asserting that all entries in a batch are consistently ranked.

```suggestion
    fallback_rank = 0
    for entry in adapter.iter_raw_routes(raw_payload, source_key=source_key):
        fallback_rank += 1
        rank = entry.source_order if entry.source_order is not None else fallback_rank
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Simplify v2 candidate rank fallback"](https://github.com/ischemist/project-procrustes/commit/cf99e6c547b38cbc1e1876929ba7c8217ad4bc6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34415076)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->