### PR TITLE
Add schema v2 collect and ingest workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ data/retrocast/0-assets/model-configs/**/*.md
 data/retrocast/**/*.gz
 data/retrocast/**/*.hdf5
 data/retrocast/2-raw/
+data/retrocast/1-benchmarks/definitions/v0.5.0/
 data/retrocast/3-processed/
 data/retrocast/4-scored/
 data/retrocast/5-results/

--- a/scripts/lib-example-use.py
+++ b/scripts/lib-example-use.py
@@ -36,9 +36,14 @@ def main() -> None:
     with quiet_info_logs("retrocast"), create_cli_progress(console=console, unit="target") as progress:
         task_id = progress.add_task("adapting targets", total=len(task.targets))
         for target_id, target in task.targets.items():
-            target_payload = raw_payload[target_id]
-            routes.extend(adapt_routes(target_payload, adapter, target=target, source_key=target_id))
-            candidates.extend(adapt_candidates(target_payload, adapter, target=target, source_key=target_id))
+            source_key = target_id if target_id in raw_payload else target.smiles
+            if source_key not in raw_payload:
+                logger.warning("missing payload for target_id=%s smiles=%s", target_id, target.smiles)
+                progress.advance(task_id)
+                continue
+            target_payload = raw_payload[source_key]
+            routes.extend(adapt_routes(target_payload, adapter, target=target, source_key=source_key))
+            candidates.extend(adapt_candidates(target_payload, adapter, target=target, source_key=source_key))
             progress.advance(task_id)
     logger.info("adapted routes=%s candidates=%s", len(routes), len(candidates))
 

--- a/scripts/lib-example-use.py
+++ b/scripts/lib-example-use.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.console import Console
+
+from retrocast.cli.progress import create_cli_progress, quiet_info_logs
+from retrocast.io import load_json_gz
+from retrocast.utils.logging import configure_script_logging, logger
+from retrocast.v2.adapters import AiZynthFinderAdapter
+from retrocast.v2.io import load_benchmark
+from retrocast.v2.workflow import (
+    adapt_candidates,
+    adapt_routes,
+    collect_candidates,
+    collect_routes,
+    ingest_candidates,
+    ingest_routes,
+)
+
+RAW_PATH = Path("data/retrocast/2-raw/aizynthfinder-4.4.1-mcts-iter100-depth6/mkt-cnv-160/results.json.gz")
+BENCHMARK_PATH = Path("data/retrocast/1-benchmarks/definitions/mkt-cnv-160.json.gz")
+
+
+def main() -> None:
+    configure_script_logging()
+
+    console = Console()
+    raw_payload = load_json_gz(RAW_PATH)
+    task = load_benchmark(BENCHMARK_PATH)
+    adapter = AiZynthFinderAdapter()
+    logger.info("loaded raw payload and benchmark: targets=%s", len(task.targets))
+
+    routes = []
+    candidates = []
+    with quiet_info_logs("retrocast"), create_cli_progress(console=console, unit="target") as progress:
+        task_id = progress.add_task("adapting targets", total=len(task.targets))
+        for target_id, target in task.targets.items():
+            target_payload = raw_payload[target_id]
+            routes.extend(adapt_routes(target_payload, adapter, target=target, source_key=target_id))
+            candidates.extend(adapt_candidates(target_payload, adapter, target=target, source_key=target_id))
+            progress.advance(task_id)
+    logger.info("adapted routes=%s candidates=%s", len(routes), len(candidates))
+
+    collected_routes = collect_routes(routes, task)
+    collected_candidates = collect_candidates(candidates, task)
+    logger.info(
+        "collected routes=%s candidates=%s",
+        sum(len(items) for items in collected_routes.values()),
+        sum(len(items) for items in collected_candidates.values()),
+    )
+
+    ingested_routes = ingest_routes(raw_payload, adapter, task)
+    ingested_candidates = ingest_candidates(raw_payload, adapter, task)
+    logger.info("ingest_routes: %s", sum(len(items) for items in ingested_routes.values()))
+    logger.info("ingest_candidates: %s", sum(len(items) for items in ingested_candidates.values()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
+++ b/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
@@ -1,0 +1,219 @@
+"""Migrate v0.5.0 benchmark definition artifacts to schema v2.
+
+By default this script only validates conversion. Pass ``--write`` to move each
+v0.5.0 benchmark and manifest into ``definitions/v0.5.0/`` and write schema v2
+benchmarks plus refreshed manifests at the original paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from retrocast.io import load_json_gz
+from retrocast.io.provenance import calculate_file_hash
+from retrocast.models.provenance import FileInfo, Manifest
+from retrocast.typing import InChIKeyStr, ReactionSmilesStr, SmilesStr
+from retrocast.utils.logging import configure_script_logging, logger
+from retrocast.v2.io import save_benchmark
+from retrocast.v2.models import Benchmark, Molecule, Reaction, Route, Target, TaskConstraints
+
+LEGACY_DIRNAME = "v0.5.0"
+
+
+def main() -> None:
+    configure_script_logging()
+    args = parse_args()
+    definitions_dir = args.definitions_dir
+    legacy_dir = definitions_dir / LEGACY_DIRNAME
+
+    benchmark_names = {path.name for path in definitions_dir.glob("*.json.gz") if ".rc0.6." not in path.name} | {
+        path.name for path in legacy_dir.glob("*.json.gz")
+    }
+    benchmark_files = [definitions_dir / name for name in sorted(benchmark_names)]
+    logger.info("Found %s benchmark definitions in %s", len(benchmark_files), definitions_dir)
+
+    for benchmark_path in benchmark_files:
+        sibling_legacy_path = legacy_sibling_path(benchmark_path)
+        if (legacy_dir / benchmark_path.name).exists():
+            source_path = legacy_dir / benchmark_path.name
+        elif sibling_legacy_path.exists():
+            source_path = sibling_legacy_path
+        else:
+            source_path = benchmark_path
+        source_manifest_path = legacy_manifest_path(source_path)
+        manifest_path = benchmark_manifest_path(benchmark_path)
+        logger.info("Migrating %s", source_path.name)
+
+        benchmark = convert_benchmark(load_json_gz(source_path))
+        route_count = sum(len(target.acceptable_routes) for target in benchmark.targets.values())
+        logger.info("  targets=%s acceptable_routes=%s", len(benchmark.targets), route_count)
+
+        if not args.write:
+            continue
+        source_for_manifest = source_manifest_path if source_manifest_path.exists() else source_path
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        if source_path == benchmark_path:
+            move_to_legacy(benchmark_path, legacy_dir / benchmark_path.name, force=args.force)
+            if manifest_path.exists():
+                move_to_legacy(manifest_path, legacy_dir / manifest_path.name, force=args.force)
+                source_for_manifest = legacy_dir / manifest_path.name
+            else:
+                source_for_manifest = legacy_dir / benchmark_path.name
+        elif source_path == sibling_legacy_path:
+            move_to_legacy(sibling_legacy_path, legacy_dir / benchmark_path.name, force=args.force)
+            source_for_manifest = legacy_dir / benchmark_path.name
+        save_benchmark(benchmark, benchmark_path)
+        save_manifest(
+            benchmark=benchmark,
+            benchmark_path=benchmark_path,
+            manifest_path=manifest_path,
+            source_path=source_for_manifest,
+            route_count=route_count,
+            root_dir=definitions_dir.parents[1],
+        )
+        logger.info("  wrote %s and refreshed %s", benchmark_path.name, manifest_path.name)
+
+    if not args.write:
+        logger.info("Dry run complete. Re-run with --write to move v0.5.0 artifacts and write schema v2 files.")
+
+
+def parse_args() -> argparse.Namespace:
+    project_root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--definitions-dir",
+        type=Path,
+        default=project_root / "data" / "retrocast" / "1-benchmarks" / "definitions",
+    )
+    parser.add_argument("--write", action="store_true", help="Move originals and write schema v2 benchmarks.")
+    parser.add_argument("--force", action="store_true", help="Allow overwriting existing v0.5.0 legacy artifacts.")
+    return parser.parse_args()
+
+
+def benchmark_manifest_path(path: Path) -> Path:
+    return path.with_name(path.name.removesuffix(".json.gz") + ".manifest.json")
+
+
+def legacy_sibling_path(path: Path) -> Path:
+    return path.with_name(path.name.removesuffix(".json.gz") + ".rc0.6.json.gz")
+
+
+def legacy_manifest_path(path: Path) -> Path:
+    return path.with_name(path.name.removesuffix(".rc0.6.json.gz").removesuffix(".json.gz") + ".manifest.json")
+
+
+def move_to_legacy(source: Path, destination: Path, *, force: bool) -> None:
+    if destination.exists():
+        if not force:
+            raise FileExistsError(f"Legacy artifact already exists: {destination}")
+        destination.unlink()
+    source.rename(destination)
+
+
+def save_manifest(
+    *,
+    benchmark: Benchmark,
+    benchmark_path: Path,
+    manifest_path: Path,
+    source_path: Path,
+    route_count: int,
+    root_dir: Path,
+) -> None:
+    manifest = Manifest(
+        action="scripts/migrations/03-migrate-benchmarks-to-schema-v2",
+        parameters={"migration": "v0.5.0-benchmark-to-schema-v2", "legacy_dir": LEGACY_DIRNAME},
+        source_files=[file_info(source_path, root_dir=root_dir)],
+        output_files=[
+            file_info(
+                benchmark_path,
+                root_dir=root_dir,
+                content_hash=benchmark_content_hash(benchmark),
+            )
+        ],
+        statistics={"n_targets": len(benchmark.targets), "n_acceptable_routes": route_count},
+        summary={"schema_version": "2", "legacy_schema": "v0.5.0"},
+    )
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+
+def file_info(path: Path, *, root_dir: Path, content_hash: str | None = None) -> FileInfo:
+    return FileInfo(
+        path=relative_path(path, root_dir=root_dir),
+        file_hash=calculate_file_hash(path),
+        content_hash=content_hash,
+    )
+
+
+def relative_path(path: Path, *, root_dir: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root_dir.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def benchmark_content_hash(benchmark: Benchmark) -> str:
+    payload = benchmark.model_dump(mode="json", exclude_none=True, exclude_computed_fields=True)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def convert_benchmark(data: dict[str, Any]) -> Benchmark:
+    targets = {target_id: convert_target(target_id, target_data) for target_id, target_data in data["targets"].items()}
+    return Benchmark(
+        name=data["name"],
+        description=data.get("description", ""),
+        targets=targets,
+        default_constraints=TaskConstraints(stock=data.get("stock_name")),
+        annotations={"migrated_from": "v0.5.0"},
+    )
+
+
+def convert_target(target_id: str, data: dict[str, Any]) -> Target:
+    return Target(
+        id=target_id,
+        smiles=SmilesStr(data["smiles"]),
+        inchikey=InChIKeyStr(data["inchi_key"]),
+        acceptable_routes=[convert_route(route) for route in data.get("acceptable_routes", [])],
+        annotations=dict(data.get("metadata") or {}),
+    )
+
+
+def convert_route(data: dict[str, Any]) -> Route:
+    annotations = dict(data.get("metadata") or {})
+    rc06_fields = {
+        key: data[key]
+        for key in ("rank", "retrocast_version", "length", "has_convergent_reaction", "content_hash", "signature")
+        if key in data
+    }
+    if rc06_fields:
+        annotations["rc0.6"] = rc06_fields
+    return Route(target=convert_molecule(data["target"]), annotations=annotations)
+
+
+def convert_molecule(data: dict[str, Any]) -> Molecule:
+    synthesis_step = data.get("synthesis_step")
+    return Molecule(
+        smiles=SmilesStr(data["smiles"]),
+        inchikey=InChIKeyStr(data.get("inchikey") or data["inchi_key"]),
+        product_of=convert_reaction(synthesis_step) if synthesis_step is not None else None,
+        annotations=dict(data.get("metadata") or {}),
+    )
+
+
+def convert_reaction(data: dict[str, Any]) -> Reaction:
+    return Reaction(
+        reactants=[convert_molecule(reactant) for reactant in data["reactants"]],
+        mapped_reaction_smiles=ReactionSmilesStr(data["mapped_smiles"]) if data.get("mapped_smiles") else None,
+        template=data.get("template"),
+        reagents=data.get("reagents"),
+        solvents=data.get("solvents"),
+        annotations=dict(data.get("metadata") or {}),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
+++ b/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
@@ -1,8 +1,13 @@
-"""Migrate v0.5.0 benchmark definition artifacts to schema v2.
+"""Migrate v0.5.0 benchmark definitions to schema v2.
 
-By default this script only validates conversion. Pass ``--write`` to move each
-v0.5.0 benchmark and manifest into ``definitions/v0.5.0/`` and write schema v2
-benchmarks plus refreshed manifests at the original paths.
+Before writing, move the old benchmark artifacts out of the output directory:
+
+    mkdir -p data/retrocast/1-benchmarks/definitions/v0.5.0
+    mv data/retrocast/1-benchmarks/definitions/*.json.gz data/retrocast/1-benchmarks/definitions/v0.5.0/
+    mv data/retrocast/1-benchmarks/definitions/*.manifest.json data/retrocast/1-benchmarks/definitions/v0.5.0/
+
+By default this script only validates conversion. Pass ``--write`` to write the
+schema v2 benchmarks and refreshed manifests at the original paths.
 """
 
 from __future__ import annotations
@@ -29,23 +34,18 @@ def main() -> None:
     args = parse_args()
     definitions_dir = args.definitions_dir
     legacy_dir = definitions_dir / LEGACY_DIRNAME
+    root_dir = definitions_dir.parents[1]
 
-    benchmark_names = {path.name for path in definitions_dir.glob("*.json.gz") if ".rc0.6." not in path.name} | {
-        path.name for path in legacy_dir.glob("*.json.gz")
-    }
-    benchmark_files = [definitions_dir / name for name in sorted(benchmark_names)]
-    logger.info("Found %s benchmark definitions in %s", len(benchmark_files), definitions_dir)
+    source_dir = legacy_dir
+    benchmark_files = sorted(source_dir.glob("*.json.gz"))
+    if not benchmark_files:
+        source_dir = definitions_dir
+        benchmark_files = sorted(source_dir.glob("*.json.gz"))
+    logger.info("Found %s benchmark definitions in %s", len(benchmark_files), source_dir)
 
-    for benchmark_path in benchmark_files:
-        sibling_legacy_path = legacy_sibling_path(benchmark_path)
-        if (legacy_dir / benchmark_path.name).exists():
-            source_path = legacy_dir / benchmark_path.name
-        elif sibling_legacy_path.exists():
-            source_path = sibling_legacy_path
-        else:
-            source_path = benchmark_path
-        source_manifest_path = legacy_manifest_path(source_path)
-        manifest_path = benchmark_manifest_path(benchmark_path)
+    for source_path in benchmark_files:
+        output_path = definitions_dir / source_path.name
+        manifest_path = definitions_dir / source_path.name.replace(".json.gz", ".manifest.json")
         logger.info("Migrating %s", source_path.name)
 
         benchmark = convert_benchmark(load_json_gz(source_path))
@@ -54,31 +54,31 @@ def main() -> None:
 
         if not args.write:
             continue
-        source_for_manifest = source_manifest_path if source_manifest_path.exists() else source_path
-        legacy_dir.mkdir(parents=True, exist_ok=True)
-        if source_path == benchmark_path:
-            move_to_legacy(benchmark_path, legacy_dir / benchmark_path.name, force=args.force)
-            if manifest_path.exists():
-                move_to_legacy(manifest_path, legacy_dir / manifest_path.name, force=args.force)
-                source_for_manifest = legacy_dir / manifest_path.name
-            else:
-                source_for_manifest = legacy_dir / benchmark_path.name
-        elif source_path == sibling_legacy_path:
-            move_to_legacy(sibling_legacy_path, legacy_dir / benchmark_path.name, force=args.force)
-            source_for_manifest = legacy_dir / benchmark_path.name
-        save_benchmark(benchmark, benchmark_path)
-        save_manifest(
-            benchmark=benchmark,
-            benchmark_path=benchmark_path,
-            manifest_path=manifest_path,
-            source_path=source_for_manifest,
-            route_count=route_count,
-            root_dir=definitions_dir.parents[1],
+        save_benchmark(benchmark, output_path)
+        manifest = Manifest(
+            action="scripts/migrations/03-migrate-benchmarks-to-schema-v2",
+            parameters={"migration": "v0.5.0-benchmark-to-schema-v2", "legacy_dir": LEGACY_DIRNAME},
+            source_files=[
+                FileInfo(
+                    path=str(source_path.relative_to(root_dir)),
+                    file_hash=calculate_file_hash(source_path),
+                )
+            ],
+            output_files=[
+                FileInfo(
+                    path=str(output_path.relative_to(root_dir)),
+                    file_hash=calculate_file_hash(output_path),
+                    content_hash=benchmark_content_hash(benchmark),
+                )
+            ],
+            statistics={"n_targets": len(benchmark.targets), "n_acceptable_routes": route_count},
+            summary={"schema_version": "2", "legacy_schema": "v0.5.0"},
         )
-        logger.info("  wrote %s and refreshed %s", benchmark_path.name, manifest_path.name)
+        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+        logger.info("  wrote %s and refreshed %s", output_path.name, manifest_path.name)
 
     if not args.write:
-        logger.info("Dry run complete. Re-run with --write to move v0.5.0 artifacts and write schema v2 files.")
+        logger.info("Dry run complete. Move legacy artifacts as documented, then re-run with --write.")
 
 
 def parse_args() -> argparse.Namespace:
@@ -89,70 +89,8 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=project_root / "data" / "retrocast" / "1-benchmarks" / "definitions",
     )
-    parser.add_argument("--write", action="store_true", help="Move originals and write schema v2 benchmarks.")
-    parser.add_argument("--force", action="store_true", help="Allow overwriting existing v0.5.0 legacy artifacts.")
+    parser.add_argument("--write", action="store_true", help="Write schema v2 benchmarks and manifests.")
     return parser.parse_args()
-
-
-def benchmark_manifest_path(path: Path) -> Path:
-    return path.with_name(path.name.removesuffix(".json.gz") + ".manifest.json")
-
-
-def legacy_sibling_path(path: Path) -> Path:
-    return path.with_name(path.name.removesuffix(".json.gz") + ".rc0.6.json.gz")
-
-
-def legacy_manifest_path(path: Path) -> Path:
-    return path.with_name(path.name.removesuffix(".rc0.6.json.gz").removesuffix(".json.gz") + ".manifest.json")
-
-
-def move_to_legacy(source: Path, destination: Path, *, force: bool) -> None:
-    if destination.exists():
-        if not force:
-            raise FileExistsError(f"Legacy artifact already exists: {destination}")
-        destination.unlink()
-    source.rename(destination)
-
-
-def save_manifest(
-    *,
-    benchmark: Benchmark,
-    benchmark_path: Path,
-    manifest_path: Path,
-    source_path: Path,
-    route_count: int,
-    root_dir: Path,
-) -> None:
-    manifest = Manifest(
-        action="scripts/migrations/03-migrate-benchmarks-to-schema-v2",
-        parameters={"migration": "v0.5.0-benchmark-to-schema-v2", "legacy_dir": LEGACY_DIRNAME},
-        source_files=[file_info(source_path, root_dir=root_dir)],
-        output_files=[
-            file_info(
-                benchmark_path,
-                root_dir=root_dir,
-                content_hash=benchmark_content_hash(benchmark),
-            )
-        ],
-        statistics={"n_targets": len(benchmark.targets), "n_acceptable_routes": route_count},
-        summary={"schema_version": "2", "legacy_schema": "v0.5.0"},
-    )
-    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
-
-
-def file_info(path: Path, *, root_dir: Path, content_hash: str | None = None) -> FileInfo:
-    return FileInfo(
-        path=relative_path(path, root_dir=root_dir),
-        file_hash=calculate_file_hash(path),
-        content_hash=content_hash,
-    )
-
-
-def relative_path(path: Path, *, root_dir: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(root_dir.resolve()))
-    except ValueError:
-        return str(path.resolve())
 
 
 def benchmark_content_hash(benchmark: Benchmark) -> str:

--- a/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
+++ b/scripts/migrations/03-migrate-benchmarks-to-schema-v2.py
@@ -32,12 +32,14 @@ LEGACY_DIRNAME = "v0.5.0"
 def main() -> None:
     configure_script_logging()
     args = parse_args()
-    definitions_dir = args.definitions_dir
+    definitions_dir = args.definitions_dir.resolve()
     legacy_dir = definitions_dir / LEGACY_DIRNAME
     root_dir = definitions_dir.parents[1]
 
     source_dir = legacy_dir
     benchmark_files = sorted(source_dir.glob("*.json.gz"))
+    if not benchmark_files and args.write:
+        raise FileNotFoundError(f"Move legacy benchmark artifacts into {legacy_dir} before running with --write.")
     if not benchmark_files:
         source_dir = definitions_dir
         benchmark_files = sorted(source_dir.glob("*.json.gz"))
@@ -103,7 +105,7 @@ def convert_benchmark(data: dict[str, Any]) -> Benchmark:
     targets = {target_id: convert_target(target_id, target_data) for target_id, target_data in data["targets"].items()}
     return Benchmark(
         name=data["name"],
-        description=data.get("description", ""),
+        description=data.get("description") or "",
         targets=targets,
         default_constraints=TaskConstraints(stock=data.get("stock_name")),
         annotations={"migrated_from": "v0.5.0"},

--- a/src/retrocast/v2/io/__init__.py
+++ b/src/retrocast/v2/io/__init__.py
@@ -1,0 +1,23 @@
+"""Schema v2 IO helpers."""
+
+from retrocast.v2.io.data import (
+    load_benchmark,
+    load_collected_candidates,
+    load_collected_routes,
+    load_task,
+    save_benchmark,
+    save_collected_candidates,
+    save_collected_routes,
+    save_task,
+)
+
+__all__ = [
+    "load_benchmark",
+    "load_collected_candidates",
+    "load_collected_routes",
+    "load_task",
+    "save_benchmark",
+    "save_collected_candidates",
+    "save_collected_routes",
+    "save_task",
+]

--- a/src/retrocast/v2/io/data.py
+++ b/src/retrocast/v2/io/data.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import TypeAdapter, ValidationError
+
+from retrocast.exceptions import ArtifactDecodeError, ArtifactFormatError, ArtifactNotFoundError, ArtifactWriteError
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Benchmark, Task
+
+CollectedCandidates = dict[str, list[Candidate]]
+CollectedRoutes = dict[str, list[Route]]
+
+_TASK_ADAPTER = TypeAdapter(Task)
+_BENCHMARK_ADAPTER = TypeAdapter(Benchmark)
+_COLLECTED_ROUTES_ADAPTER = TypeAdapter(CollectedRoutes)
+_COLLECTED_CANDIDATES_ADAPTER = TypeAdapter(CollectedCandidates)
+
+T = TypeVar("T")
+
+
+def load_task(path: Path) -> Task:
+    return _load_model(path, _TASK_ADAPTER, artifact="task")
+
+
+def save_task(task: Task, path: Path) -> None:
+    _save_model(task, path, _TASK_ADAPTER, artifact="task")
+
+
+def load_benchmark(path: Path) -> Benchmark:
+    return _load_model(path, _BENCHMARK_ADAPTER, artifact="benchmark")
+
+
+def save_benchmark(benchmark: Benchmark, path: Path) -> None:
+    _save_model(benchmark, path, _BENCHMARK_ADAPTER, artifact="benchmark")
+
+
+def load_collected_routes(path: Path) -> CollectedRoutes:
+    return _load_model(path, _COLLECTED_ROUTES_ADAPTER, artifact="collected_routes")
+
+
+def save_collected_routes(routes: CollectedRoutes, path: Path) -> None:
+    _save_model(routes, path, _COLLECTED_ROUTES_ADAPTER, artifact="collected_routes")
+
+
+def load_collected_candidates(path: Path) -> CollectedCandidates:
+    return _load_model(path, _COLLECTED_CANDIDATES_ADAPTER, artifact="collected_candidates")
+
+
+def save_collected_candidates(candidates: CollectedCandidates, path: Path) -> None:
+    _save_model(candidates, path, _COLLECTED_CANDIDATES_ADAPTER, artifact="collected_candidates")
+
+
+def _load_model(path: Path, adapter: TypeAdapter[T], *, artifact: str) -> T:
+    path = Path(path)
+    if not path.exists():
+        raise ArtifactNotFoundError(
+            f"{artifact} file not found: {path}",
+            code="io.not_found",
+            context={"path": str(path), "artifact": artifact},
+        )
+
+    try:
+        with gzip.open(path, "rb") as handle:
+            payload = handle.read()
+    except OSError as exc:
+        raise ArtifactDecodeError(
+            f"Failed to load {artifact} from {path}: {exc}",
+            code="io.decode_failed",
+            context={"path": str(path), "artifact": artifact},
+        ) from exc
+
+    try:
+        return adapter.validate_json(payload)
+    except ValidationError as exc:
+        raise ArtifactFormatError(
+            f"Invalid {artifact} JSON format in {path}: {exc}",
+            code="io.invalid_artifact_shape",
+            context={"path": str(path), "artifact": artifact},
+        ) from exc
+
+
+def _save_model(value: T, path: Path, adapter: TypeAdapter[T], *, artifact: str) -> None:
+    path = Path(path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = adapter.dump_json(value, indent=2, exclude_none=True, exclude_computed_fields=True)
+        with gzip.open(path, "wb") as handle:
+            handle.write(payload)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ArtifactWriteError(
+            f"Failed to save {artifact} to {path}: {exc}",
+            code="io.write_failed",
+            context={"path": str(path), "artifact": artifact},
+        ) from exc

--- a/src/retrocast/v2/io/data.py
+++ b/src/retrocast/v2/io/data.py
@@ -7,12 +7,8 @@ from typing import TypeVar
 from pydantic import TypeAdapter, ValidationError
 
 from retrocast.exceptions import ArtifactDecodeError, ArtifactFormatError, ArtifactNotFoundError, ArtifactWriteError
-from retrocast.v2.models.candidates import Candidate
-from retrocast.v2.models.route import Route
 from retrocast.v2.models.task import Benchmark, Task
-
-CollectedCandidates = dict[str, list[Candidate]]
-CollectedRoutes = dict[str, list[Route]]
+from retrocast.v2.workflow.collect import CollectedCandidates, CollectedRoutes
 
 _TASK_ADAPTER = TypeAdapter(Task)
 _BENCHMARK_ADAPTER = TypeAdapter(Benchmark)
@@ -66,7 +62,7 @@ def _load_model(path: Path, adapter: TypeAdapter[T], *, artifact: str) -> T:
     try:
         with gzip.open(path, "rb") as handle:
             payload = handle.read()
-    except OSError as exc:
+    except (OSError, EOFError) as exc:
         raise ArtifactDecodeError(
             f"Failed to load {artifact} from {path}: {exc}",
             code="io.decode_failed",

--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -1,9 +1,22 @@
 """Schema v2 workflow APIs."""
 
 from retrocast.v2.workflow.adapt import adapt_candidates, adapt_route, adapt_routes
+from retrocast.v2.workflow.collect import (
+    CollectedCandidates,
+    CollectedRoutes,
+    collect_candidates,
+    collect_routes,
+)
+from retrocast.v2.workflow.ingest import ingest_candidates, ingest_routes
 
 __all__ = [
+    "CollectedCandidates",
+    "CollectedRoutes",
     "adapt_candidates",
     "adapt_route",
     "adapt_routes",
+    "collect_candidates",
+    "collect_routes",
+    "ingest_candidates",
+    "ingest_routes",
 ]

--- a/src/retrocast/v2/workflow/collect.py
+++ b/src/retrocast/v2/workflow/collect.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.models.route import Route
+from retrocast.v2.models.task import Task
+
+CollectedCandidates = dict[str, list[Candidate]]
+CollectedRoutes = dict[str, list[Route]]
+
+
+def collect_candidates(candidates: Iterable[Candidate], task: Task) -> CollectedCandidates:
+    """Map adapted candidates onto task targets by route or failure identity."""
+    collected: CollectedCandidates = {target_id: [] for target_id in task.targets}
+    target_id_by_inchikey = {target.inchikey: target_id for target_id, target in task.targets.items()}
+
+    for candidate in candidates:
+        target_id = None
+        if candidate.route is not None:
+            target_id = target_id_by_inchikey.get(candidate.route.target.inchikey)
+        elif candidate.failure is not None:
+            if candidate.failure.target_id in task.targets:
+                target_id = candidate.failure.target_id
+            elif candidate.failure.target_inchikey is not None:
+                target_id = target_id_by_inchikey.get(candidate.failure.target_inchikey)
+
+        if target_id is not None:
+            collected[target_id].append(candidate)
+    return collected
+
+
+def collect_routes(routes: Iterable[Route], task: Task) -> CollectedRoutes:
+    """Map valid canonical routes onto task targets."""
+    collected: CollectedRoutes = {target_id: [] for target_id in task.targets}
+    target_id_by_inchikey = {target.inchikey: target_id for target_id, target in task.targets.items()}
+
+    for route in routes:
+        target_id = target_id_by_inchikey.get(route.target.inchikey)
+        if target_id is not None:
+            collected[target_id].append(route)
+    return collected

--- a/src/retrocast/v2/workflow/ingest.py
+++ b/src/retrocast/v2/workflow/ingest.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+from retrocast.v2.adapters.base import Adapter, AdaptMode
+from retrocast.v2.models.task import Target, Task
+from retrocast.v2.workflow.adapt import adapt_candidates, adapt_routes
+from retrocast.v2.workflow.collect import (
+    CollectedCandidates,
+    CollectedRoutes,
+    collect_candidates,
+    collect_routes,
+)
+
+
+def ingest_routes(
+    raw_payload: Any,
+    adapter: Adapter,
+    task: Task,
+    *,
+    mode: AdaptMode = "strict",
+) -> CollectedRoutes:
+    """Adapt raw planner output into valid routes and collect them by target id."""
+    routes = []
+    for target, payload, source_key in _target_payloads(raw_payload, task):
+        routes.extend(adapt_routes(payload, adapter, mode=mode, target=target, source_key=source_key))
+    return collect_routes(routes, task)
+
+
+def ingest_candidates(
+    raw_payload: Any,
+    adapter: Adapter,
+    task: Task,
+    *,
+    mode: AdaptMode = "strict",
+) -> CollectedCandidates:
+    """Adapt raw planner output into candidates and collect them by target id."""
+    candidates = []
+    for target, payload, source_key in _target_payloads(raw_payload, task):
+        candidates.extend(adapt_candidates(payload, adapter, mode=mode, target=target, source_key=source_key))
+    return collect_candidates(candidates, task)
+
+
+def _target_payloads(raw_payload: Any, task: Task) -> Iterator[tuple[Target | None, Any, str | None]]:
+    if not isinstance(raw_payload, Mapping):
+        target = next(iter(task.targets.values())) if len(task.targets) == 1 else None
+        yield target, raw_payload, None
+        return
+
+    for target_id, target in task.targets.items():
+        if target_id in raw_payload:
+            yield target, raw_payload[target_id], target_id
+        elif target.smiles in raw_payload:
+            yield target, raw_payload[target.smiles], target.smiles

--- a/src/retrocast/v2/workflow/ingest.py
+++ b/src/retrocast/v2/workflow/ingest.py
@@ -44,7 +44,9 @@ def ingest_candidates(
 
 def _target_payloads(raw_payload: Any, task: Task) -> Iterator[tuple[Target | None, Any, str | None]]:
     if not isinstance(raw_payload, Mapping):
-        target = next(iter(task.targets.values())) if len(task.targets) == 1 else None
+        if len(task.targets) != 1:
+            raise ValueError("Multi-target ingest requires raw_payload keyed by target id or target SMILES.")
+        target = next(iter(task.targets.values()))
         yield target, raw_payload, None
         return
 

--- a/tests/v2/adapters/test_ursa.py
+++ b/tests/v2/adapters/test_ursa.py
@@ -87,6 +87,41 @@ def test_ursa_iter_raw_routes_rejects_invalid_meta_product() -> None:
 
 
 @pytest.mark.contract
+def test_ursa_iter_raw_routes_rejects_non_list_payload() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(UrsaAdapter().iter_raw_routes({"completion": completion("C")}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_rejects_non_dict_record() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(UrsaAdapter().iter_raw_routes(["not-a-record"]))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_allows_non_dict_meta() -> None:
+    entries = list(UrsaAdapter().iter_raw_routes([{"completion": completion("C"), "meta": "not-a-dict"}]))
+
+    assert entries[0].target_hint_smiles is None
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_allows_meta_without_product() -> None:
+    entries = list(UrsaAdapter().iter_raw_routes([{"completion": completion("C"), "meta": {}}]))
+
+    assert entries[0].target_hint_smiles is None
+
+
+@pytest.mark.contract
+def test_ursa_iter_raw_routes_rejects_non_string_meta_product() -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(UrsaAdapter().iter_raw_routes([{"completion": completion("C"), "meta": {"product_smiles": 123}}]))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
 def test_ursa_rejects_missing_target() -> None:
     with pytest.raises(AdapterLogicError) as exc_info:
         UrsaAdapter().cast(completion("C"))
@@ -105,6 +140,51 @@ def test_ursa_strict_rejects_invalid_product_smiles() -> None:
     with pytest.raises(InvalidSmilesError) as exc_info:
         UrsaAdapter().cast(completion("C", product="not-smiles"), target=target_for("CCO"))
     assert exc_info.value.code == "chem.invalid_smiles"
+
+
+@pytest.mark.contract
+def test_ursa_ignores_steps_without_product() -> None:
+    raw_completion = "<synthesis_step><reactant><smiles>C</smiles></reactant></synthesis_step>" + completion("C")
+
+    route = UrsaAdapter().cast(raw_completion, target=target_for("CCO"))
+
+    assert route.target.smiles == "CCO"
+
+
+@pytest.mark.contract
+def test_ursa_ignores_steps_without_product_smiles() -> None:
+    raw_completion = (
+        "<synthesis_step><product></product><reactant><smiles>C</smiles></reactant></synthesis_step>" + completion("C")
+    )
+
+    route = UrsaAdapter().cast(raw_completion, target=target_for("CCO"))
+
+    assert route.target.smiles == "CCO"
+
+
+@pytest.mark.contract
+def test_ursa_prune_ignores_invalid_product_step() -> None:
+    raw_completion = completion("C", product="not-smiles") + completion("C")
+
+    route = UrsaAdapter().cast(raw_completion, target=target_for("CCO"), mode="prune")
+
+    assert route.target.smiles == "CCO"
+
+
+@pytest.mark.contract
+def test_ursa_prune_rejects_target_when_all_reactants_are_invalid() -> None:
+    with pytest.raises(AdapterLogicError) as exc_info:
+        UrsaAdapter().cast(completion("not-smiles"), target=target_for("CCO"), mode="prune")
+    assert exc_info.value.code == "adapter.target_pruned"
+
+
+@pytest.mark.contract
+def test_ursa_ignores_reactants_without_smiles() -> None:
+    raw_completion = "<synthesis_step><product><smiles>CCO</smiles></product><reactant></reactant><reactant><smiles>C</smiles></reactant></synthesis_step>"
+
+    route = UrsaAdapter().cast(raw_completion, target=target_for("CCO"))
+
+    assert [reactant.value.smiles for reactant in route.reaction_at("rc:r:/").reactants()] == ["C"]
 
 
 @pytest.mark.contract

--- a/tests/v2/io/test_data.py
+++ b/tests/v2/io/test_data.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import gzip
+
 import pytest
 
 from retrocast.chem import canonicalize_smiles, get_inchi_key
-from retrocast.exceptions import ArtifactNotFoundError
+from retrocast.exceptions import ArtifactDecodeError, ArtifactFormatError, ArtifactNotFoundError, ArtifactWriteError
 from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
 from retrocast.v2.io import (
     load_benchmark,
@@ -87,3 +89,28 @@ def test_collected_candidates_round_trip(tmp_path) -> None:
 def test_missing_benchmark_raises_io_error(tmp_path) -> None:
     with pytest.raises(ArtifactNotFoundError):
         load_benchmark(tmp_path / "missing.json.gz")
+
+
+def test_invalid_gzip_raises_decode_error(tmp_path) -> None:
+    path = tmp_path / "benchmark.json.gz"
+    path.write_text("not gzip", encoding="utf-8")
+
+    with pytest.raises(ArtifactDecodeError):
+        load_benchmark(path)
+
+
+def test_invalid_benchmark_shape_raises_format_error(tmp_path) -> None:
+    path = tmp_path / "benchmark.json.gz"
+    with gzip.open(path, "wb") as handle:
+        handle.write(b"{}")
+
+    with pytest.raises(ArtifactFormatError):
+        load_benchmark(path)
+
+
+def test_save_failure_raises_write_error(tmp_path) -> None:
+    parent_file = tmp_path / "not-a-dir"
+    parent_file.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(ArtifactWriteError):
+        save_benchmark(benchmark(), parent_file / "benchmark.json.gz")

--- a/tests/v2/io/test_data.py
+++ b/tests/v2/io/test_data.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.exceptions import ArtifactNotFoundError
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.io import (
+    load_benchmark,
+    load_collected_candidates,
+    load_collected_routes,
+    load_task,
+    save_benchmark,
+    save_collected_candidates,
+    save_collected_routes,
+    save_task,
+)
+from retrocast.v2.models import Benchmark, Candidate, FailureRecord, Molecule, Route, Target, Task, TaskConstraints
+
+
+def target(smiles: str = "CCO", target_id: str = "ethanol") -> Target:
+    canonical = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=SmilesStr(canonical), inchikey=InChIKeyStr(get_inchi_key(canonical)))
+
+
+def route(smiles: str = "CCO") -> Route:
+    canonical = canonicalize_smiles(smiles)
+    return Route(target=Molecule(smiles=SmilesStr(canonical), inchikey=InChIKeyStr(get_inchi_key(canonical))))
+
+
+def benchmark() -> Benchmark:
+    benchmark_target = target()
+    return Benchmark(
+        name="small",
+        description="round-trip fixture",
+        targets={benchmark_target.id: benchmark_target},
+        default_constraints=TaskConstraints(stock="n5-stock"),
+    )
+
+
+def task_value() -> Task:
+    task_target = target()
+    return Task(name="small-task", targets={task_target.id: task_target})
+
+
+def test_task_round_trips(tmp_path) -> None:
+    path = tmp_path / "task.json.gz"
+    value = task_value()
+
+    save_task(value, path)
+
+    assert load_task(path) == value
+
+
+def test_benchmark_round_trips(tmp_path) -> None:
+    path = tmp_path / "benchmark.json.gz"
+    value = benchmark()
+
+    save_benchmark(value, path)
+
+    assert load_benchmark(path) == value
+
+
+def test_collected_routes_round_trip(tmp_path) -> None:
+    path = tmp_path / "routes.json.gz"
+    value = {"ethanol": [route()]}
+
+    save_collected_routes(value, path)
+
+    assert load_collected_routes(path) == value
+
+
+def test_collected_candidates_round_trip(tmp_path) -> None:
+    path = tmp_path / "candidates.json.gz"
+    value = {
+        "ethanol": [
+            Candidate(rank=1, route=route()),
+            Candidate(rank=2, failure=FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="ethanol")),
+        ]
+    }
+
+    save_collected_candidates(value, path)
+
+    assert load_collected_candidates(path) == value
+
+
+def test_missing_benchmark_raises_io_error(tmp_path) -> None:
+    with pytest.raises(ArtifactNotFoundError):
+        load_benchmark(tmp_path / "missing.json.gz")

--- a/tests/v2/io/test_data.py
+++ b/tests/v2/io/test_data.py
@@ -99,6 +99,16 @@ def test_invalid_gzip_raises_decode_error(tmp_path) -> None:
         load_benchmark(path)
 
 
+def test_truncated_gzip_raises_decode_error(tmp_path) -> None:
+    path = tmp_path / "benchmark.json.gz"
+    with gzip.open(path, "wb") as handle:
+        handle.write(b"{}")
+    path.write_bytes(path.read_bytes()[:-4])
+
+    with pytest.raises(ArtifactDecodeError):
+        load_benchmark(path)
+
+
 def test_invalid_benchmark_shape_raises_format_error(tmp_path) -> None:
     path = tmp_path / "benchmark.json.gz"
     with gzip.open(path, "wb") as handle:

--- a/tests/v2/workflow/test_adapt.py
+++ b/tests/v2/workflow/test_adapt.py
@@ -115,6 +115,32 @@ def test_adapt_candidates_records_failed_target_identity_from_entry_hint() -> No
     assert failure.target_inchikey == get_inchi_key("CC(=O)O")
 
 
+def test_adapt_candidates_records_target_id_when_smiles_hint_is_missing() -> None:
+    candidates = adapt_candidates(
+        [{"rank": 3, "target_id": "target-1", "smiles": "not-a-smiles"}],
+        TreeAdapter(),
+    )
+
+    failure = candidates[0].failure
+    assert failure is not None
+    assert failure.target_id == "target-1"
+    assert failure.target_smiles is None
+    assert failure.target_inchikey is None
+
+
+def test_adapt_candidates_ignores_invalid_target_smiles_hint() -> None:
+    candidates = adapt_candidates(
+        [{"rank": 3, "target_id": "target-1", "target_smiles": "not-a-smiles", "smiles": "not-a-smiles"}],
+        TreeAdapter(),
+    )
+
+    failure = candidates[0].failure
+    assert failure is not None
+    assert failure.target_id == "target-1"
+    assert failure.target_smiles is None
+    assert failure.target_inchikey is None
+
+
 def test_prune_mode_drops_invalid_branch() -> None:
     candidates = adapt_candidates(
         [

--- a/tests/v2/workflow/test_adapt.py
+++ b/tests/v2/workflow/test_adapt.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -22,6 +22,7 @@ class TreeAdapter:
         for index, raw_route in enumerate(raw_payload, start=1):
             if not isinstance(raw_route, dict):
                 raise AdapterSchemaError("expected route dict", code="adapter.schema_invalid")
+            raw_route = cast("dict[str, Any]", raw_route)
             yield RawRouteEntry(
                 payload=raw_route,
                 source_key=source_key,

--- a/tests/v2/workflow/test_collect.py
+++ b/tests/v2/workflow/test_collect.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.models.candidates import Candidate, FailureRecord
+from retrocast.v2.models.route import Molecule, Route
+from retrocast.v2.models.task import Target, Task
+from retrocast.v2.workflow.collect import collect_candidates, collect_routes
+
+
+def target(smiles: str, target_id: str) -> Target:
+    canonical = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=SmilesStr(canonical), inchikey=get_inchi_key(canonical))
+
+
+def route(smiles: str) -> Route:
+    canonical = canonicalize_smiles(smiles)
+    return Route(target=Molecule(smiles=SmilesStr(canonical), inchikey=InChIKeyStr(get_inchi_key(canonical))))
+
+
+def task() -> Task:
+    first = target("CCO", "ethanol")
+    second = target("CC(=O)O", "acetic-acid")
+    return Task(name="two-targets", targets={first.id: first, second.id: second})
+
+
+def test_collect_candidates_places_successful_candidate_by_route_target() -> None:
+    candidate = Candidate(rank=1, route=route("CCO"))
+
+    collected = collect_candidates([candidate], task())
+
+    assert collected["ethanol"] == [candidate]
+    assert collected["acetic-acid"] == []
+
+
+def test_collect_candidates_places_failed_candidate_by_target_id() -> None:
+    candidate = Candidate(rank=1, failure=FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="ethanol"))
+
+    collected = collect_candidates([candidate], task())
+
+    assert collected["ethanol"] == [candidate]
+    assert collected["acetic-acid"] == []
+
+
+def test_collect_candidates_places_failed_candidate_by_target_inchikey() -> None:
+    candidate = Candidate(
+        rank=1,
+        failure=FailureRecord(
+            code=ErrorCode("adapter.schema_invalid"),
+            target_inchikey=InChIKeyStr(get_inchi_key("CC(=O)O")),
+        ),
+    )
+
+    collected = collect_candidates([candidate], task())
+    assert collected["ethanol"] == []
+    assert collected["acetic-acid"] == [candidate]
+
+
+def test_collect_routes_places_routes_by_target() -> None:
+    ethanol_route = route("CCO")
+    unmatched_route = route("CCC")
+
+    collected = collect_routes([ethanol_route, unmatched_route], task())
+
+    assert collected["ethanol"] == [ethanol_route]
+    assert collected["acetic-acid"] == []

--- a/tests/v2/workflow/test_ingest.py
+++ b/tests/v2/workflow/test_ingest.py
@@ -62,3 +62,12 @@ def test_ingest_candidates_handles_target_keyed_payloads() -> None:
     assert [candidate.rank for candidate in collected["ethanol"]] == [1, 2]
     assert collected["ethanol"][0].route is not None
     assert collected["ethanol"][1].failure is not None
+
+
+def test_ingest_candidates_handles_target_smiles_keyed_payloads() -> None:
+    raw_payload = {"CCO": [{"smiles": "CCO"}]}
+
+    collected = ingest_candidates(raw_payload, SmilesAdapter(), task())
+
+    assert len(collected["ethanol"]) == 1
+    assert collected["ethanol"][0].route is not None

--- a/tests/v2/workflow/test_ingest.py
+++ b/tests/v2/workflow/test_ingest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
+from retrocast.v2.models.route import Molecule, Route
+from retrocast.v2.models.task import Target, Task
+from retrocast.v2.workflow.adapt import adapt_candidates, adapt_routes
+from retrocast.v2.workflow.collect import collect_candidates, collect_routes
+from retrocast.v2.workflow.ingest import ingest_candidates, ingest_routes
+
+
+class SmilesAdapter:
+    def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
+        for index, raw_route in enumerate(raw_payload, start=1):
+            yield RawRouteEntry(payload=raw_route, source_key=source_key, source_order=index)
+
+    def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
+        smiles = canonicalize_smiles(raw_route["smiles"])
+        return Route(target=Molecule(smiles=SmilesStr(smiles), inchikey=InChIKeyStr(get_inchi_key(smiles))))
+
+
+def target(smiles: str, target_id: str) -> Target:
+    canonical = canonicalize_smiles(smiles)
+    return Target(id=target_id, smiles=SmilesStr(canonical), inchikey=get_inchi_key(canonical))
+
+
+def task() -> Task:
+    ethanol = target("CCO", "ethanol")
+    return Task(name="one-target", targets={ethanol.id: ethanol})
+
+
+def test_ingest_routes_is_adapt_plus_collect() -> None:
+    raw_payload = [{"smiles": "CCO"}, {"smiles": "not-a-smiles"}]
+    adapter = SmilesAdapter()
+    expected = collect_routes(adapt_routes(raw_payload, adapter, target=target("CCO", "ethanol")), task())
+
+    assert ingest_routes(raw_payload, adapter, task()) == expected
+
+
+def test_ingest_candidates_is_adapt_plus_collect() -> None:
+    raw_payload = [{"smiles": "CCO"}, {"smiles": "not-a-smiles"}]
+    adapter = SmilesAdapter()
+    expected = collect_candidates(adapt_candidates(raw_payload, adapter, target=target("CCO", "ethanol")), task())
+
+    collected = ingest_candidates(raw_payload, adapter, task())
+
+    assert collected == expected
+    assert [candidate.rank for candidate in collected["ethanol"]] == [1, 2]
+    assert collected["ethanol"][1].failure is not None
+    assert collected["ethanol"][1].failure.code == ErrorCode("chem.invalid_smiles")
+
+
+def test_ingest_candidates_handles_target_keyed_payloads() -> None:
+    raw_payload = {"ethanol": [{"smiles": "CCO"}, {"smiles": "not-a-smiles"}]}
+
+    collected = ingest_candidates(raw_payload, SmilesAdapter(), task())
+
+    assert [candidate.rank for candidate in collected["ethanol"]] == [1, 2]
+    assert collected["ethanol"][0].route is not None
+    assert collected["ethanol"][1].failure is not None

--- a/tests/v2/workflow/test_ingest.py
+++ b/tests/v2/workflow/test_ingest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any
 
+import pytest
+
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
 from retrocast.v2.adapters.base import AdaptMode, RawRouteEntry
@@ -31,6 +33,12 @@ def target(smiles: str, target_id: str) -> Target:
 def task() -> Task:
     ethanol = target("CCO", "ethanol")
     return Task(name="one-target", targets={ethanol.id: ethanol})
+
+
+def two_target_task() -> Task:
+    ethanol = target("CCO", "ethanol")
+    acetic_acid = target("CC(=O)O", "acetic-acid")
+    return Task(name="two-targets", targets={ethanol.id: ethanol, acetic_acid.id: acetic_acid})
 
 
 def test_ingest_routes_is_adapt_plus_collect() -> None:
@@ -71,3 +79,8 @@ def test_ingest_candidates_handles_target_smiles_keyed_payloads() -> None:
 
     assert len(collected["ethanol"]) == 1
     assert collected["ethanol"][0].route is not None
+
+
+def test_ingest_candidates_rejects_unkeyed_multi_target_payload() -> None:
+    with pytest.raises(ValueError, match="Multi-target ingest"):
+        ingest_candidates([{"smiles": "CCO"}], SmilesAdapter(), two_target_task())


### PR DESCRIPTION
why: schema v2 had adapter output normalization, but not the task-level collection/ingest boundary needed to turn planner payloads into benchmark predictions or serialize v2 artifacts. This adds the smallest workflow and IO slice needed before scoring/analyze work.

what changed: added v2 collect and ingest APIs, v2 IO helpers for tasks/benchmarks/collected outputs, a benchmark migration script, and a script-level library usage example. The migration reads legacy benchmark artifacts from `definitions/v0.5.0/`, refuses `--write` if that folder has not been populated, and refreshes manifests at the original paths.

risk: the important data-shape boundary is target-keyed collected predictions. Successful routes/candidates collect by canonical target identity; failed candidates collect by `FailureRecord` target id or inchikey. Multi-target ingest now rejects unkeyed raw payloads because they cannot be assigned safely.

verification:
- `uv run pytest tests/v2`
- `uv run ruff check src/retrocast/v2 scripts/migrations/03-migrate-benchmarks-to-schema-v2.py tests/v2 scripts/lib-example-use.py`
- `uv run ruff format --check src/retrocast/v2 scripts/migrations/03-migrate-benchmarks-to-schema-v2.py tests/v2 scripts/lib-example-use.py`
- `uv run ty check src/retrocast/v2/io src/retrocast/v2/workflow tests/v2/io tests/v2/workflow scripts/lib-example-use.py scripts/migrations/03-migrate-benchmarks-to-schema-v2.py`
- `uv run python scripts/migrations/03-migrate-benchmarks-to-schema-v2.py`
- `uv run python scripts/lib-example-use.py`

follow-ups: score/analyze workflow and CLI cutover remain separate schema v2 slices.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the schema v2 collect and ingest workflow layer: `collect_routes`/`collect_candidates` map already-adapted outputs onto task targets by inchikey or `FailureRecord` identity, and `ingest_routes`/`ingest_candidates` wrap the full adapt→collect pipeline in a single call. It also adds v2 IO helpers for tasks, benchmarks, and collected outputs, a benchmark migration script from `v0.5.0`, and a library usage example.

- **`workflow/collect.py`**: routes are bucketed by `route.target.inchikey`; failures fall back first to `failure.target_id`, then `failure.target_inchikey`. `Benchmark` is a `Task` subclass, so passing a loaded benchmark to any `Task`-typed parameter is type-safe.
- **`workflow/ingest.py`**: `_target_payloads` resolves keys by `target_id` first, then `target.smiles`; unkeyed multi-target payloads are rejected with a `ValueError`; single-target unkeyed payloads are forwarded directly.
- **`io/data.py`**: the gzip read path now catches both `OSError` and `EOFError`, addressing the truncated-file gap from the prior review round. `CollectedCandidates`/`CollectedRoutes` are imported from `collect.py` rather than re-declared, closing the divergence risk also flagged previously.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core collect/ingest logic is straightforward, well-tested, and the two issues raised in the previous review round have both been addressed.

The adapt→collect data path is simple and thoroughly covered by unit tests across all four dispatch branches (route inchikey, failure target_id, failure inchikey, unmatched). The `io/data.py` error handling now wraps both `OSError` and `EOFError`. The migration script correctly guards `--write` against an absent legacy directory. No correctness issues were found in the new code.

No files require special attention. The one observation worth a second look is `_target_payloads` in `ingest.py` silently dropping targets whose keys don't appear in a Mapping payload, which could obscure key-alignment problems at call sites.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/workflow/collect.py | New collect module: maps adapted routes/candidates onto task targets by inchikey or FailureRecord identity; logic is clean and consistent with the Candidate model validator. |
| src/retrocast/v2/workflow/ingest.py | New ingest module: combines adapt + collect into a single call; correctly guards against unkeyed multi-target payloads; single-target unkeyed path and SMILES fallback both implemented correctly. |
| src/retrocast/v2/io/data.py | New IO helpers wrapping gzip+Pydantic for tasks, benchmarks, and collected outputs; catches both OSError and EOFError on read, wraps all write errors into ArtifactWriteError. |
| scripts/migrations/03-migrate-benchmarks-to-schema-v2.py | Migration script: guards --write against absent legacy dir, uses `or ""` pattern for nullable string fields, preserves rc0.6 metadata in annotations, and builds the full recursive molecule tree via product_of. |
| scripts/lib-example-use.py | Example script demonstrating both the manual adapt→collect pipeline and the ingest shortcut; correctly uses Benchmark (a Task subclass) with collect/ingest APIs. |
| tests/v2/workflow/test_ingest.py | Covers target-id keyed, SMILES keyed, single unkeyed, and multi-target rejection cases; assert-plus-collect equivalence test is correct. |
| tests/v2/workflow/test_collect.py | Covers successful-route, failure-by-target-id, failure-by-inchikey, and unmatched-route cases; all assertions are correct. |
| tests/v2/io/test_data.py | Round-trip tests for all four artifact types plus ArtifactNotFoundError, ArtifactDecodeError (bad gzip and truncated gzip), ArtifactFormatError, and ArtifactWriteError paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[raw_payload] --> B{Mapping?}
    B -- No + single target --> C[yield target, payload, None]
    B -- No + multi target --> ERR[raise ValueError]
    B -- Yes --> D{target_id key present?}
    D -- Yes --> E[yield target, id-keyed payload]
    D -- No --> F{smiles key present?}
    F -- Yes --> G[yield target, smiles-keyed payload]
    F -- No --> H[skip target silently]

    C --> I[adapt_routes / adapt_candidates]
    E --> I
    G --> I
    I --> J[collect by inchikey or FailureRecord identity]
    J --> K[CollectedRoutes / CollectedCandidates]

    subgraph Ingest shortcut
        direction LR
        L[ingest_routes / ingest_candidates] --> M[_target_payloads + adapt + collect]
        M --> K
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/v2/workflow/ingest.py:511-515
**Silent skip for unmatched Mapping keys**

When `raw_payload` is a `Mapping` but a task target matches neither by `target_id` nor `target.smiles`, the target is silently omitted from the iteration — callers receive an all-empty `CollectedRoutes`/`CollectedCandidates` for that target with no indication that a key alignment problem occurred. The example script (`lib-example-use.py`) handles this with an explicit `logger.warning`, but the `ingest_*` API offers no equivalent signal. A typo in a target ID or a payload keyed by a different convention would produce empty results that look identical to a run with genuinely no routes found.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address schema v2 PR review findings"](https://github.com/ischemist/project-procrustes/commit/a7513899a41a25226fbf05b7b92a62db43feb63b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34441686)</sub>

<!-- /greptile_comment -->