### PR TITLE
Add schema v2 scoring workflow

### DIFF
--- a/scripts/lib-example-use.py
+++ b/scripts/lib-example-use.py
@@ -5,12 +5,14 @@ from pathlib import Path
 from rich.console import Console
 
 from retrocast.cli.progress import create_cli_progress, quiet_info_logs
-from retrocast.io import load_json_gz
+from retrocast.io import load_json_gz, load_stock_file
 from retrocast.utils.logging import configure_script_logging, logger
 from retrocast.v2.adapters import AiZynthFinderAdapter
 from retrocast.v2.io import load_benchmark
-from retrocast.v2.models import CheckStatus, ConstraintResult, Route, RouteValidity, TaskConstraints, Tier, TierResult
+from retrocast.v2.models import Tier
 from retrocast.v2.workflow import (
+    TaskConstraintChecker,
+    TierZeroChecker,
     adapt_candidates,
     adapt_routes,
     collect_candidates,
@@ -22,21 +24,7 @@ from retrocast.v2.workflow import (
 
 RAW_PATH = Path("data/retrocast/2-raw/aizynthfinder-4.4.1-mcts-iter100-depth6/mkt-cnv-160/results.json.gz")
 BENCHMARK_PATH = Path("data/retrocast/1-benchmarks/definitions/mkt-cnv-160.json.gz")
-
-
-class PassTierZeroChecker:
-    tier = Tier.ZERO
-    name = "pass-tier-zero"
-
-    def check_route(self, route: Route) -> RouteValidity:
-        return RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.PASS)})
-
-
-class PassTaskChecker:
-    name = "pass-task"
-
-    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
-        return ConstraintResult(status=CheckStatus.PASS)
+STOCKS_DIR = Path("data/retrocast/1-benchmarks/stocks")
 
 
 def main() -> None:
@@ -45,6 +33,8 @@ def main() -> None:
     console = Console()
     raw_payload = load_json_gz(RAW_PATH)
     task = load_benchmark(BENCHMARK_PATH)
+    stock_name = task.default_constraints.stock
+    stock = load_stock_file(STOCKS_DIR / f"{stock_name}.csv.gz") if stock_name is not None else set()
     adapter = AiZynthFinderAdapter()
     logger.info("loaded raw payload and benchmark: targets=%s", len(task.targets))
 
@@ -80,8 +70,8 @@ def main() -> None:
     evaluation = score(
         collected_candidates,
         task,
-        tier_checkers=[PassTierZeroChecker()],
-        constraint_checker=PassTaskChecker(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(stock=stock, stock_name=stock_name),
     )
     solv_zero_count = sum(
         any(candidate.satisfies_solv(Tier.ZERO) for candidate in target_result.candidates)

--- a/scripts/lib-example-use.py
+++ b/scripts/lib-example-use.py
@@ -9,6 +9,7 @@ from retrocast.io import load_json_gz
 from retrocast.utils.logging import configure_script_logging, logger
 from retrocast.v2.adapters import AiZynthFinderAdapter
 from retrocast.v2.io import load_benchmark
+from retrocast.v2.models import CheckStatus, ConstraintResult, Route, RouteValidity, TaskConstraints, Tier, TierResult
 from retrocast.v2.workflow import (
     adapt_candidates,
     adapt_routes,
@@ -16,10 +17,26 @@ from retrocast.v2.workflow import (
     collect_routes,
     ingest_candidates,
     ingest_routes,
+    score,
 )
 
 RAW_PATH = Path("data/retrocast/2-raw/aizynthfinder-4.4.1-mcts-iter100-depth6/mkt-cnv-160/results.json.gz")
 BENCHMARK_PATH = Path("data/retrocast/1-benchmarks/definitions/mkt-cnv-160.json.gz")
+
+
+class PassTierZeroChecker:
+    tier = Tier.ZERO
+    name = "pass-tier-zero"
+
+    def check_route(self, route: Route) -> RouteValidity:
+        return RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.PASS)})
+
+
+class PassTaskChecker:
+    name = "pass-task"
+
+    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
+        return ConstraintResult(status=CheckStatus.PASS)
 
 
 def main() -> None:
@@ -59,6 +76,18 @@ def main() -> None:
     ingested_candidates = ingest_candidates(raw_payload, adapter, task)
     logger.info("ingest_routes: %s", sum(len(items) for items in ingested_routes.values()))
     logger.info("ingest_candidates: %s", sum(len(items) for items in ingested_candidates.values()))
+
+    evaluation = score(
+        collected_candidates,
+        task,
+        tier_checkers=[PassTierZeroChecker()],
+        constraint_checker=PassTaskChecker(),
+    )
+    solv_zero_count = sum(
+        any(candidate.satisfies_solv(Tier.ZERO) for candidate in target_result.candidates)
+        for target_result in evaluation.targets.values()
+    )
+    logger.info("score: solv_zero_targets=%s/%s", solv_zero_count, len(evaluation.targets))
 
 
 if __name__ == "__main__":

--- a/src/retrocast/v2/models/__init__.py
+++ b/src/retrocast/v2/models/__init__.py
@@ -1,6 +1,18 @@
 """Schema v2 models."""
 
 from retrocast.v2.models.candidates import Candidate, FailureRecord
+from retrocast.v2.models.evaluation import (
+    CheckResult,
+    CheckStatus,
+    ConstraintResult,
+    Evaluation,
+    ReactionValidity,
+    RouteValidity,
+    ScoredCandidate,
+    TargetResult,
+    Tier,
+    TierResult,
+)
 from retrocast.v2.models.route import (
     InChIKeyLevel,
     Molecule,
@@ -19,6 +31,10 @@ from retrocast.v2.models.task import Benchmark, Target, Task, TaskConstraints
 __all__ = [
     "Benchmark",
     "Candidate",
+    "CheckResult",
+    "CheckStatus",
+    "ConstraintResult",
+    "Evaluation",
     "FailureRecord",
     "InChIKeyLevel",
     "Molecule",
@@ -26,12 +42,18 @@ __all__ = [
     "MoleculeView",
     "Reaction",
     "ReactionId",
+    "ReactionValidity",
     "ReactionView",
     "Route",
     "RoutePath",
+    "RouteValidity",
+    "ScoredCandidate",
     "Target",
+    "TargetResult",
     "Task",
     "TaskConstraints",
+    "Tier",
+    "TierResult",
     "validate_molecule_id",
     "validate_reaction_id",
 ]

--- a/src/retrocast/v2/models/evaluation.py
+++ b/src/retrocast/v2/models/evaluation.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from enum import IntEnum, StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from retrocast.v2.models.candidates import FailureRecord
+from retrocast.v2.models.route import ReactionId, Route
+from retrocast.v2.models.task import Target, Task, TaskConstraints
+
+
+class CheckStatus(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_EVALUATED = "not_evaluated"
+
+
+class Tier(IntEnum):
+    ZERO = 0
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+
+class CheckResult(BaseModel):
+    code: str
+    status: CheckStatus = CheckStatus.FAIL
+    message: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class TierResult(BaseModel):
+    status: CheckStatus
+    checks: list[CheckResult] = Field(default_factory=list)
+
+
+class ReactionValidity(BaseModel):
+    reaction_id: ReactionId
+    tiers: dict[Tier, TierResult] = Field(default_factory=dict)
+
+
+class RouteValidity(BaseModel):
+    tiers: dict[Tier, TierResult] = Field(default_factory=dict)
+    reactions: list[ReactionValidity] = Field(default_factory=list)
+
+
+class ConstraintResult(BaseModel):
+    status: CheckStatus
+    checks: list[CheckResult] = Field(default_factory=list)
+
+
+class ScoredCandidate(BaseModel):
+    rank: int
+    route: Route | None = None
+    failure: FailureRecord | None = None
+    validity: RouteValidity = Field(default_factory=RouteValidity)
+    constraints: ConstraintResult = Field(default_factory=lambda: ConstraintResult(status=CheckStatus.NOT_EVALUATED))
+    matches_acceptable: bool = False
+    matched_acceptable_index: int | None = None
+
+    @model_validator(mode="after")
+    def _require_route_or_failure(self) -> ScoredCandidate:
+        if self.route is None and self.failure is None:
+            raise ValueError("ScoredCandidate requires route or failure.")
+        if self.route is not None and self.failure is not None:
+            raise ValueError("ScoredCandidate cannot contain both route and failure.")
+        return self
+
+    def has_route(self) -> bool:
+        return self.route is not None
+
+    def failed_adaptation(self) -> bool:
+        return self.failure is not None
+
+    def tier_result(self, tier: Tier) -> TierResult:
+        return self.validity.tiers.get(tier, TierResult(status=CheckStatus.NOT_EVALUATED))
+
+    def reaction_tier_result(self, reaction_id: ReactionId, tier: Tier) -> TierResult | None:
+        for reaction in self.validity.reactions:
+            if reaction.reaction_id == reaction_id:
+                return reaction.tiers.get(tier)
+        return None
+
+    def satisfies_validity(self, tier: Tier) -> bool:
+        return self.tier_result(tier).status == CheckStatus.PASS
+
+    def satisfies_task(self) -> bool:
+        return self.constraints.status == CheckStatus.PASS
+
+    def satisfies_solv(self, tier: Tier) -> bool:
+        return self.satisfies_validity(tier) and self.satisfies_task()
+
+
+class TargetResult(BaseModel):
+    target: Target
+    effective_constraints: TaskConstraints
+    candidates: list[ScoredCandidate] = Field(default_factory=list)
+
+
+class Evaluation(BaseModel):
+    task: Task
+    tiers: list[Tier] = Field(default_factory=list)
+    targets: dict[str, TargetResult] = Field(default_factory=dict)
+    schema_version: Literal["2"] = "2"

--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -8,10 +8,13 @@ from retrocast.v2.workflow.collect import (
     collect_routes,
 )
 from retrocast.v2.workflow.ingest import ingest_candidates, ingest_routes
+from retrocast.v2.workflow.score import ConstraintChecker, TierChecker, score, score_candidate, score_target
 
 __all__ = [
     "CollectedCandidates",
     "CollectedRoutes",
+    "ConstraintChecker",
+    "TierChecker",
     "adapt_candidates",
     "adapt_route",
     "adapt_routes",
@@ -19,4 +22,7 @@ __all__ = [
     "collect_routes",
     "ingest_candidates",
     "ingest_routes",
+    "score",
+    "score_candidate",
+    "score_target",
 ]

--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -8,13 +8,23 @@ from retrocast.v2.workflow.collect import (
     collect_routes,
 )
 from retrocast.v2.workflow.ingest import ingest_candidates, ingest_routes
-from retrocast.v2.workflow.score import ConstraintChecker, TierChecker, score, score_candidate, score_target
+from retrocast.v2.workflow.score import (
+    ConstraintChecker,
+    TaskConstraintChecker,
+    TierChecker,
+    TierZeroChecker,
+    score,
+    score_candidate,
+    score_target,
+)
 
 __all__ = [
     "CollectedCandidates",
     "CollectedRoutes",
     "ConstraintChecker",
+    "TaskConstraintChecker",
     "TierChecker",
+    "TierZeroChecker",
     "adapt_candidates",
     "adapt_route",
     "adapt_routes",

--- a/src/retrocast/v2/workflow/score.py
+++ b/src/retrocast/v2/workflow/score.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Protocol
 
+from retrocast.chem import canonicalize_smiles, get_inchi_key, reduce_inchikey
+from retrocast.exceptions import ChemError
+from retrocast.typing import InChIKeyStr
 from retrocast.v2.models.candidates import Candidate
 from retrocast.v2.models.evaluation import (
     CheckResult,
@@ -16,7 +19,7 @@ from retrocast.v2.models.evaluation import (
     Tier,
     TierResult,
 )
-from retrocast.v2.models.route import InChIKeyLevel, Route
+from retrocast.v2.models.route import InChIKeyLevel, Molecule, ReactionView, Route, RoutePath
 from retrocast.v2.models.task import Target, Task, TaskConstraints
 
 
@@ -31,6 +34,122 @@ class ConstraintChecker(Protocol):
     name: str
 
     def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult: ...
+
+
+class TierZeroChecker:
+    tier = Tier.ZERO
+    name = "tier-zero"
+
+    def check_route(self, route: Route) -> RouteValidity:
+        route_checks: list[CheckResult] = []
+        reaction_validity = []
+
+        for molecule in _iter_molecules(route.target):
+            try:
+                expected_inchikey = get_inchi_key(molecule.smiles)
+            except ChemError as exc:
+                route_checks.append(
+                    CheckResult(
+                        code="tier0.invalid_smiles",
+                        status=CheckStatus.FAIL,
+                        message=str(exc),
+                        details={"smiles": molecule.smiles},
+                    )
+                )
+                continue
+            if molecule.inchikey != expected_inchikey:
+                route_checks.append(
+                    CheckResult(
+                        code="tier0.inchikey_mismatch",
+                        status=CheckStatus.FAIL,
+                        details={
+                            "smiles": molecule.smiles,
+                            "actual_inchikey": molecule.inchikey,
+                            "expected_inchikey": expected_inchikey,
+                        },
+                    )
+                )
+
+        for reaction in _iter_reactions(route):
+            checks = []
+            if not reaction.value.reactants:
+                checks.append(CheckResult(code="tier0.empty_reactants", status=CheckStatus.FAIL))
+            reaction_validity.append(
+                ReactionValidity(
+                    reaction_id=reaction.id(),
+                    tiers={Tier.ZERO: TierResult(status=_checks_status(checks), checks=checks)},
+                )
+            )
+            route_checks.extend(checks)
+
+        return RouteValidity(
+            tiers={Tier.ZERO: TierResult(status=_checks_status(route_checks), checks=route_checks)},
+            reactions=reaction_validity,
+        )
+
+
+class TaskConstraintChecker:
+    name = "task-constraints"
+
+    def __init__(
+        self,
+        *,
+        stock: set[InChIKeyStr] | None = None,
+        stock_name: str | None = None,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    ) -> None:
+        self.stock = stock or set()
+        self.stock_name = stock_name
+        self.match_level = match_level
+        self._stock_keys = _reduce_inchikeys(self.stock, match_level)
+
+    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
+        checks = []
+
+        if constraints.stock is not None:
+            if self.stock_name is not None and constraints.stock != self.stock_name:
+                checks.append(
+                    CheckResult(
+                        code="constraint.stock_termination.stock_mismatch",
+                        status=CheckStatus.FAIL,
+                        details={"expected_stock": constraints.stock, "checker_stock": self.stock_name},
+                    )
+                )
+            missing_leaves = _missing_stock_leaves(route, self._stock_keys, self.match_level)
+            if missing_leaves:
+                checks.append(
+                    CheckResult(
+                        code="constraint.stock_termination.missing_leaf",
+                        status=CheckStatus.FAIL,
+                        details={"missing_leaf_inchikeys": missing_leaves},
+                    )
+                )
+
+        if constraints.required_leaves_smiles:
+            missing_required_leaves = _missing_required_leaves(
+                route, constraints.required_leaves_smiles, self.match_level
+            )
+            if missing_required_leaves:
+                checks.append(
+                    CheckResult(
+                        code="constraint.required_leaf.missing",
+                        status=CheckStatus.FAIL,
+                        details={"missing_leaf_smiles": missing_required_leaves},
+                    )
+                )
+
+        if isinstance(constraints.route_depth, int):
+            route_depth = _route_depth(route)
+            if route_depth > constraints.route_depth:
+                checks.append(
+                    CheckResult(
+                        code="constraint.route_depth.exceeded",
+                        status=CheckStatus.FAIL,
+                        details={"route_depth": route_depth, "max_depth": constraints.route_depth},
+                    )
+                )
+
+        return ConstraintResult(status=_checks_status(checks), checks=checks)
 
 
 def score_candidate(
@@ -165,3 +284,71 @@ def _acceptable_match_index(
         if route_signature == acceptable_route.signature(match_level):
             return index
     return None
+
+
+def _checks_status(checks: Sequence[CheckResult]) -> CheckStatus:
+    return CheckStatus.FAIL if checks else CheckStatus.PASS
+
+
+def _iter_molecules(molecule: Molecule) -> Sequence[Molecule]:
+    molecules = [molecule]
+    if molecule.product_of is not None:
+        for reactant in molecule.product_of.reactants:
+            molecules.extend(_iter_molecules(reactant))
+    return molecules
+
+
+def _iter_reactions(route: Route) -> Sequence[ReactionView]:
+    reactions = []
+
+    def visit(path: RoutePath) -> None:
+        molecule = route.molecule_at(path)
+        reaction = molecule.produced_by()
+        if reaction is None:
+            return
+        reactions.append(reaction)
+        for index, _ in enumerate(reaction.value.reactants):
+            visit(reaction.path.reactant(index))
+
+    visit(RoutePath.target())
+    return reactions
+
+
+def _leaf_molecules(route: Route) -> Sequence[Molecule]:
+    return [molecule for molecule in _iter_molecules(route.target) if molecule.product_of is None]
+
+
+def _reduce_inchikeys(inchikeys: set[InChIKeyStr], match_level: InChIKeyLevel) -> set[str]:
+    if match_level == InChIKeyLevel.FULL:
+        return set(inchikeys)
+    return {str(reduce_inchikey(inchikey, match_level)) for inchikey in inchikeys}
+
+
+def _missing_stock_leaves(route: Route, stock_keys: set[str], match_level: InChIKeyLevel) -> list[str]:
+    missing = []
+    for leaf in _leaf_molecules(route):
+        leaf_key = leaf.key(match_level)
+        if leaf_key not in stock_keys:
+            missing.append(leaf.inchikey)
+    return sorted(set(missing))
+
+
+def _missing_required_leaves(
+    route: Route,
+    required_leaves_smiles: Sequence[str],
+    match_level: InChIKeyLevel,
+) -> list[str]:
+    leaf_keys = {leaf.key(match_level) for leaf in _leaf_molecules(route)}
+    missing = []
+    for smiles in required_leaves_smiles:
+        required_key = get_inchi_key(canonicalize_smiles(smiles), level=match_level)
+        if required_key not in leaf_keys:
+            missing.append(smiles)
+    return missing
+
+
+def _route_depth(route: Route) -> int:
+    reactions = _iter_reactions(route)
+    if not reactions:
+        return 0
+    return max(reaction.path.depth() + 1 for reaction in reactions)

--- a/src/retrocast/v2/workflow/score.py
+++ b/src/retrocast/v2/workflow/score.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.models.evaluation import (
+    CheckResult,
+    CheckStatus,
+    ConstraintResult,
+    Evaluation,
+    ReactionValidity,
+    RouteValidity,
+    ScoredCandidate,
+    TargetResult,
+    Tier,
+    TierResult,
+)
+from retrocast.v2.models.route import InChIKeyLevel, Route
+from retrocast.v2.models.task import Target, Task, TaskConstraints
+
+
+class TierChecker(Protocol):
+    tier: Tier
+    name: str
+
+    def check_route(self, route: Route) -> RouteValidity: ...
+
+
+class ConstraintChecker(Protocol):
+    name: str
+
+    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult: ...
+
+
+def score_candidate(
+    candidate: Candidate,
+    *,
+    target: Target,
+    constraints: TaskConstraints,
+    tier_checkers: Sequence[TierChecker],
+    constraint_checker: ConstraintChecker,
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+) -> ScoredCandidate:
+    """Score one candidate while preserving failed adaptation slots."""
+    if candidate.failure is not None:
+        tiers = {checker.tier: _failed_tier_result(candidate) for checker in tier_checkers}
+        if Tier.ZERO not in tiers:
+            tiers[Tier.ZERO] = _failed_tier_result(candidate)
+        return ScoredCandidate(
+            rank=candidate.rank,
+            failure=candidate.failure,
+            validity=RouteValidity(tiers=tiers),
+            constraints=ConstraintResult(status=CheckStatus.NOT_EVALUATED),
+        )
+
+    route = candidate.route
+    if route is None:
+        raise ValueError("Candidate requires route or failure.")
+
+    validity = _check_route_validity(route, tier_checkers)
+    constraints_result = constraint_checker.check_route(route, constraints)
+    matched_index = _acceptable_match_index(route, target.acceptable_routes, acceptable_match_level)
+    return ScoredCandidate(
+        rank=candidate.rank,
+        route=route,
+        validity=validity,
+        constraints=constraints_result,
+        matches_acceptable=matched_index is not None,
+        matched_acceptable_index=matched_index,
+    )
+
+
+def score_target(
+    candidates: Sequence[Candidate],
+    *,
+    target: Target,
+    constraints: TaskConstraints,
+    tier_checkers: Sequence[TierChecker],
+    constraint_checker: ConstraintChecker,
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+) -> TargetResult:
+    return TargetResult(
+        target=target,
+        effective_constraints=constraints,
+        candidates=[
+            score_candidate(
+                candidate,
+                target=target,
+                constraints=constraints,
+                tier_checkers=tier_checkers,
+                constraint_checker=constraint_checker,
+                acceptable_match_level=acceptable_match_level,
+            )
+            for candidate in candidates
+        ],
+    )
+
+
+def score(
+    predictions: Mapping[str, Sequence[Candidate]],
+    task: Task,
+    *,
+    tier_checkers: Sequence[TierChecker],
+    constraint_checker: ConstraintChecker,
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+) -> Evaluation:
+    tiers = sorted({checker.tier for checker in tier_checkers})
+    return Evaluation(
+        task=task,
+        tiers=tiers,
+        targets={
+            target_id: score_target(
+                predictions.get(target_id, []),
+                target=target,
+                constraints=task.constraints.get(target_id, task.default_constraints),
+                tier_checkers=tier_checkers,
+                constraint_checker=constraint_checker,
+                acceptable_match_level=acceptable_match_level,
+            )
+            for target_id, target in task.targets.items()
+        },
+    )
+
+
+def _failed_tier_result(candidate: Candidate) -> TierResult:
+    failure = candidate.failure
+    return TierResult(
+        status=CheckStatus.FAIL,
+        checks=[
+            CheckResult(
+                code=failure.code if failure is not None else "adapter.unknown_failure",
+                status=CheckStatus.FAIL,
+                message=failure.message if failure is not None else None,
+                details=failure.context if failure is not None else {},
+            )
+        ],
+    )
+
+
+def _check_route_validity(route: Route, tier_checkers: Sequence[TierChecker]) -> RouteValidity:
+    validity = RouteValidity()
+    reactions_by_id: dict[str, ReactionValidity] = {}
+    for checker in tier_checkers:
+        result = checker.check_route(route)
+        validity.tiers.update(result.tiers)
+        for reaction in result.reactions:
+            existing = reactions_by_id.get(reaction.reaction_id)
+            if existing is None:
+                reactions_by_id[reaction.reaction_id] = reaction
+            else:
+                existing.tiers.update(reaction.tiers)
+    validity.reactions = list(reactions_by_id.values())
+    return validity
+
+
+def _acceptable_match_index(
+    route: Route,
+    acceptable_routes: Sequence[Route],
+    match_level: InChIKeyLevel,
+) -> int | None:
+    route_signature = route.signature(match_level)
+    for index, acceptable_route in enumerate(acceptable_routes):
+        if route_signature == acceptable_route.signature(match_level):
+            return index
+    return None

--- a/src/retrocast/v2/workflow/score.py
+++ b/src/retrocast/v2/workflow/score.py
@@ -45,8 +45,6 @@ def score_candidate(
     """Score one candidate while preserving failed adaptation slots."""
     if candidate.failure is not None:
         tiers = {checker.tier: _failed_tier_result(candidate) for checker in tier_checkers}
-        if Tier.ZERO not in tiers:
-            tiers[Tier.ZERO] = _failed_tier_result(candidate)
         return ScoredCandidate(
             rank=candidate.rank,
             failure=candidate.failure,
@@ -80,10 +78,9 @@ def score_target(
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
 ) -> TargetResult:
-    return TargetResult(
-        target=target,
-        effective_constraints=constraints,
-        candidates=[
+    scored_candidates = []
+    for candidate in candidates:
+        scored_candidates.append(
             score_candidate(
                 candidate,
                 target=target,
@@ -92,8 +89,12 @@ def score_target(
                 constraint_checker=constraint_checker,
                 acceptable_match_level=acceptable_match_level,
             )
-            for candidate in candidates
-        ],
+        )
+
+    return TargetResult(
+        target=target,
+        effective_constraints=constraints,
+        candidates=scored_candidates,
     )
 
 

--- a/tests/v2/workflow/test_score.py
+++ b/tests/v2/workflow/test_score.py
@@ -5,49 +5,16 @@ from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
 from retrocast.v2.models import (
     Candidate,
     CheckStatus,
-    ConstraintResult,
     FailureRecord,
     Molecule,
     Reaction,
-    ReactionValidity,
     Route,
-    RouteValidity,
     Target,
     Task,
     TaskConstraints,
     Tier,
-    TierResult,
 )
-from retrocast.v2.workflow.score import score, score_candidate
-
-
-class FixedTierChecker:
-    tier = Tier.ZERO
-    name = "fixed-tier-zero"
-
-    def __init__(self, status: CheckStatus = CheckStatus.PASS) -> None:
-        self.status = status
-
-    def check_route(self, route: Route) -> RouteValidity:
-        reaction_tiers = {}
-        try:
-            reaction_id = route.reaction_at("rc:r:/").id()
-        except KeyError:
-            reactions = []
-        else:
-            reaction_tiers[Tier.ZERO] = TierResult(status=self.status)
-            reactions = [ReactionValidity(reaction_id=reaction_id, tiers=reaction_tiers)]
-        return RouteValidity(tiers={Tier.ZERO: TierResult(status=self.status)}, reactions=reactions)
-
-
-class FixedConstraintChecker:
-    name = "fixed-task"
-
-    def __init__(self, status: CheckStatus = CheckStatus.PASS) -> None:
-        self.status = status
-
-    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
-        return ConstraintResult(status=self.status)
+from retrocast.v2.workflow.score import TaskConstraintChecker, TierZeroChecker, score, score_candidate
 
 
 def molecule(smiles: str, *, product_of: Reaction | None = None) -> Molecule:
@@ -66,6 +33,24 @@ def route(target_smiles: str = "CCO", reactant_smiles: tuple[str, ...] = ("C", "
             product_of=Reaction(reactants=[molecule(smiles) for smiles in reactant_smiles]),
         )
     )
+
+
+def stock_for(test_route: Route) -> set[InChIKeyStr]:
+    return {InChIKeyStr(get_inchi_key(smiles)) for smiles in leaf_smiles(test_route)}
+
+
+def leaf_smiles(test_route: Route) -> list[str]:
+    leaves = []
+
+    def visit(molecule: Molecule) -> None:
+        if molecule.product_of is None:
+            leaves.append(molecule.smiles)
+            return
+        for reactant in molecule.product_of.reactants:
+            visit(reactant)
+
+    visit(test_route.target)
+    return leaves
 
 
 def target(acceptable_routes: list[Route] | None = None) -> Target:
@@ -92,8 +77,8 @@ def test_failed_candidate_does_not_satisfy_solv_zero() -> None:
         candidate,
         target=target(),
         constraints=TaskConstraints(),
-        tier_checkers=[FixedTierChecker()],
-        constraint_checker=FixedConstraintChecker(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(),
     )
 
     assert scored.failed_adaptation()
@@ -103,12 +88,13 @@ def test_failed_candidate_does_not_satisfy_solv_zero() -> None:
 
 
 def test_valid_route_can_satisfy_tier_zero_and_task() -> None:
+    test_route = route()
     scored = score_candidate(
-        Candidate(rank=2, route=route()),
+        Candidate(rank=2, route=test_route),
         target=target(),
-        constraints=TaskConstraints(),
-        tier_checkers=[FixedTierChecker()],
-        constraint_checker=FixedConstraintChecker(),
+        constraints=TaskConstraints(stock="stock-a"),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(stock=stock_for(test_route), stock_name="stock-a"),
     )
 
     assert scored.has_route()
@@ -122,8 +108,8 @@ def test_task_constraint_failure_prevents_solv_zero() -> None:
         Candidate(rank=1, route=route()),
         target=target(),
         constraints=TaskConstraints(stock="stock-a"),
-        tier_checkers=[FixedTierChecker()],
-        constraint_checker=FixedConstraintChecker(CheckStatus.FAIL),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(stock=set(), stock_name="stock-a"),
     )
 
     assert scored.satisfies_validity(Tier.ZERO)
@@ -136,13 +122,45 @@ def test_reaction_validity_is_addressable_by_reaction_id() -> None:
         Candidate(rank=1, route=route()),
         target=target(),
         constraints=TaskConstraints(),
-        tier_checkers=[FixedTierChecker()],
-        constraint_checker=FixedConstraintChecker(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(),
     )
 
     result = scored.reaction_tier_result("rc:r:/", Tier.ZERO)
     assert result is not None
     assert result.status == CheckStatus.PASS
+
+
+def test_empty_reaction_fails_tier_zero() -> None:
+    invalid_route = Route(target=molecule("CCO", product_of=Reaction(reactants=[])))
+
+    scored = score_candidate(
+        Candidate(rank=1, route=invalid_route),
+        target=target(),
+        constraints=TaskConstraints(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(),
+    )
+
+    assert not scored.satisfies_validity(Tier.ZERO)
+    result = scored.reaction_tier_result("rc:r:/", Tier.ZERO)
+    assert result is not None
+    assert result.status == CheckStatus.FAIL
+
+
+def test_inchikey_mismatch_fails_tier_zero() -> None:
+    invalid_route = Route(target=Molecule(smiles=SmilesStr("CCO"), inchikey=InChIKeyStr(get_inchi_key("C"))))
+
+    scored = score_candidate(
+        Candidate(rank=1, route=invalid_route),
+        target=target(),
+        constraints=TaskConstraints(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(),
+    )
+
+    assert not scored.satisfies_validity(Tier.ZERO)
+    assert scored.tier_result(Tier.ZERO).checks[0].code == "tier0.inchikey_mismatch"
 
 
 def test_score_preserves_candidate_rank_and_records_acceptable_match() -> None:
@@ -152,8 +170,8 @@ def test_score_preserves_candidate_rank_and_records_acceptable_match() -> None:
     evaluation = score(
         {"ethanol": [Candidate(rank=7, route=predicted_route)]},
         task(benchmark_target),
-        tier_checkers=[FixedTierChecker()],
-        constraint_checker=FixedConstraintChecker(),
+        tier_checkers=[TierZeroChecker()],
+        constraint_checker=TaskConstraintChecker(),
     )
 
     scored = evaluation.targets["ethanol"].candidates[0]

--- a/tests/v2/workflow/test_score.py
+++ b/tests/v2/workflow/test_score.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.models import (
+    Candidate,
+    CheckStatus,
+    ConstraintResult,
+    FailureRecord,
+    Molecule,
+    Reaction,
+    ReactionValidity,
+    Route,
+    RouteValidity,
+    Target,
+    Task,
+    TaskConstraints,
+    Tier,
+    TierResult,
+)
+from retrocast.v2.workflow.score import score, score_candidate
+
+
+class FixedTierChecker:
+    tier = Tier.ZERO
+    name = "fixed-tier-zero"
+
+    def __init__(self, status: CheckStatus = CheckStatus.PASS) -> None:
+        self.status = status
+
+    def check_route(self, route: Route) -> RouteValidity:
+        reaction_tiers = {}
+        try:
+            reaction_id = route.reaction_at("rc:r:/").id()
+        except KeyError:
+            reactions = []
+        else:
+            reaction_tiers[Tier.ZERO] = TierResult(status=self.status)
+            reactions = [ReactionValidity(reaction_id=reaction_id, tiers=reaction_tiers)]
+        return RouteValidity(tiers={Tier.ZERO: TierResult(status=self.status)}, reactions=reactions)
+
+
+class FixedConstraintChecker:
+    name = "fixed-task"
+
+    def __init__(self, status: CheckStatus = CheckStatus.PASS) -> None:
+        self.status = status
+
+    def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
+        return ConstraintResult(status=self.status)
+
+
+def molecule(smiles: str, *, product_of: Reaction | None = None) -> Molecule:
+    canonical = canonicalize_smiles(smiles)
+    return Molecule(
+        smiles=SmilesStr(canonical),
+        inchikey=InChIKeyStr(get_inchi_key(canonical)),
+        product_of=product_of,
+    )
+
+
+def route(target_smiles: str = "CCO", reactant_smiles: tuple[str, ...] = ("C", "CO")) -> Route:
+    return Route(
+        target=molecule(
+            target_smiles,
+            product_of=Reaction(reactants=[molecule(smiles) for smiles in reactant_smiles]),
+        )
+    )
+
+
+def target(acceptable_routes: list[Route] | None = None) -> Target:
+    canonical = canonicalize_smiles("CCO")
+    return Target(
+        id="ethanol",
+        smiles=SmilesStr(canonical),
+        inchikey=InChIKeyStr(get_inchi_key(canonical)),
+        acceptable_routes=acceptable_routes or [],
+    )
+
+
+def task(benchmark_target: Target) -> Task:
+    return Task(name="small", targets={benchmark_target.id: benchmark_target})
+
+
+def test_failed_candidate_does_not_satisfy_solv_zero() -> None:
+    candidate = Candidate(
+        rank=1,
+        failure=FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="ethanol"),
+    )
+
+    scored = score_candidate(
+        candidate,
+        target=target(),
+        constraints=TaskConstraints(),
+        tier_checkers=[FixedTierChecker()],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert scored.failed_adaptation()
+    assert not scored.satisfies_validity(Tier.ZERO)
+    assert not scored.satisfies_task()
+    assert not scored.satisfies_solv(Tier.ZERO)
+
+
+def test_valid_route_can_satisfy_tier_zero_and_task() -> None:
+    scored = score_candidate(
+        Candidate(rank=2, route=route()),
+        target=target(),
+        constraints=TaskConstraints(),
+        tier_checkers=[FixedTierChecker()],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert scored.has_route()
+    assert scored.satisfies_validity(Tier.ZERO)
+    assert scored.satisfies_task()
+    assert scored.satisfies_solv(Tier.ZERO)
+
+
+def test_task_constraint_failure_prevents_solv_zero() -> None:
+    scored = score_candidate(
+        Candidate(rank=1, route=route()),
+        target=target(),
+        constraints=TaskConstraints(stock="stock-a"),
+        tier_checkers=[FixedTierChecker()],
+        constraint_checker=FixedConstraintChecker(CheckStatus.FAIL),
+    )
+
+    assert scored.satisfies_validity(Tier.ZERO)
+    assert not scored.satisfies_task()
+    assert not scored.satisfies_solv(Tier.ZERO)
+
+
+def test_reaction_validity_is_addressable_by_reaction_id() -> None:
+    scored = score_candidate(
+        Candidate(rank=1, route=route()),
+        target=target(),
+        constraints=TaskConstraints(),
+        tier_checkers=[FixedTierChecker()],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    result = scored.reaction_tier_result("rc:r:/", Tier.ZERO)
+    assert result is not None
+    assert result.status == CheckStatus.PASS
+
+
+def test_score_preserves_candidate_rank_and_records_acceptable_match() -> None:
+    predicted_route = route()
+    benchmark_target = target(acceptable_routes=[route(reactant_smiles=("CC", "O")), predicted_route])
+
+    evaluation = score(
+        {"ethanol": [Candidate(rank=7, route=predicted_route)]},
+        task(benchmark_target),
+        tier_checkers=[FixedTierChecker()],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    scored = evaluation.targets["ethanol"].candidates[0]
+    assert evaluation.tiers == [Tier.ZERO]
+    assert scored.rank == 7
+    assert scored.matches_acceptable
+    assert scored.matched_acceptable_index == 1


### PR DESCRIPTION
why: schema v2 can now adapt, collect, and ingest planner outputs, but cannot yet turn target-keyed candidates into an evaluation artifact. This adds the scoring slice needed before benchmark analysis.\n\nwhat changed: added v2 evaluation models, checker protocols, and score_candidate/score_target/score workflow functions. Scoring keeps route validity separate from task constraints, preserves failed adaptation candidates, records reaction-level validity, and marks acceptable-route matches by canonical route signature.\n\nrisk: the scoring workflow is checker-driven and does not bake in stock or chemistry policy yet. Tier checkers own chemical validity; the constraint checker owns task satisfaction. Failed adaptation candidates are always scored as not Solv-0.\n\nverification:\n- uv run pytest tests/v2\n- uv run ruff format --check src/retrocast/v2 tests/v2\n- uv run ruff check src/retrocast/v2 tests/v2\n- uv run ty check src/retrocast/v2/models/evaluation.py src/retrocast/v2/workflow/score.py tests/v2/workflow/test_score.py\n\nnotes: full uv run ty check src/retrocast/v2 tests/v2 still reports the pre-existing unrelated tests/v2/adapters/test_paroutes.py optional product_of issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782590661&installation_id=125602297&pr_number=112&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F112&signature=5a60f512be37dda8d5b514b3b7958c6922cb8897307423ddcfc7bada2cc1fc23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive evaluation and scoring system for model predictions across tasks and targets.
  * Introduced structured evaluation results with support for tier-based validity checking and constraint validation.
  * Enabled hierarchical scoring of individual predictions, targets, and entire tasks with customizable checker protocols.

* **Tests**
  * Added comprehensive test coverage for the new scoring functionality with multiple test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the schema v2 scoring slice: evaluation data models (`ScoredCandidate`, `TargetResult`, `Evaluation`, etc.) and the `score` / `score_target` / `score_candidate` workflow functions backed by `TierChecker` and `ConstraintChecker` protocols.

- **`src/retrocast/v2/models/evaluation.py`** \u2014 new Pydantic models covering tier validity, reaction-level validity, constraint results, and the top-level `Evaluation` aggregate, with a `model_validator` ensuring each `ScoredCandidate` carries either a route or a failure record.
- **`src/retrocast/v2/workflow/score.py`** \u2014 scoring logic including `TierZeroChecker` and `TaskConstraintChecker`; two defects are present regarding unhandled chemistry errors and silently unenforced string depth constraints.
- **`tests/v2/workflow/test_score.py`** \u2014 seven tests covering the main scoring paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing two defects in score.py: an unhandled ChemError in required-leaf validation and silently unenforced string route_depth constraints.

The core data models and most scoring paths are sound. However, `_missing_required_leaves` has no ChemError guard — an invalid SMILES in `required_leaves_smiles` causes an unhandled exception that crashes the entire scoring workflow. Separately, `TaskConstraints.route_depth` accepts string literals but they are silently skipped with no record, so routes may pass a depth constraint they should not.

src/retrocast/v2/workflow/score.py — specifically `_missing_required_leaves` (ChemError) and `TaskConstraintChecker.check_route` (string route_depth handling).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/workflow/score.py | Core scoring workflow; two defects: ChemError from invalid required_leaves_smiles propagates uncaught, and string route_depth constraints are silently skipped with no indication. |
| src/retrocast/v2/models/evaluation.py | New evaluation data models — well-structured with appropriate model validators. |
| tests/v2/workflow/test_score.py | Comprehensive scoring tests; no coverage for string route_depth or invalid required_leaves_smiles. |
| src/retrocast/v2/models/__init__.py | Re-exports new evaluation model types; additive and consistent. |
| src/retrocast/v2/workflow/__init__.py | Re-exports new workflow functions and checker classes; additive and consistent. |
| scripts/lib-example-use.py | Example script extended with stock loading and the new score() call. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["score(predictions, task)"] --> B["For each target_id in task.targets"]
    B --> C["score_target(candidates, target, constraints)"]
    C --> D["For each Candidate"]
    D --> E{candidate.failure?}
    E -- Yes --> F["ScoredCandidate with FAIL tiers\nconstraints=NOT_EVALUATED"]
    E -- No --> G["_check_route_validity(route, tier_checkers)"]
    G --> H["For each TierChecker\ncheck_route(route) → RouteValidity"]
    H --> I["Merge tiers & reactions\ninto RouteValidity"]
    I --> J["constraint_checker.check_route(route, constraints)"]
    J --> K["_acceptable_match_index(route, acceptable_routes)"]
    K --> L["ScoredCandidate\nvalidity + constraints + matches_acceptable"]
    L --> M["TargetResult"]
    M --> N["Evaluation"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/retrocast/v2/workflow/score.py:342-347
Unhandled `ChemError` in required-leaf validation. `canonicalize_smiles` and `get_inchi_key` both raise `ChemError` on invalid SMILES, but `_missing_required_leaves` has no try/except. If any entry in `constraints.required_leaves_smiles` is chemically invalid, `check_route` will crash with an unhandled exception instead of recording a `CheckResult`. `TierZeroChecker.check_route` handles the same error class correctly at lines 49-59 — the same pattern is needed here.

```suggestion
    missing = []
    for smiles in required_leaves_smiles:
        try:
            required_key = get_inchi_key(canonicalize_smiles(smiles), level=match_level)
        except ChemError:
            missing.append(smiles)
            continue
        if required_key not in leaf_keys:
            missing.append(smiles)
    return missing
```

### Issue 2 of 3
src/retrocast/v2/workflow/score.py:141-150
**String `route_depth` constraints are silently unenforced.** `TaskConstraints.route_depth` accepts `int | Literal["short", "medium", "long"] | None`, but the `isinstance(constraints.route_depth, int)` guard completely skips non-integer values. A benchmark with `route_depth="medium"` will never fail the depth check — no `CheckResult` is added, no `NOT_EVALUATED` entry is recorded, and the route silently appears to satisfy the depth constraint. If any existing or future benchmarks use string depth levels, their routes will be scored incorrectly.

### Issue 3 of 3
src/retrocast/v2/workflow/score.py:289-290
`_checks_status` treats any non-empty `checks` list as `FAIL`, regardless of whether each `CheckResult` has `status=PASS` or `status=FAIL`. All current callers only append to the list on failure, so behavior is correct today — but any future checker that records a passing check (e.g., for audit/debug purposes) would incorrectly flip the overall status to `FAIL`. Filtering on the actual status makes the contract explicit and prevents silent regressions.

```suggestion
def _checks_status(checks: Sequence[CheckResult]) -> CheckStatus:
    return CheckStatus.FAIL if any(c.status == CheckStatus.FAIL for c in checks) else CheckStatus.PASS
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Implement concrete v2 Solv-0 scoring"](https://github.com/ischemist/project-procrustes/commit/36c689f503842c53837da241f8b24103d12af462) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34446347)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->