### PR TITLE
Implement schema v2 analyze workflow

### DIFF
--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -345,6 +345,7 @@ class Task(BaseModel):
     targets: dict[str, Target]
     default_constraints: TaskConstraints = Field(default_factory=TaskConstraints)
     constraints: dict[str, TaskConstraints] = Field(default_factory=dict)
+    metric_label: str | None = None
     annotations: dict[str, Any] = Field(default_factory=dict)
     schema_version: str = "2"
 
@@ -361,6 +362,8 @@ class Benchmark(Task):
 - `long`: depth 7+
 
 One benchmark is a `Task`. One daedalus query is also a `Task`, usually with one target.
+
+`metric_label` controls the bracketed task name in Solv-N metrics, e.g. `Solv-0[buyables]`. If unset, the label is derived from effective target constraints in fixed order: stock label, `leaf`, `depth`. For example, stock termination plus per-target route-depth constraints becomes `buyables+depth`; stock termination plus per-target required leaves becomes `buyables+leaf`.
 
 ## 3. Ingest
 

--- a/docs/rationale/solv-n-evaluation.md
+++ b/docs/rationale/solv-n-evaluation.md
@@ -24,6 +24,8 @@ Fundamentally, Solv-N combines two key concepts:
 Solv-i[task] = Tier-i validity + satisfying task constraints
 ```
 
+The bracketed metric label should name the task semantics, not every per-target value. For example, stock termination against a purchasable set is `Solv-i[buyables]`; adding target-specific route-depth constraints gives `Solv-i[buyables+depth]`; adding target-specific required leaves gives `Solv-i[buyables+leaf]`. Exact constraint values remain in the task artifact.
+
 ### Tier-N Chemical Validity
 
 As a refresher (consult [Syntax of Matter](https://ischemist.com/syntax-of-matter) for more details):

--- a/scripts/lib-example-use.py
+++ b/scripts/lib-example-use.py
@@ -10,10 +10,10 @@ from retrocast.utils.logging import configure_script_logging, logger
 from retrocast.v2.adapters import AiZynthFinderAdapter
 from retrocast.v2.io import load_benchmark
 from retrocast.v2.metrics import TaskConstraintChecker
-from retrocast.v2.models import Tier
 from retrocast.v2.workflow import (
     adapt_candidates,
     adapt_routes,
+    analyze,
     collect_candidates,
     collect_routes,
     ingest_candidates,
@@ -72,26 +72,34 @@ def main() -> None:
         tier_checkers=[],
         constraint_checker=TaskConstraintChecker.stock_termination(stock=stock, stock_name=stock_name),
     )
-    target_count = len(evaluation.targets)
-    tier_zero_count = 0
-    solv_zero_count = 0
-    top_one_count = 0
-    top_ten_count = 0
-    for target_result in evaluation.targets.values():
-        candidates = target_result.candidates
-        if any(candidate.satisfies_validity(Tier.ZERO) for candidate in candidates):
-            tier_zero_count += 1
-        if any(candidate.satisfies_solv(Tier.ZERO) for candidate in candidates):
-            solv_zero_count += 1
-        if any(candidate.matches_acceptable for candidate in candidates[:1]):
-            top_one_count += 1
-        if any(candidate.matches_acceptable for candidate in candidates[:10]):
-            top_ten_count += 1
-
-    logger.info("score: tier_zero_targets=%s/%s", tier_zero_count, target_count)
-    logger.info("score: solv_zero_targets=%s/%s", solv_zero_count, target_count)
-    logger.info("score: top_one_targets=%s/%s", top_one_count, target_count)
-    logger.info("score: top_ten_targets=%s/%s", top_ten_count, target_count)
+    report = analyze(evaluation, ks=(1, 10))
+    logger.info("score: targets=%s", len(evaluation.targets))
+    for name, metric in report.metrics.items():
+        ci_low = "n/a" if metric.ci_low is None else f"{metric.ci_low:.3f}"
+        ci_high = "n/a" if metric.ci_high is None else f"{metric.ci_high:.3f}"
+        logger.info(
+            "analyze: %s=%.3f ci95=[%s, %s] count=%s",
+            name,
+            metric.value,
+            ci_low,
+            ci_high,
+            metric.count,
+        )
+    if not report.by_stratum:
+        logger.info("analyze: no stratified metrics")
+    for stratum, metrics in report.by_stratum.items():
+        for name, metric in metrics.items():
+            ci_low = "n/a" if metric.ci_low is None else f"{metric.ci_low:.3f}"
+            ci_high = "n/a" if metric.ci_high is None else f"{metric.ci_high:.3f}"
+            logger.info(
+                "analyze: stratum=%s metric=%s value=%.3f ci95=[%s, %s] count=%s",
+                stratum,
+                name,
+                metric.value,
+                ci_low,
+                ci_high,
+                metric.count,
+            )
 
 
 if __name__ == "__main__":

--- a/src/retrocast/metrics/bootstrap.py
+++ b/src/retrocast/metrics/bootstrap.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
 
 import numpy as np
@@ -210,7 +210,7 @@ def compute_paired_difference(
 
 
 def get_bootstrap_distribution(
-    targets: list[TargetEvaluation], extractor: Callable[[TargetEvaluation], float], n_boot: int = 10000, seed: int = 42
+    targets: Sequence[T], extractor: Callable[[T], float], n_boot: int = 10000, seed: int = 42
 ) -> np.ndarray:
     """
     Returns the raw array of bootstrap means. Shape: (n_boot,)

--- a/src/retrocast/v2/metrics/__init__.py
+++ b/src/retrocast/v2/metrics/__init__.py
@@ -1,5 +1,6 @@
 """Schema v2 metric checkers."""
 
+from retrocast.v2.metrics.analysis import summarize_targets
 from retrocast.v2.metrics.constraints import TaskConstraintChecker
 
-__all__ = ["TaskConstraintChecker"]
+__all__ = ["TaskConstraintChecker", "summarize_targets"]

--- a/src/retrocast/v2/metrics/analysis.py
+++ b/src/retrocast/v2/metrics/analysis.py
@@ -27,7 +27,7 @@ def summarize_targets(
     reconstruction_targets = [target for target in targets if target.target.acceptable_routes]
     if reconstruction_targets:
         for k in sorted(set(ks)):
-            metrics[f"acceptable_reconstruction_top_{k}"] = _top_k_reconstruction(
+            metrics[f"acceptable_reconstruction_top_{k}[{metric_label}]"] = _top_k_reconstruction(
                 reconstruction_targets,
                 k,
                 n_boot=n_boot,

--- a/src/retrocast/v2/metrics/analysis.py
+++ b/src/retrocast/v2/metrics/analysis.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from retrocast.metrics.bootstrap import get_bootstrap_distribution
+from retrocast.v2.models.analysis import MetricSummary
+from retrocast.v2.models.evaluation import TargetResult, Tier
+
+
+def summarize_targets(
+    targets: Sequence[TargetResult],
+    *,
+    tiers: Sequence[Tier],
+    ks: Sequence[int],
+    metric_label: str = "task",
+    n_boot: int = 10000,
+    seed: int = 42,
+) -> dict[str, MetricSummary]:
+    metrics: dict[str, MetricSummary] = {}
+    for tier in tiers:
+        metric_suffix = str(int(tier))
+        metrics[f"solv_{metric_suffix}[{metric_label}]_rate"] = _solv_rate(targets, tier, n_boot=n_boot, seed=seed)
+        metrics[f"mrr_solv_{metric_suffix}[{metric_label}]"] = _mrr_solv(targets, tier, n_boot=n_boot, seed=seed)
+
+    reconstruction_targets = [target for target in targets if target.target.acceptable_routes]
+    if reconstruction_targets:
+        for k in sorted(set(ks)):
+            metrics[f"acceptable_reconstruction_top_{k}"] = _top_k_reconstruction(
+                reconstruction_targets,
+                k,
+                n_boot=n_boot,
+                seed=seed,
+            )
+    return metrics
+
+
+def _solv_rate(targets: Sequence[TargetResult], tier: Tier, *, n_boot: int, seed: int) -> MetricSummary:
+    values = []
+    for target in targets:
+        values.append(1.0 if any(candidate.satisfies_solv(tier) for candidate in target.candidates) else 0.0)
+    return _summarize_values(values, n_boot=n_boot, seed=seed)
+
+
+def _mrr_solv(targets: Sequence[TargetResult], tier: Tier, *, n_boot: int, seed: int) -> MetricSummary:
+    values = []
+    for target in targets:
+        candidates = sorted(target.candidates, key=lambda candidate: candidate.rank)
+        reciprocal_rank = 0.0
+        for candidate in candidates:
+            if candidate.satisfies_solv(tier):
+                reciprocal_rank = 1.0 / candidate.rank
+                break
+        values.append(reciprocal_rank)
+    return _summarize_values(values, n_boot=n_boot, seed=seed)
+
+
+def _top_k_reconstruction(targets: Sequence[TargetResult], k: int, *, n_boot: int, seed: int) -> MetricSummary:
+    values = []
+    for target in targets:
+        ranked = sorted(target.candidates, key=lambda candidate: candidate.rank)
+        candidates = [candidate for candidate in ranked if candidate.satisfies_task()]
+        values.append(1.0 if any(candidate.matches_acceptable for candidate in candidates[:k]) else 0.0)
+    return _summarize_values(values, n_boot=n_boot, seed=seed)
+
+
+def _summarize_values(values: Sequence[float], *, n_boot: int, seed: int) -> MetricSummary:
+    if not values:
+        return MetricSummary(value=0.0, count=0)
+    distribution = get_bootstrap_distribution(values, lambda value: value, n_boot=n_boot, seed=seed)
+    return MetricSummary(
+        value=sum(values) / len(values),
+        count=len(values),
+        ci_low=float(np.percentile(distribution, 2.5)),
+        ci_high=float(np.percentile(distribution, 97.5)),
+    )

--- a/src/retrocast/v2/models/__init__.py
+++ b/src/retrocast/v2/models/__init__.py
@@ -1,5 +1,6 @@
 """Schema v2 models."""
 
+from retrocast.v2.models.analysis import AnalysisReport, MetricSummary
 from retrocast.v2.models.candidates import Candidate, FailureRecord
 from retrocast.v2.models.evaluation import (
     CheckResult,
@@ -29,6 +30,7 @@ from retrocast.v2.models.route import (
 from retrocast.v2.models.task import Benchmark, Target, Task, TaskConstraints
 
 __all__ = [
+    "AnalysisReport",
     "Benchmark",
     "Candidate",
     "CheckResult",
@@ -40,6 +42,7 @@ __all__ = [
     "Molecule",
     "MoleculeId",
     "MoleculeView",
+    "MetricSummary",
     "Reaction",
     "ReactionId",
     "ReactionValidity",

--- a/src/retrocast/v2/models/analysis.py
+++ b/src/retrocast/v2/models/analysis.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class MetricSummary(BaseModel):
+    value: float
+    count: int
+    ci_low: float | None = None
+    ci_high: float | None = None
+
+
+class AnalysisReport(BaseModel):
+    metrics: dict[str, MetricSummary] = Field(default_factory=dict)
+    by_stratum: dict[str, dict[str, MetricSummary]] = Field(default_factory=dict)

--- a/src/retrocast/v2/models/candidates.py
+++ b/src/retrocast/v2/models/candidates.py
@@ -18,7 +18,7 @@ class FailureRecord(BaseModel):
 
 
 class Candidate(BaseModel):
-    rank: int
+    rank: int = Field(ge=1)
     route: Route | None = None
     failure: FailureRecord | None = None
 

--- a/src/retrocast/v2/models/evaluation.py
+++ b/src/retrocast/v2/models/evaluation.py
@@ -51,7 +51,7 @@ class ConstraintResult(BaseModel):
 
 
 class ScoredCandidate(BaseModel):
-    rank: int
+    rank: int = Field(ge=1)
     route: Route | None = None
     failure: FailureRecord | None = None
     validity: RouteValidity = Field(default_factory=RouteValidity)

--- a/src/retrocast/v2/models/evaluation.py
+++ b/src/retrocast/v2/models/evaluation.py
@@ -101,5 +101,6 @@ class TargetResult(BaseModel):
 class Evaluation(BaseModel):
     task: Task
     tiers: list[Tier] = Field(default_factory=list)
+    metric_label: str = "task"
     targets: dict[str, TargetResult] = Field(default_factory=dict)
     schema_version: Literal["2"] = "2"

--- a/src/retrocast/v2/models/task.py
+++ b/src/retrocast/v2/models/task.py
@@ -46,6 +46,7 @@ class Task(BaseModel):
     targets: dict[str, Target]
     default_constraints: TaskConstraints = Field(default_factory=TaskConstraints)
     constraints: dict[str, TaskConstraints] = Field(default_factory=dict)
+    metric_label: str | None = None
     annotations: dict[str, Any] = Field(default_factory=dict)
     schema_version: Literal["2"] = "2"
 
@@ -55,6 +56,36 @@ class Task(BaseModel):
         if mismatches:
             raise ValueError("Task.targets keys must match Target.id values.")
         return self
+
+    def effective_constraints(self, target_id: str) -> TaskConstraints:
+        return self.constraints.get(target_id, self.default_constraints)
+
+    def derived_metric_label(self) -> str:
+        if self.metric_label is not None:
+            return self.metric_label
+
+        stocks = set()
+        has_leaf = False
+        has_depth = False
+        for target_id in self.targets:
+            constraints = self.effective_constraints(target_id)
+            if constraints.stock is not None:
+                stocks.add(constraints.stock)
+            if constraints.required_leaves_smiles:
+                has_leaf = True
+            if constraints.route_depth is not None:
+                has_depth = True
+
+        parts = []
+        if len(stocks) == 1:
+            parts.append(next(iter(stocks)))
+        elif len(stocks) > 1:
+            parts.append("mixed-stock")
+        if has_leaf:
+            parts.append("leaf")
+        if has_depth:
+            parts.append("depth")
+        return "+".join(parts) if parts else "task"
 
 
 class Benchmark(Task):

--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -1,6 +1,7 @@
 """Schema v2 workflow APIs."""
 
 from retrocast.v2.workflow.adapt import adapt_candidates, adapt_route, adapt_routes
+from retrocast.v2.workflow.analyze import analyze
 from retrocast.v2.workflow.collect import (
     CollectedCandidates,
     CollectedRoutes,
@@ -24,6 +25,7 @@ __all__ = [
     "adapt_candidates",
     "adapt_route",
     "adapt_routes",
+    "analyze",
     "collect_candidates",
     "collect_routes",
     "ingest_candidates",

--- a/src/retrocast/v2/workflow/analyze.py
+++ b/src/retrocast/v2/workflow/analyze.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from retrocast.v2.metrics.analysis import summarize_targets
+from retrocast.v2.models.analysis import AnalysisReport, MetricSummary
+from retrocast.v2.models.evaluation import Evaluation, TargetResult
+
+
+def analyze(
+    evaluation: Evaluation,
+    *,
+    ks: Sequence[int] = (1, 5, 10, 50),
+    stratify_by: Callable[[TargetResult], str | None] | None = None,
+    n_boot: int = 10000,
+    seed: int = 42,
+) -> AnalysisReport:
+    targets = list(evaluation.targets.values())
+    metrics = summarize_targets(
+        targets,
+        tiers=evaluation.tiers,
+        ks=ks,
+        metric_label=evaluation.metric_label,
+        n_boot=n_boot,
+        seed=seed,
+    )
+
+    by_stratum: dict[str, dict[str, MetricSummary]] = {}
+    if stratify_by is not None or any(_default_route_depth_stratum(target) is not None for target in targets):
+        strata: dict[str, list[TargetResult]] = {}
+        for target in targets:
+            stratum = _default_route_depth_stratum(target) if stratify_by is None else stratify_by(target)
+            if stratum is None:
+                continue
+            strata.setdefault(stratum, []).append(target)
+        by_stratum = {
+            stratum: summarize_targets(
+                stratum_targets,
+                tiers=evaluation.tiers,
+                ks=ks,
+                metric_label=evaluation.metric_label,
+                n_boot=n_boot,
+                seed=seed,
+            )
+            for stratum, stratum_targets in strata.items()
+        }
+
+    return AnalysisReport(metrics=metrics, by_stratum=by_stratum)
+
+
+def _default_route_depth_stratum(target: TargetResult) -> str | None:
+    if target.target.acceptable_routes:
+        return f"depth {target.target.acceptable_routes[0].depth()}"
+    route_depth = target.effective_constraints.route_depth
+    if route_depth is None:
+        return None
+    return f"depth {route_depth}"

--- a/src/retrocast/v2/workflow/analyze.py
+++ b/src/retrocast/v2/workflow/analyze.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 
 from retrocast.v2.metrics.analysis import summarize_targets
-from retrocast.v2.models.analysis import AnalysisReport, MetricSummary
+from retrocast.v2.models.analysis import AnalysisReport
 from retrocast.v2.models.evaluation import Evaluation, TargetResult
 
 
@@ -25,25 +25,23 @@ def analyze(
         seed=seed,
     )
 
-    by_stratum: dict[str, dict[str, MetricSummary]] = {}
-    if stratify_by is not None or any(_default_route_depth_stratum(target) is not None for target in targets):
-        strata: dict[str, list[TargetResult]] = {}
-        for target in targets:
-            stratum = _default_route_depth_stratum(target) if stratify_by is None else stratify_by(target)
-            if stratum is None:
-                continue
-            strata.setdefault(stratum, []).append(target)
-        by_stratum = {
-            stratum: summarize_targets(
-                stratum_targets,
-                tiers=evaluation.tiers,
-                ks=ks,
-                metric_label=evaluation.metric_label,
-                n_boot=n_boot,
-                seed=seed,
-            )
-            for stratum, stratum_targets in strata.items()
-        }
+    strata: dict[str, list[TargetResult]] = {}
+    for target in targets:
+        stratum = _default_route_depth_stratum(target) if stratify_by is None else stratify_by(target)
+        if stratum is None:
+            continue
+        strata.setdefault(stratum, []).append(target)
+    by_stratum = {
+        stratum: summarize_targets(
+            stratum_targets,
+            tiers=evaluation.tiers,
+            ks=ks,
+            metric_label=evaluation.metric_label,
+            n_boot=n_boot,
+            seed=seed,
+        )
+        for stratum, stratum_targets in strata.items()
+    }
 
     return AnalysisReport(metrics=metrics, by_stratum=by_stratum)
 

--- a/src/retrocast/v2/workflow/score.py
+++ b/src/retrocast/v2/workflow/score.py
@@ -105,7 +105,7 @@ def score(
     tiers = [Tier.ZERO, *sorted({checker.tier for checker in tier_checkers})]
     target_results = {}
     for target_id, target in task.targets.items():
-        constraints = task.constraints.get(target_id, task.default_constraints)
+        constraints = task.effective_constraints(target_id)
         target_results[target_id] = score_target(
             predictions.get(target_id, []),
             target=target,
@@ -114,7 +114,7 @@ def score(
             constraint_checker=constraint_checker,
             acceptable_match_level=acceptable_match_level,
         )
-    return Evaluation(task=task, tiers=tiers, targets=target_results)
+    return Evaluation(task=task, tiers=tiers, metric_label=task.derived_metric_label(), targets=target_results)
 
 
 def _tier_zero_validity(candidate: Candidate) -> RouteValidity:

--- a/tests/v2/models/test_candidates.py
+++ b/tests/v2/models/test_candidates.py
@@ -50,3 +50,9 @@ def test_candidate_rejects_both_route_and_failure() -> None:
 
     with pytest.raises(ValidationError):
         Candidate(rank=1, route=one_step_route(), failure=failure)
+
+
+@pytest.mark.unit
+def test_candidate_rejects_non_positive_rank() -> None:
+    with pytest.raises(ValidationError):
+        Candidate(rank=0, route=one_step_route())

--- a/tests/v2/models/test_task.py
+++ b/tests/v2/models/test_task.py
@@ -54,6 +54,49 @@ def test_task_constraints_derive_required_leaf_inchikeys_from_smiles() -> None:
 
 
 @pytest.mark.unit
+def test_task_derives_metric_label_from_effective_constraints() -> None:
+    t1 = Target(id="t1", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+    t2 = Target(id="t2", smiles=SmilesStr("CC"), inchikey=get_inchi_key("CC"))
+    task = Task(
+        name="constrained",
+        targets={"t1": t1, "t2": t2},
+        default_constraints=TaskConstraints(stock="buyables", route_depth=3),
+        constraints={"t2": TaskConstraints(stock="buyables", required_leaves_smiles=[SmilesStr("C")])},
+    )
+
+    assert task.derived_metric_label() == "buyables+leaf+depth"
+
+
+@pytest.mark.unit
+def test_task_metric_label_overrides_derived_metric_label() -> None:
+    target = Target(id="ethanol", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+    task = Task(
+        name="custom",
+        targets={target.id: target},
+        default_constraints=TaskConstraints(stock="buyables"),
+        metric_label="bidirectional",
+    )
+
+    assert task.derived_metric_label() == "bidirectional"
+
+
+@pytest.mark.unit
+def test_task_metric_label_marks_multiple_stocks_as_mixed() -> None:
+    t1 = Target(id="t1", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+    t2 = Target(id="t2", smiles=SmilesStr("CC"), inchikey=get_inchi_key("CC"))
+    task = Task(
+        name="mixed",
+        targets={"t1": t1, "t2": t2},
+        constraints={
+            "t1": TaskConstraints(stock="buyables"),
+            "t2": TaskConstraints(stock="enamine"),
+        },
+    )
+
+    assert task.derived_metric_label() == "mixed-stock"
+
+
+@pytest.mark.unit
 def test_benchmark_is_a_task_with_description() -> None:
     benchmark = Benchmark(name="bench", description="small", targets={})
 

--- a/tests/v2/workflow/test_analyze.py
+++ b/tests/v2/workflow/test_analyze.py
@@ -127,7 +127,7 @@ def test_mrr_uses_first_solv_satisfying_candidate() -> None:
 def test_top_k_reconstruction_is_omitted_without_acceptable_routes() -> None:
     report = analyze(evaluation({"ethanol": result(target("ethanol"), [solved_candidate(1)])}))
 
-    assert "acceptable_reconstruction_top_1" not in report.metrics
+    assert "acceptable_reconstruction_top_1[task]" not in report.metrics
 
 
 def test_top_k_reconstruction_ranks_after_task_satisfaction_filtering() -> None:
@@ -148,8 +148,8 @@ def test_top_k_reconstruction_ranks_after_task_satisfaction_filtering() -> None:
         ks=(1, 2),
     )
 
-    assert report.metrics["acceptable_reconstruction_top_1"].value == 0.0
-    assert report.metrics["acceptable_reconstruction_top_2"].value == 1.0
+    assert report.metrics["acceptable_reconstruction_top_1[task]"].value == 0.0
+    assert report.metrics["acceptable_reconstruction_top_2[task]"].value == 1.0
 
 
 def test_analyze_stratifies_by_primary_acceptable_route_depth() -> None:

--- a/tests/v2/workflow/test_analyze.py
+++ b/tests/v2/workflow/test_analyze.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pytest import approx
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
+from retrocast.v2.models import (
+    CheckStatus,
+    ConstraintResult,
+    Evaluation,
+    FailureRecord,
+    Molecule,
+    Reaction,
+    Route,
+    RouteValidity,
+    ScoredCandidate,
+    Target,
+    TargetResult,
+    Task,
+    TaskConstraints,
+    Tier,
+    TierResult,
+)
+from retrocast.v2.workflow.analyze import analyze
+
+
+def molecule(smiles: str, *, product_of: Reaction | None = None) -> Molecule:
+    canonical = canonicalize_smiles(smiles)
+    return Molecule(
+        smiles=SmilesStr(canonical),
+        inchikey=InChIKeyStr(get_inchi_key(canonical)),
+        product_of=product_of,
+    )
+
+
+def route() -> Route:
+    return Route(target=molecule("CCO", product_of=Reaction(reactants=[molecule("C"), molecule("CO")])))
+
+
+def route_with_depth(depth: int) -> Route:
+    current = molecule("C")
+    for _ in range(depth):
+        current = molecule("CCO", product_of=Reaction(reactants=[current]))
+    return Route(target=current)
+
+
+def target(target_id: str, *, acceptable_routes: list[Route] | None = None) -> Target:
+    canonical = canonicalize_smiles("CCO")
+    return Target(
+        id=target_id,
+        smiles=SmilesStr(canonical),
+        inchikey=InChIKeyStr(get_inchi_key(canonical)),
+        acceptable_routes=acceptable_routes or [],
+    )
+
+
+def solved_candidate(rank: int, *, matches_acceptable: bool = False) -> ScoredCandidate:
+    return ScoredCandidate(
+        rank=rank,
+        route=route(),
+        validity=RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.PASS)}),
+        constraints=ConstraintResult(status=CheckStatus.PASS),
+        matches_acceptable=matches_acceptable,
+    )
+
+
+def failed_candidate(rank: int) -> ScoredCandidate:
+    return ScoredCandidate(
+        rank=rank,
+        failure=FailureRecord(code=ErrorCode("adapter.schema_invalid"), target_id="ethanol"),
+        validity=RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.FAIL)}),
+        constraints=ConstraintResult(status=CheckStatus.NOT_EVALUATED),
+    )
+
+
+def unsolved_candidate(rank: int, *, matches_acceptable: bool = False) -> ScoredCandidate:
+    return ScoredCandidate(
+        rank=rank,
+        route=route(),
+        validity=RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.PASS)}),
+        constraints=ConstraintResult(status=CheckStatus.FAIL),
+        matches_acceptable=matches_acceptable,
+    )
+
+
+def evaluation(results: dict[str, TargetResult]) -> Evaluation:
+    task = Task(name="small", targets={target_id: result.target for target_id, result in results.items()})
+    return Evaluation(task=task, tiers=[Tier.ZERO], targets=results)
+
+
+def result(benchmark_target: Target, candidates: list[ScoredCandidate]) -> TargetResult:
+    return TargetResult(target=benchmark_target, effective_constraints=TaskConstraints(), candidates=candidates)
+
+
+def test_solv_rate_denominator_includes_failed_candidates() -> None:
+    report = analyze(
+        evaluation(
+            {
+                "failed": result(target("failed"), [failed_candidate(1)]),
+                "solved": result(target("solved"), [solved_candidate(1)]),
+            }
+        )
+    )
+
+    metric = report.metrics["solv_0[task]_rate"]
+    assert metric.count == 2
+    assert metric.value == approx(0.5)
+    assert metric.ci_low is not None
+    assert metric.ci_high is not None
+
+
+def test_mrr_uses_first_solv_satisfying_candidate() -> None:
+    report = analyze(
+        evaluation(
+            {
+                "ethanol": result(
+                    target("ethanol"),
+                    [unsolved_candidate(1), solved_candidate(5), solved_candidate(9)],
+                )
+            }
+        )
+    )
+
+    assert report.metrics["mrr_solv_0[task]"].value == approx(0.2)
+
+
+def test_top_k_reconstruction_is_omitted_without_acceptable_routes() -> None:
+    report = analyze(evaluation({"ethanol": result(target("ethanol"), [solved_candidate(1)])}))
+
+    assert "acceptable_reconstruction_top_1" not in report.metrics
+
+
+def test_top_k_reconstruction_ranks_after_task_satisfaction_filtering() -> None:
+    acceptable_route = route()
+    report = analyze(
+        evaluation(
+            {
+                "ethanol": result(
+                    target("ethanol", acceptable_routes=[acceptable_route]),
+                    [
+                        unsolved_candidate(1, matches_acceptable=True),
+                        solved_candidate(2, matches_acceptable=False),
+                        solved_candidate(3, matches_acceptable=True),
+                    ],
+                )
+            }
+        ),
+        ks=(1, 2),
+    )
+
+    assert report.metrics["acceptable_reconstruction_top_1"].value == 0.0
+    assert report.metrics["acceptable_reconstruction_top_2"].value == 1.0
+
+
+def test_analyze_stratifies_by_primary_acceptable_route_depth() -> None:
+    report = analyze(
+        evaluation(
+            {
+                "depth-1": result(
+                    target("depth-1", acceptable_routes=[route_with_depth(1)]),
+                    [solved_candidate(1)],
+                ),
+                "depth-2": result(
+                    target("depth-2", acceptable_routes=[route_with_depth(2)]),
+                    [failed_candidate(1)],
+                ),
+            }
+        )
+    )
+
+    assert report.by_stratum["depth 1"]["solv_0[task]_rate"].value == 1.0
+    assert report.by_stratum["depth 2"]["solv_0[task]_rate"].value == 0.0
+
+
+def test_analyze_stratifies_by_route_depth_constraint_when_no_acceptable_route_exists() -> None:
+    benchmark_target = target("ethanol")
+    report = analyze(
+        evaluation(
+            {
+                "ethanol": TargetResult(
+                    target=benchmark_target,
+                    effective_constraints=TaskConstraints(route_depth=3),
+                    candidates=[solved_candidate(1)],
+                )
+            }
+        )
+    )
+
+    assert report.by_stratum["depth 3"]["solv_0[task]_rate"].value == 1.0

--- a/tests/v2/workflow/test_score.py
+++ b/tests/v2/workflow/test_score.py
@@ -205,3 +205,21 @@ def test_score_preserves_candidate_rank_and_records_acceptable_match() -> None:
     assert scored.rank == 7
     assert scored.matches_acceptable
     assert scored.matched_acceptable_index == 1
+
+
+def test_score_records_metric_label_from_task() -> None:
+    benchmark_target = target()
+    benchmark_task = Task(
+        name="scoped",
+        targets={benchmark_target.id: benchmark_target},
+        default_constraints=TaskConstraints(stock="buyables", route_depth=3),
+    )
+
+    evaluation = score(
+        {"ethanol": [Candidate(rank=1, route=route())]},
+        benchmark_task,
+        tier_checkers=[],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert evaluation.metric_label == "buyables+depth"


### PR DESCRIPTION
why: PR5 needs the v2 score output to produce benchmark metrics instead of leaving users to hand-roll Solv-N, MRR, and reconstruction counts. The Solv-N bracket also needs a stable metric label so aggregate metrics are not ambiguous across task constraints.

what changed: added v2 AnalysisReport/MetricSummary models, pure analysis metrics with bootstrap CIs, the analyze workflow, task-derived metric labels, route-depth strata, and example-script logging. The bootstrap distribution helper is now typed generically so v2 can reuse it without old-schema adapters.

risk: metric semantics are the important boundary. Solv/MRR metrics use Evaluation.metric_label, Top-K reconstruction is emitted only when acceptable routes exist, and reconstruction ranking filters to task-satisfying candidates first. Default route-depth stratification uses primary acceptable route depth, falling back to route_depth constraints when acceptable routes are absent.

verification: uv run ruff check src/retrocast/v2 tests/v2 scripts/lib-example-use.py src/retrocast/metrics/bootstrap.py; uv run pytest tests/v2 tests/metrics/test_bootstrap.py; git diff --check.

follow-ups: CLI/IO wiring remains PR6 per the schema-v2 plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782609423&installation_id=125602297&pr_number=114&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F114&signature=ea92f93af80f2a8a59998978875c59124c02c4085d078e796e298b3fab3712a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `metric_label` field to tasks for customized metrics reporting
  * New `analyze()` function computes evaluation metrics with 95% confidence intervals
  * Metrics can be stratified by route depth or custom criteria

* **Documentation**
  * Updated schema design documentation with metric label field guidance

* **Tests**
  * Added comprehensive test coverage for metrics analysis and stratification functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the v2 analyze workflow, adding `AnalysisReport`/`MetricSummary` models, bootstrap-CI metric computation (Solv-N rate, MRR, top-k reconstruction), task-derived metric labels, and route-depth stratification on top of the existing v2 scoring pipeline.

- **New `analyze()` function** (`workflow/analyze.py`) aggregates `Evaluation` targets into global and per-stratum metrics; stratification defaults to primary acceptable route depth, falling back to the `route_depth` constraint.
- **`Task.derived_metric_label()`** derives a stable label from effective constraints (stock name, leaf, depth) used to namespace metric keys (e.g. `solv_0[buyables+depth]_rate`).
- **`bootstrap.py` generalised** from `list[TargetEvaluation]` to `Sequence[T]`, allowing v2 to reuse it without adapters; `rank ≥ 1` is now enforced on both `Candidate` and `ScoredCandidate`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one metric-correctness concern in the default stratification path.

The `_default_route_depth_stratum` fallback uses `f"depth {route_depth}"` directly, where `route_depth` can be a string literal. This produces stratum keys like `"depth short"` that co-exist with numeric `"depth 2"` keys in the same `AnalysisReport.by_stratum` dict, silently inflating stratum counts and making cross-stratum comparison misleading. All other logic — bootstrap CI computation, metric labelling, rank-zero guard, reconstruction filtering — looks correct.

src/retrocast/v2/workflow/analyze.py — specifically the `_default_route_depth_stratum` fallback branch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/workflow/analyze.py | New `analyze()` workflow; `_default_route_depth_stratum` can silently mix string constraint labels ("depth short") with numeric measured-depth strata ("depth 2") when `route_depth` is a string literal |
| src/retrocast/v2/metrics/analysis.py | New metric computation helpers; rank ≥ 1 is now enforced upstream so the MRR 1/rank calculation is safe; bootstrap CIs via `_summarize_values` look correct |
| src/retrocast/v2/models/task.py | Adds `metric_label` field and `derived_metric_label()` / `effective_constraints()` helpers; label derivation logic is consistent with docs and tests |
| src/retrocast/v2/models/evaluation.py | Adds `metric_label` to `Evaluation` (defaulting to "task"); enforces `rank ≥ 1` on `ScoredCandidate` |
| src/retrocast/metrics/bootstrap.py | Generalises `get_bootstrap_distribution` from `list[TargetEvaluation]` to `Sequence[T]`; backward-compatible with existing v1 callers |
| src/retrocast/v2/workflow/score.py | Minor refactor: replaces inline `constraints.get(...)` with `effective_constraints()` and propagates `derived_metric_label()` into the returned `Evaluation` |
| src/retrocast/v2/models/analysis.py | New `MetricSummary` and `AnalysisReport` Pydantic models; straightforward and well-scoped |
| tests/v2/workflow/test_analyze.py | Comprehensive test coverage for all new metrics and stratification paths; edge cases (no acceptable routes, task-satisfaction filtering for top-k) are well covered |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    E[Evaluation] --> A[analyze]
    A --> ST[summarize_targets\nglobal metrics]
    A --> STRAT{stratify_by?}
    STRAT -- custom fn --> CS[custom stratum key]
    STRAT -- None --> DR[_default_route_depth_stratum]
    DR -- acceptable_routes present --> RD[depth = acceptable_routes 0 .depth]
    DR -- no acceptable_routes --> CD[depth = effective_constraints.route_depth]
    CD -- int --> SK2[stratum 'depth N']
    CD -- string literal --> SK3[stratum 'depth short/medium/long']
    RD --> SK1[stratum 'depth N']
    CS --> SS[summarize_targets\nper-stratum metrics]
    SK1 --> SS
    SK2 --> SS
    SK3 --> SS
    ST --> AR[AnalysisReport]
    SS --> AR
    ST --> SV[_summarize_values\nbootstrap CI]
    SS --> SV
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/v2/workflow/analyze.py:49-55
**Mixed stratum key types when `route_depth` is a string constraint**

`TaskConstraints.route_depth` is typed `int | Literal["short", "medium", "long"] | None`. When a target has no `acceptable_routes` and its `route_depth` is a string (e.g. `"short"`), this function produces a stratum key of `"depth short"`. Meanwhile, targets whose depth is measured from `acceptable_routes[0].depth()` always produce numeric keys like `"depth 2"`.

These two cases end up as sibling keys in `AnalysisReport.by_stratum`. A target whose constraint says `route_depth="short"` might in practice have the same depth as a target that measured `depth=2`, but they land in different strata with no indication to the caller that the keys carry incomparable semantics (constraint label vs measured depth). This silently inflates the stratum count and can lead to incorrect per-depth aggregations.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address analyze review comments"](https://github.com/ischemist/project-procrustes/commit/4f2c1145c5870a15fe911bac0b98ef3349d24132) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34496244)</sub>

<!-- /greptile_comment -->