### PR TITLE
Add schema v2 CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ Homepage = "https://github.com/ischemist/project-procrustes"
 Issues = "https://github.com/ischemist/project-procrustes/issues"
 
 [project.scripts]
-retrocast = "retrocast.cli.main:main"
+retrocast = "retrocast.v2.cli.main:main"
 
 [project.optional-dependencies]
 viz = ["ischemist>=0.2.0", "kaleido>=1.1.0", "plotly>=6.3.0"]

--- a/src/retrocast/v2/adapters/__init__.py
+++ b/src/retrocast/v2/adapters/__init__.py
@@ -8,6 +8,12 @@ from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
 from retrocast.v2.adapters.molbuilder import MolBuilderAdapter
 from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
 from retrocast.v2.adapters.paroutes import PaRoutesAdapter
+from retrocast.v2.adapters.registry import (
+    ADAPTER_TYPES,
+    DEPRECATED_ADAPTER_SLUGS,
+    get_adapter,
+    normalize_adapter_slug,
+)
 from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
 from retrocast.v2.adapters.retrostar import RetroStarAdapter
 from retrocast.v2.adapters.synllama import SynLlamaAdapter
@@ -17,9 +23,11 @@ from retrocast.v2.adapters.ursa import UrsaAdapter
 
 __all__ = [
     "Adapter",
+    "ADAPTER_TYPES",
     "AdaptMode",
     "AiZynthFinderAdapter",
     "AskcosAdapter",
+    "DEPRECATED_ADAPTER_SLUGS",
     "DirectMultiStepAdapter",
     "DreamRetroErAdapter",
     "MolBuilderAdapter",
@@ -32,4 +40,6 @@ __all__ = [
     "SynPlannerAdapter",
     "SyntheseusAdapter",
     "UrsaAdapter",
+    "get_adapter",
+    "normalize_adapter_slug",
 ]

--- a/src/retrocast/v2/adapters/registry.py
+++ b/src/retrocast/v2/adapters/registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from retrocast.exceptions import AdapterResolutionError
+from retrocast.v2.adapters.aizynth import AiZynthFinderAdapter
+from retrocast.v2.adapters.askcos import AskcosAdapter
+from retrocast.v2.adapters.base import Adapter
+from retrocast.v2.adapters.dms import DirectMultiStepAdapter
+from retrocast.v2.adapters.dreamretro import DreamRetroErAdapter
+from retrocast.v2.adapters.molbuilder import MolBuilderAdapter
+from retrocast.v2.adapters.multistepttl import MultiStepTTLAdapter
+from retrocast.v2.adapters.paroutes import PaRoutesAdapter
+from retrocast.v2.adapters.retrochimera import RetroChimeraAdapter
+from retrocast.v2.adapters.retrostar import RetroStarAdapter
+from retrocast.v2.adapters.synllama import SynLlamaAdapter
+from retrocast.v2.adapters.synplanner import SynPlannerAdapter
+from retrocast.v2.adapters.syntheseus import SyntheseusAdapter
+from retrocast.v2.adapters.ursa import UrsaAdapter
+
+AdapterFactory = Callable[[], Adapter]
+
+ADAPTER_TYPES: dict[str, AdapterFactory] = {
+    "aizynthfinder": AiZynthFinderAdapter,
+    "askcos": AskcosAdapter,
+    "directmultistep": DirectMultiStepAdapter,
+    "dms": DirectMultiStepAdapter,
+    "dreamretroer": DreamRetroErAdapter,
+    "molbuilder": MolBuilderAdapter,
+    "multistepttl": MultiStepTTLAdapter,
+    "paroutes": PaRoutesAdapter,
+    "retrochimera": RetroChimeraAdapter,
+    "retrostar": RetroStarAdapter,
+    "synllama": SynLlamaAdapter,
+    "synplanner": SynPlannerAdapter,
+    "syntheseus": SyntheseusAdapter,
+    "ursa": UrsaAdapter,
+}
+
+DEPRECATED_ADAPTER_SLUGS = {
+    "aizynth": "aizynthfinder",
+    "dreamretro": "dreamretroer",
+    "retro-star": "retrostar",
+}
+
+
+def normalize_adapter_slug(name: str) -> str:
+    normalized = name.strip().lower()
+    return DEPRECATED_ADAPTER_SLUGS.get(normalized, normalized)
+
+
+def get_adapter(name: str) -> Adapter:
+    slug = normalize_adapter_slug(name)
+    try:
+        return ADAPTER_TYPES[slug]()
+    except KeyError as exc:
+        raise AdapterResolutionError(
+            f"Unknown v2 adapter: {name}",
+            code="adapter.unknown",
+            context={"adapter": name, "available_adapters": sorted(ADAPTER_TYPES)},
+        ) from exc

--- a/src/retrocast/v2/cli/__init__.py
+++ b/src/retrocast/v2/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Schema v2 command line interface."""

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -119,7 +119,6 @@ def _build_parser() -> argparse.ArgumentParser:
 
     score_parser = subparsers.add_parser("score", help="Score v2 processed candidates")
     _add_model_dataset_args(score_parser)
-    score_parser.add_argument("--stock", help="Override stock name")
     score_parser.add_argument("--ignore-stereo", action="store_true", help="Use stereo-agnostic stock matching")
 
     analyze_parser = subparsers.add_parser("analyze", help="Analyze v2 evaluation artifacts")
@@ -293,7 +292,7 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
 
     predictions = load_collected_candidates(candidates_path)
     task = load_benchmark(task_path)
-    stock_registry, stock_paths, output_label = _load_stock_registry(task, paths, stock_override=args.stock)
+    stock_registry, stock_paths, output_label = _load_stock_registry(task, paths)
     match_level = InChIKeyLevel.NO_STEREO if args.ignore_stereo else InChIKeyLevel.FULL
     evaluation = score(
         predictions=predictions,
@@ -447,16 +446,8 @@ def _manifest_directive(path: Path, key: str) -> str | None:
 def _load_stock_registry(
     task: Benchmark,
     paths: dict[str, Path],
-    *,
-    stock_override: str | None,
 ) -> tuple[dict[str, set[InChIKeyStr]], list[Path], str]:
     stock_names = _effective_stock_names(task)
-    if stock_override is not None:
-        stock_path = paths["stocks"] / f"{stock_override}.csv.gz"
-        stock = set(load_stock_file(stock_path, return_as="inchikey"))
-        registry_names = stock_names or {stock_override}
-        return {stock_name: stock for stock_name in registry_names}, [stock_path], stock_override
-
     stock_paths = []
     stock_registry = {}
     for stock_name in sorted(stock_names):

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -198,13 +198,12 @@ def handle_ingest(args: argparse.Namespace, config: dict[str, Any]) -> None:
     total_jobs = len(models) * len(benchmarks)
 
     if show_progress and total_jobs > 1:
-        with create_cli_progress(console=console, unit="jobs") as progress:
+        with create_cli_progress(console=console, unit="jobs") as progress, quiet_info_logs("retrocast"):
             task_id = progress.add_task("Ingesting model/dataset jobs", total=total_jobs)
-            with quiet_info_logs("retrocast"):
-                for model_name in models:
-                    for benchmark_name in benchmarks:
-                        _ingest_one(model_name, benchmark_name, paths, args, show_route_progress=False)
-                        progress.advance(task_id)
+            for model_name in models:
+                for benchmark_name in benchmarks:
+                    _ingest_one(model_name, benchmark_name, paths, args, show_route_progress=False)
+                    progress.advance(task_id)
         return
 
     for model_name in models:
@@ -246,23 +245,22 @@ def _ingest_one(
         benchmark_targets=task.targets,
     )
 
-    def run_ingest(progress_callback=None) -> tuple[Path, dict[str, object]]:
-        collected = ingest_candidates(raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback)
-        output_path = output_dir / "candidates.json.gz"
-        save_collected_candidates(collected, output_path)
-        return output_path, collected_candidate_statistics(collected).to_manifest_dict()
-
     if show_route_progress:
-        with create_cli_progress(console=console, unit="routes") as progress:
+        with create_cli_progress(console=console, unit="routes") as progress, quiet_info_logs("retrocast"):
             task_id = progress.add_task(f"Ingesting {model_name}/{benchmark_name}", total=progress_total)
-
-            def advance_progress() -> None:
-                progress.advance(task_id)
-
-            with quiet_info_logs("retrocast"):
-                output_path, stats = run_ingest(advance_progress)
+            collected = ingest_candidates(
+                raw_payload,
+                adapter,
+                task,
+                mode=args.mode,
+                progress_callback=lambda: progress.advance(task_id),
+            )
     else:
-        output_path, stats = run_ingest()
+        collected = ingest_candidates(raw_payload, adapter, task, mode=args.mode)
+
+    output_path = output_dir / "candidates.json.gz"
+    save_collected_candidates(collected, output_path)
+    stats = collected_candidate_statistics(collected).to_manifest_dict()
 
     write_manifest(
         output_dir / "manifest.json",

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +27,7 @@ from retrocast.paths import (
 )
 from retrocast.utils.logging import configure_script_logging
 from retrocast.v2.adapters import ADAPTER_TYPES, DEPRECATED_ADAPTER_SLUGS, get_adapter, normalize_adapter_slug
-from retrocast.v2.adapters.base import AdaptMode
+from retrocast.v2.adapters.base import Adapter, AdaptMode
 from retrocast.v2.cli.manifest import manifest_sidecar_path, write_manifest
 from retrocast.v2.cli.report import create_analysis_table, generate_markdown_report
 from retrocast.v2.io import (
@@ -163,8 +164,7 @@ def handle_adapt(args: argparse.Namespace) -> None:
         if args.benchmark is None:
             raise ValueError("--benchmark is required for target-keyed provider output")
         task = load_benchmark(args.benchmark)
-        collected = ingest_candidates(raw_payload, adapter, task, mode=mode)
-        candidates = _flatten_candidates(collected)
+        candidates = _adapt_target_keyed_candidates(raw_payload, adapter, task, mode=mode)
         save_candidates(candidates, args.output)
         stats = candidate_statistics(candidates).to_manifest_dict()
         sources = [args.input, args.benchmark]
@@ -481,6 +481,27 @@ def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | No
     if len(stock_names) == 1:
         return next(iter(stock_names))
     return None
+
+
+def _adapt_target_keyed_candidates(
+    raw_payload: Any, adapter: Adapter, task: Benchmark, *, mode: AdaptMode
+) -> list[Candidate]:
+    if not isinstance(raw_payload, Mapping):
+        raise ValueError("target-keyed provider output requires a mapping keyed by target id or target SMILES")
+
+    candidates = []
+    for target_id, target in task.targets.items():
+        if target_id in raw_payload:
+            candidates.extend(
+                adapt_candidates(raw_payload[target_id], adapter, mode=mode, target=target, source_key=target_id)
+            )
+        elif target.smiles in raw_payload:
+            candidates.extend(
+                adapt_candidates(
+                    raw_payload[target.smiles], adapter, mode=mode, target=target, source_key=target.smiles
+                )
+            )
+    return candidates
 
 
 def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -26,6 +26,7 @@ from retrocast.paths import (
     validate_directory_name,
     validate_filename,
 )
+from retrocast.typing import InChIKeyStr
 from retrocast.utils.logging import configure_script_logging
 from retrocast.v2.adapters import ADAPTER_TYPES, DEPRECATED_ADAPTER_SLUGS, get_adapter, normalize_adapter_slug
 from retrocast.v2.adapters.base import AdaptMode
@@ -297,23 +298,26 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
 
     predictions = load_collected_candidates(candidates_path)
     task = load_benchmark(task_path)
-    stock_name = _resolve_stock_name(task, args.stock) or "task"
-    stock: set[Any] = set()
+    stock_name = _resolve_stock_name(task, args.stock)
+    stock: set[InChIKeyStr] = set()
     stock_path: Path | None = None
-    if stock_name != "task":
+    if stock_name is not None:
         stock_path = paths["stocks"] / f"{stock_name}.csv.gz"
         stock = set(load_stock_file(stock_path, return_as="inchikey"))
     match_level = InChIKeyLevel.NO_STEREO if args.ignore_stereo else InChIKeyLevel.FULL
     evaluation = score(
-        predictions,
-        task,
+        predictions=predictions,
+        task=task,
         constraint_checker=TaskConstraintChecker(
-            stock=stock, stock_name=None if stock_name == "task" else stock_name, match_level=match_level
+            stock=stock,
+            stock_name=stock_name,
+            match_level=match_level,
         ),
         acceptable_match_level=match_level,
     )
 
-    output_dir = paths["scored"] / benchmark_name / model_name / stock_name
+    output_label = stock_name or "task"
+    output_dir = paths["scored"] / benchmark_name / model_name / output_label
     output_path = output_dir / "evaluation.json.gz"
     save_evaluation(evaluation, output_path)
     sources = [task_path, candidates_path] + ([stock_path] if stock_path is not None else [])
@@ -326,12 +330,12 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
         parameters={
             "model": model_name,
             "benchmark": benchmark_name,
-            "stock": stock_name,
+            "stock": output_label,
             "ignore_stereo": args.ignore_stereo,
         },
         statistics=evaluation_statistics(evaluation),
     )
-    logger.info("Scored %s/%s using %s to %s", model_name, benchmark_name, stock_name, output_path)
+    logger.info("Scored %s/%s using %s to %s", model_name, benchmark_name, output_label, output_path)
 
 
 def handle_analyze(args: argparse.Namespace, config: dict[str, Any]) -> None:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import logging
 import sys
-from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +26,7 @@ from retrocast.paths import (
 )
 from retrocast.utils.logging import configure_script_logging
 from retrocast.v2.adapters import ADAPTER_TYPES, DEPRECATED_ADAPTER_SLUGS, get_adapter, normalize_adapter_slug
-from retrocast.v2.adapters.base import Adapter, AdaptMode
+from retrocast.v2.adapters.base import AdaptMode
 from retrocast.v2.cli.manifest import manifest_sidecar_path, write_manifest
 from retrocast.v2.cli.report import create_analysis_table, generate_markdown_report
 from retrocast.v2.io import (
@@ -107,10 +106,6 @@ def _build_parser() -> argparse.ArgumentParser:
     adapt.add_argument("--input", required=True, type=Path)
     adapt.add_argument("--output", required=True, type=Path)
     adapt.add_argument("--adapter", required=True)
-    adapt.add_argument("--benchmark", type=Path, help="V2 task/benchmark for target-keyed raw output")
-    adapt.add_argument(
-        "--input-kind", choices=["provider-output", "target-keyed-provider-output"], default="provider-output"
-    )
     adapt.add_argument("--mode", choices=["strict", "prune"], default="strict")
 
     collect = subparsers.add_parser("collect", help="Collect v2 candidates by benchmark target")
@@ -159,30 +154,18 @@ def handle_adapt(args: argparse.Namespace) -> None:
     raw_payload = load_json_artifact(args.input)
     mode: AdaptMode = args.mode
     root_dir = args.output.parent.resolve()
-
-    if args.input_kind == "target-keyed-provider-output":
-        if args.benchmark is None:
-            raise ValueError("--benchmark is required for target-keyed provider output")
-        task = load_benchmark(args.benchmark)
-        candidates = _adapt_target_keyed_candidates(raw_payload, adapter, task, mode=mode)
-        save_candidates(candidates, args.output)
-        stats = candidate_statistics(candidates).to_manifest_dict()
-        sources = [args.input, args.benchmark]
-    else:
-        candidates = adapt_candidates(raw_payload, adapter, mode=mode)
-        save_candidates(candidates, args.output)
-        stats = candidate_statistics(candidates).to_manifest_dict()
-        sources = [args.input]
+    candidates = adapt_candidates(raw_payload, adapter, mode=mode)
+    save_candidates(candidates, args.output)
+    stats = candidate_statistics(candidates).to_manifest_dict()
 
     write_manifest(
         manifest_sidecar_path(args.output),
         action="[cli:v2]adapt",
-        sources=sources,
+        sources=[args.input],
         outputs=[args.output],
         root_dir=root_dir,
         parameters={
             "adapter": normalize_adapter_slug(args.adapter),
-            "input_kind": args.input_kind,
             "mode": mode,
         },
         statistics=stats,
@@ -481,27 +464,6 @@ def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | No
     if len(stock_names) == 1:
         return next(iter(stock_names))
     return None
-
-
-def _adapt_target_keyed_candidates(
-    raw_payload: Any, adapter: Adapter, task: Benchmark, *, mode: AdaptMode
-) -> list[Candidate]:
-    if not isinstance(raw_payload, Mapping):
-        raise ValueError("target-keyed provider output requires a mapping keyed by target id or target SMILES")
-
-    candidates = []
-    for target_id, target in task.targets.items():
-        if target_id in raw_payload:
-            candidates.extend(
-                adapt_candidates(raw_payload[target_id], adapter, mode=mode, target=target, source_key=target_id)
-            )
-        elif target.smiles in raw_payload:
-            candidates.extend(
-                adapt_candidates(
-                    raw_payload[target.smiles], adapter, mode=mode, target=target, source_key=target.smiles
-                )
-            )
-    return candidates
 
 
 def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import logging
 import sys
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -34,28 +33,21 @@ from retrocast.v2.io import (
     load_benchmark,
     load_candidates,
     load_collected_candidates,
-    load_collected_routes,
     load_evaluation,
-    load_routes,
     save_analysis_report,
     save_candidates,
     save_collected_candidates,
-    save_collected_routes,
     save_evaluation,
-    save_routes,
 )
 from retrocast.v2.metrics.constraints import TaskConstraintChecker
 from retrocast.v2.models import Candidate
-from retrocast.v2.models.route import InChIKeyLevel, Route
+from retrocast.v2.models.route import InChIKeyLevel
 from retrocast.v2.models.task import Benchmark
 from retrocast.v2.workflow import (
     adapt_candidates,
-    adapt_routes,
     analyze,
     collect_candidates,
-    collect_routes,
     ingest_candidates,
-    ingest_routes,
     score,
 )
 from retrocast.v2.workflow.stats import candidate_statistics, collected_candidate_statistics, evaluation_statistics
@@ -110,7 +102,7 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("config", help="Show resolved configuration and paths")
     subparsers.add_parser("list-adapters", help="List available schema v2 adapters")
 
-    adapt = subparsers.add_parser("adapt", help="Adapt raw planner output into v2 candidates or routes")
+    adapt = subparsers.add_parser("adapt", help="Adapt raw planner output into v2 candidates")
     adapt.add_argument("--input", required=True, type=Path)
     adapt.add_argument("--output", required=True, type=Path)
     adapt.add_argument("--adapter", required=True)
@@ -118,20 +110,17 @@ def _build_parser() -> argparse.ArgumentParser:
     adapt.add_argument(
         "--input-kind", choices=["provider-output", "target-keyed-provider-output"], default="provider-output"
     )
-    adapt.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
     adapt.add_argument("--mode", choices=["strict", "prune"], default="strict")
 
-    collect = subparsers.add_parser("collect", help="Collect v2 candidates or routes by benchmark target")
+    collect = subparsers.add_parser("collect", help="Collect v2 candidates by benchmark target")
     collect.add_argument("--input", required=True, type=Path)
     collect.add_argument("--benchmark", required=True, type=Path)
     collect.add_argument("--output", required=True, type=Path)
-    collect.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
 
     ingest = subparsers.add_parser("ingest", help="Project-mode v2 adapt plus collect")
     _add_model_dataset_args(ingest)
     ingest.add_argument("--adapter", help="Override adapter from raw manifest")
     ingest.add_argument("--mode", choices=["strict", "prune"], default="strict")
-    ingest.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
     ingest.add_argument("--no-progress", action="store_true", help="Disable progress bars during ingestion")
 
     score_parser = subparsers.add_parser("score", help="Score v2 processed candidates")
@@ -174,26 +163,15 @@ def handle_adapt(args: argparse.Namespace) -> None:
         if args.benchmark is None:
             raise ValueError("--benchmark is required for target-keyed provider output")
         task = load_benchmark(args.benchmark)
-        if args.artifact == "candidates":
-            collected = ingest_candidates(raw_payload, adapter, task, mode=mode)
-            candidates = _flatten_candidates(collected)
-            save_candidates(candidates, args.output)
-            stats = candidate_statistics(candidates).to_manifest_dict()
-        else:
-            collected_routes = ingest_routes(raw_payload, adapter, task, mode=mode)
-            routes = _flatten_collected_routes(collected_routes)
-            save_routes(routes, args.output)
-            stats = {"final_routes_saved": len(routes)}
+        collected = ingest_candidates(raw_payload, adapter, task, mode=mode)
+        candidates = _flatten_candidates(collected)
+        save_candidates(candidates, args.output)
+        stats = candidate_statistics(candidates).to_manifest_dict()
         sources = [args.input, args.benchmark]
     else:
-        if args.artifact == "candidates":
-            candidates = adapt_candidates(raw_payload, adapter, mode=mode)
-            save_candidates(candidates, args.output)
-            stats = candidate_statistics(candidates).to_manifest_dict()
-        else:
-            routes = adapt_routes(raw_payload, adapter, mode=mode)
-            save_routes(routes, args.output)
-            stats = {"final_routes_saved": len(routes)}
+        candidates = adapt_candidates(raw_payload, adapter, mode=mode)
+        save_candidates(candidates, args.output)
+        stats = candidate_statistics(candidates).to_manifest_dict()
         sources = [args.input]
 
     write_manifest(
@@ -205,24 +183,18 @@ def handle_adapt(args: argparse.Namespace) -> None:
         parameters={
             "adapter": normalize_adapter_slug(args.adapter),
             "input_kind": args.input_kind,
-            "artifact": args.artifact,
             "mode": mode,
         },
         statistics=stats,
     )
-    logger.info("Adapted v2 %s artifact to %s", args.artifact, args.output)
+    logger.info("Adapted v2 candidates to %s", args.output)
 
 
 def handle_collect(args: argparse.Namespace) -> None:
     task = load_benchmark(args.benchmark)
-    if args.artifact == "candidates":
-        collected = collect_candidates(load_candidates(args.input), task)
-        save_collected_candidates(collected, args.output)
-        stats = collected_candidate_statistics(collected).to_manifest_dict()
-    else:
-        collected_routes = collect_routes(load_routes(args.input), task)
-        save_collected_routes(collected_routes, args.output)
-        stats = {"final_routes_saved": sum(len(routes) for routes in collected_routes.values())}
+    collected = collect_candidates(load_candidates(args.input), task)
+    save_collected_candidates(collected, args.output)
+    stats = collected_candidate_statistics(collected).to_manifest_dict()
 
     write_manifest(
         manifest_sidecar_path(args.output),
@@ -230,10 +202,9 @@ def handle_collect(args: argparse.Namespace) -> None:
         sources=[args.input, args.benchmark],
         outputs=[args.output],
         root_dir=args.output.parent.resolve(),
-        parameters={"artifact": args.artifact},
         statistics=stats,
     )
-    logger.info("Collected v2 %s artifact to %s", args.artifact, args.output)
+    logger.info("Collected v2 candidates to %s", args.output)
 
 
 def handle_ingest(args: argparse.Namespace, config: dict[str, Any]) -> None:
@@ -293,18 +264,10 @@ def _ingest_one(
     )
 
     def run_ingest(progress_callback=None) -> tuple[Path, dict[str, object]]:
-        if args.artifact == "candidates":
-            collected = ingest_candidates(
-                raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback
-            )
-            output_path = output_dir / "candidates.json.gz"
-            save_collected_candidates(collected, output_path)
-            return output_path, collected_candidate_statistics(collected).to_manifest_dict()
-
-        routes = ingest_routes(raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback)
-        output_path = output_dir / "routes.json.gz"
-        save_collected_routes(routes, output_path)
-        return output_path, {"final_routes_saved": sum(len(target_routes) for target_routes in routes.values())}
+        collected = ingest_candidates(raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback)
+        output_path = output_dir / "candidates.json.gz"
+        save_collected_candidates(collected, output_path)
+        return output_path, collected_candidate_statistics(collected).to_manifest_dict()
 
     if show_route_progress:
         with create_cli_progress(console=console, unit="routes") as progress:
@@ -328,7 +291,6 @@ def _ingest_one(
             "model": model_name,
             "benchmark": benchmark_name,
             "adapter": normalize_adapter_slug(adapter_name),
-            "artifact": args.artifact,
             "mode": args.mode,
         },
         statistics=stats,
@@ -346,20 +308,11 @@ def handle_score(args: argparse.Namespace, config: dict[str, Any]) -> None:
 def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], args: argparse.Namespace) -> None:
     task_path = paths["benchmarks"] / f"{benchmark_name}.json.gz"
     candidates_path = paths["processed"] / benchmark_name / model_name / "candidates.json.gz"
-    routes_path = paths["processed"] / benchmark_name / model_name / "routes.json.gz"
-    if candidates_path.exists():
-        predictions = load_collected_candidates(candidates_path)
-        prediction_path = candidates_path
-    elif routes_path.exists():
-        predictions = {
-            target_id: [Candidate(rank=index, route=route) for index, route in enumerate(routes, start=1)]
-            for target_id, routes in load_collected_routes(routes_path).items()
-        }
-        prediction_path = routes_path
-    else:
-        logger.warning("Skipping %s/%s: no processed candidates or routes", model_name, benchmark_name)
+    if not candidates_path.exists():
+        logger.warning("Skipping %s/%s: no processed candidates", model_name, benchmark_name)
         return
 
+    predictions = load_collected_candidates(candidates_path)
     task = load_benchmark(task_path)
     stock_name = _resolve_stock_name(task, args.stock) or "task"
     stock: set[Any] = set()
@@ -380,7 +333,7 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
     output_dir = paths["scored"] / benchmark_name / model_name / stock_name
     output_path = output_dir / "evaluation.json.gz"
     save_evaluation(evaluation, output_path)
-    sources = [task_path, prediction_path] + ([stock_path] if stock_path is not None else [])
+    sources = [task_path, candidates_path] + ([stock_path] if stock_path is not None else [])
     write_manifest(
         output_dir / "manifest.json",
         action="score:v2",
@@ -532,10 +485,6 @@ def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | No
 
 def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:
     return [candidate for candidates in candidates_by_target.values() for candidate in candidates]
-
-
-def _flatten_collected_routes(routes_by_target: Mapping[str, Sequence[Route]]) -> list[Route]:
-    return [route for routes in routes_by_target.values() for route in routes]
 
 
 if __name__ == "__main__":

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -13,7 +13,7 @@ from rich.console import Console
 
 from retrocast import __version__
 from retrocast.cli.progress import create_cli_progress, estimate_raw_route_entries, quiet_info_logs
-from retrocast.exceptions import RetroCastException
+from retrocast.exceptions import ConfigurationError, RetroCastException
 from retrocast.io.blob import load_json_artifact
 from retrocast.io.data import load_stock_file
 from retrocast.paths import (
@@ -142,8 +142,15 @@ def _add_model_dataset_args(parser: argparse.ArgumentParser) -> None:
 def _load_config(config_path: Path) -> dict[str, Any]:
     if not config_path.exists():
         return {}
-    with open(config_path) as handle:
-        return yaml.safe_load(handle) or {}
+    try:
+        with open(config_path, encoding="utf-8") as handle:
+            return yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        raise ConfigurationError(
+            f"Failed to parse config file {config_path}",
+            code="config.parse_error",
+            context={"config_path": str(config_path)},
+        ) from exc
 
 
 def handle_adapt(args: argparse.Namespace) -> None:
@@ -350,7 +357,10 @@ def _analyze_one(model_name: str, benchmark_name: str, paths: dict[str, Path], a
         markdown_path = output_dir / "report.md"
         save_analysis_report(report, analysis_path)
         markdown_path.write_text(
-            generate_markdown_report(report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}")
+            generate_markdown_report(
+                report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}"
+            ),
+            encoding="utf-8",
         )
         write_manifest(
             output_dir / "manifest.json",
@@ -411,13 +421,13 @@ def _resolve_models(args: argparse.Namespace, paths: dict[str, Path], *, stage: 
         return []
 
     models = set()
-    for benchmark_dir in base.iterdir():
-        if not benchmark_dir.is_dir():
+    for top_level_dir in base.iterdir():
+        if not top_level_dir.is_dir():
             continue
         if stage == "ingest":
-            models.add(benchmark_dir.name)
+            models.add(top_level_dir.name)
         else:
-            for model_dir in benchmark_dir.iterdir():
+            for model_dir in top_level_dir.iterdir():
                 if model_dir.is_dir():
                     models.add(model_dir.name)
     return sorted(validate_directory_name(model, param_name="model") for model in models)

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -470,13 +470,7 @@ def _load_stock_registry(
         stock_registry[stock_name] = set(load_stock_file(stock_path, return_as="inchikey"))
         stock_paths.append(stock_path)
 
-    if not stock_names:
-        output_label = "task"
-    elif len(stock_names) == 1:
-        output_label = next(iter(stock_names))
-    else:
-        output_label = "mixed-stock"
-    return stock_registry, stock_paths, output_label
+    return stock_registry, stock_paths, task.derived_metric_label()
 
 
 def _effective_stock_names(task: Benchmark) -> set[str]:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -88,10 +87,7 @@ def main() -> None:
                 handle_analyze(args, config)
     except RetroCastException as exc:
         logger.error("Command failed: %s", exc, exc_info=True)
-        sys.exit(1)
-    except Exception as exc:
-        logger.error("Command failed: %s", exc, exc_info=True)
-        sys.exit(1)
+        raise SystemExit(1) from exc
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+
+from retrocast import __version__
+from retrocast.cli.progress import create_cli_progress, estimate_raw_route_entries, quiet_info_logs
+from retrocast.exceptions import RetroCastException
+from retrocast.io.blob import load_json_artifact
+from retrocast.io.data import load_stock_file
+from retrocast.paths import (
+    DEFAULT_DATA_DIR,
+    ENV_VAR_NAME,
+    get_data_dir_source,
+    get_paths,
+    resolve_data_dir,
+    validate_directory_name,
+    validate_filename,
+)
+from retrocast.utils.logging import configure_script_logging
+from retrocast.v2.adapters import ADAPTER_TYPES, DEPRECATED_ADAPTER_SLUGS, get_adapter, normalize_adapter_slug
+from retrocast.v2.adapters.base import AdaptMode
+from retrocast.v2.cli.manifest import manifest_sidecar_path, write_manifest
+from retrocast.v2.cli.report import create_analysis_table, generate_markdown_report
+from retrocast.v2.io import (
+    load_benchmark,
+    load_candidates,
+    load_collected_candidates,
+    load_collected_routes,
+    load_evaluation,
+    load_routes,
+    save_analysis_report,
+    save_candidates,
+    save_collected_candidates,
+    save_collected_routes,
+    save_evaluation,
+    save_routes,
+)
+from retrocast.v2.metrics.constraints import TaskConstraintChecker
+from retrocast.v2.models import Candidate
+from retrocast.v2.models.route import InChIKeyLevel, Route
+from retrocast.v2.models.task import Benchmark
+from retrocast.v2.workflow import (
+    adapt_candidates,
+    adapt_routes,
+    analyze,
+    collect_candidates,
+    collect_routes,
+    ingest_candidates,
+    ingest_routes,
+    score,
+)
+from retrocast.v2.workflow.stats import candidate_statistics, collected_candidate_statistics, evaluation_statistics
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def main() -> None:
+    configure_script_logging(use_rich=True)
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        if args.command == "adapt":
+            handle_adapt(args)
+        elif args.command == "collect":
+            handle_collect(args)
+        elif args.command == "list-adapters":
+            handle_list_adapters()
+        else:
+            config = _load_config(args.config)
+            config_data_dir = config.get("data_dir")
+            data_dir = resolve_data_dir(cli_arg=getattr(args, "data_dir", None), config_value=config_data_dir)
+            config["data_dir"] = str(data_dir)
+            config["_data_dir_source"] = get_data_dir_source(
+                cli_arg=getattr(args, "data_dir", None), config_value=config_data_dir
+            )
+            if args.command == "config":
+                handle_config(config)
+            elif args.command == "ingest":
+                handle_ingest(args, config)
+            elif args.command == "score":
+                handle_score(args, config)
+            elif args.command == "analyze":
+                handle_analyze(args, config)
+    except RetroCastException as exc:
+        logger.error("Command failed: %s", exc, exc_info=True)
+        sys.exit(1)
+    except Exception as exc:
+        logger.error("Command failed: %s", exc, exc_info=True)
+        sys.exit(1)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=f"Retrocast schema v2 CLI v{__version__}")
+    parser.add_argument("--config", type=Path, default=Path("retrocast-config.yaml"), help="Path to config file")
+    parser.add_argument("--data-dir", type=Path, help=f"Override data directory, or use {ENV_VAR_NAME}")
+    parser.add_argument("--version", "-V", action="version", version=f"retrocast {__version__}")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("config", help="Show resolved configuration and paths")
+    subparsers.add_parser("list-adapters", help="List available schema v2 adapters")
+
+    adapt = subparsers.add_parser("adapt", help="Adapt raw planner output into v2 candidates or routes")
+    adapt.add_argument("--input", required=True, type=Path)
+    adapt.add_argument("--output", required=True, type=Path)
+    adapt.add_argument("--adapter", required=True)
+    adapt.add_argument("--benchmark", type=Path, help="V2 task/benchmark for target-keyed raw output")
+    adapt.add_argument(
+        "--input-kind", choices=["provider-output", "target-keyed-provider-output"], default="provider-output"
+    )
+    adapt.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
+    adapt.add_argument("--mode", choices=["strict", "prune"], default="strict")
+
+    collect = subparsers.add_parser("collect", help="Collect v2 candidates or routes by benchmark target")
+    collect.add_argument("--input", required=True, type=Path)
+    collect.add_argument("--benchmark", required=True, type=Path)
+    collect.add_argument("--output", required=True, type=Path)
+    collect.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
+
+    ingest = subparsers.add_parser("ingest", help="Project-mode v2 adapt plus collect")
+    _add_model_dataset_args(ingest)
+    ingest.add_argument("--adapter", help="Override adapter from raw manifest")
+    ingest.add_argument("--mode", choices=["strict", "prune"], default="strict")
+    ingest.add_argument("--artifact", choices=["candidates", "routes"], default="candidates")
+    ingest.add_argument("--no-progress", action="store_true", help="Disable progress bars during ingestion")
+
+    score_parser = subparsers.add_parser("score", help="Score v2 processed candidates")
+    _add_model_dataset_args(score_parser)
+    score_parser.add_argument("--stock", help="Override stock name")
+    score_parser.add_argument("--ignore-stereo", action="store_true", help="Use stereo-agnostic stock matching")
+
+    analyze_parser = subparsers.add_parser("analyze", help="Analyze v2 evaluation artifacts")
+    _add_model_dataset_args(analyze_parser)
+    analyze_parser.add_argument("--stock", help="Specific stock to analyze")
+    analyze_parser.add_argument("--top-k", nargs="+", type=int, default=[1, 3, 5, 10, 20, 50, 100])
+    analyze_parser.add_argument("--n-boot", type=int, default=10000)
+
+    return parser
+
+
+def _add_model_dataset_args(parser: argparse.ArgumentParser) -> None:
+    model_group = parser.add_mutually_exclusive_group(required=True)
+    model_group.add_argument("--model")
+    model_group.add_argument("--all-models", action="store_true")
+    dataset_group = parser.add_mutually_exclusive_group(required=True)
+    dataset_group.add_argument("--dataset")
+    dataset_group.add_argument("--all-datasets", action="store_true")
+
+
+def _load_config(config_path: Path) -> dict[str, Any]:
+    if not config_path.exists():
+        return {}
+    with open(config_path, encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def handle_adapt(args: argparse.Namespace) -> None:
+    adapter = get_adapter(args.adapter)
+    raw_payload = load_json_artifact(args.input)
+    mode: AdaptMode = args.mode
+    root_dir = args.output.parent.resolve()
+
+    if args.input_kind == "target-keyed-provider-output":
+        if args.benchmark is None:
+            raise ValueError("--benchmark is required for target-keyed provider output")
+        task = load_benchmark(args.benchmark)
+        if args.artifact == "candidates":
+            collected = ingest_candidates(raw_payload, adapter, task, mode=mode)
+            candidates = _flatten_candidates(collected)
+            save_candidates(candidates, args.output)
+            stats = candidate_statistics(candidates).to_manifest_dict()
+        else:
+            collected_routes = ingest_routes(raw_payload, adapter, task, mode=mode)
+            routes = _flatten_collected_routes(collected_routes)
+            save_routes(routes, args.output)
+            stats = {"final_routes_saved": len(routes)}
+        sources = [args.input, args.benchmark]
+    else:
+        if args.artifact == "candidates":
+            candidates = adapt_candidates(raw_payload, adapter, mode=mode)
+            save_candidates(candidates, args.output)
+            stats = candidate_statistics(candidates).to_manifest_dict()
+        else:
+            routes = adapt_routes(raw_payload, adapter, mode=mode)
+            save_routes(routes, args.output)
+            stats = {"final_routes_saved": len(routes)}
+        sources = [args.input]
+
+    write_manifest(
+        manifest_sidecar_path(args.output),
+        action="[cli:v2]adapt",
+        sources=sources,
+        outputs=[args.output],
+        root_dir=root_dir,
+        parameters={
+            "adapter": normalize_adapter_slug(args.adapter),
+            "input_kind": args.input_kind,
+            "artifact": args.artifact,
+            "mode": mode,
+        },
+        statistics=stats,
+    )
+    logger.info("Adapted v2 %s artifact to %s", args.artifact, args.output)
+
+
+def handle_collect(args: argparse.Namespace) -> None:
+    task = load_benchmark(args.benchmark)
+    if args.artifact == "candidates":
+        collected = collect_candidates(load_candidates(args.input), task)
+        save_collected_candidates(collected, args.output)
+        stats = collected_candidate_statistics(collected).to_manifest_dict()
+    else:
+        collected_routes = collect_routes(load_routes(args.input), task)
+        save_collected_routes(collected_routes, args.output)
+        stats = {"final_routes_saved": sum(len(routes) for routes in collected_routes.values())}
+
+    write_manifest(
+        manifest_sidecar_path(args.output),
+        action="[cli:v2]collect",
+        sources=[args.input, args.benchmark],
+        outputs=[args.output],
+        root_dir=args.output.parent.resolve(),
+        parameters={"artifact": args.artifact},
+        statistics=stats,
+    )
+    logger.info("Collected v2 %s artifact to %s", args.artifact, args.output)
+
+
+def handle_ingest(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    paths = get_paths(Path(config.get("data_dir", DEFAULT_DATA_DIR)))
+    models = _resolve_models(args, paths, stage="ingest")
+    benchmarks = _resolve_benchmarks(args, paths)
+    show_progress = not getattr(args, "no_progress", False)
+    total_jobs = len(models) * len(benchmarks)
+
+    if show_progress and total_jobs > 1:
+        with create_cli_progress(console=console, unit="jobs") as progress:
+            task_id = progress.add_task("Ingesting model/dataset jobs", total=total_jobs)
+            with quiet_info_logs("retrocast"):
+                for model_name in models:
+                    for benchmark_name in benchmarks:
+                        _ingest_one(model_name, benchmark_name, paths, args, show_route_progress=False)
+                        progress.advance(task_id)
+        return
+
+    for model_name in models:
+        for benchmark_name in benchmarks:
+            _ingest_one(model_name, benchmark_name, paths, args, show_route_progress=show_progress)
+
+
+def _ingest_one(
+    model_name: str,
+    benchmark_name: str,
+    paths: dict[str, Path],
+    args: argparse.Namespace,
+    *,
+    show_route_progress: bool,
+) -> None:
+    raw_dir = paths["raw"] / model_name / benchmark_name
+    if not raw_dir.exists():
+        logger.warning("Skipping %s/%s: raw directory missing", model_name, benchmark_name)
+        return
+    adapter_name = args.adapter or _manifest_directive(raw_dir / "manifest.json", "adapter")
+    if adapter_name is None:
+        logger.warning("Skipping %s/%s: no adapter in CLI or manifest", model_name, benchmark_name)
+        return
+    raw_filename = _manifest_directive(raw_dir / "manifest.json", "raw_results_filename") or "results.json.gz"
+    raw_path = raw_dir / raw_filename
+    if not raw_path.exists():
+        logger.warning("Skipping %s/%s: raw file missing at %s", model_name, benchmark_name, raw_path)
+        return
+
+    task_path = paths["benchmarks"] / f"{benchmark_name}.json.gz"
+    task = load_benchmark(task_path)
+    raw_payload = load_json_artifact(raw_path)
+    adapter = get_adapter(adapter_name)
+    output_dir = paths["processed"] / benchmark_name / model_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    progress_total = estimate_raw_route_entries(
+        raw_payload,
+        input_kind="target-keyed-provider-output",
+        benchmark_targets=task.targets,
+    )
+
+    def run_ingest(progress_callback=None) -> tuple[Path, dict[str, object]]:
+        if args.artifact == "candidates":
+            collected = ingest_candidates(
+                raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback
+            )
+            output_path = output_dir / "candidates.json.gz"
+            save_collected_candidates(collected, output_path)
+            return output_path, collected_candidate_statistics(collected).to_manifest_dict()
+
+        routes = ingest_routes(raw_payload, adapter, task, mode=args.mode, progress_callback=progress_callback)
+        output_path = output_dir / "routes.json.gz"
+        save_collected_routes(routes, output_path)
+        return output_path, {"final_routes_saved": sum(len(target_routes) for target_routes in routes.values())}
+
+    if show_route_progress:
+        with create_cli_progress(console=console, unit="routes") as progress:
+            task_id = progress.add_task(f"Ingesting {model_name}/{benchmark_name}", total=progress_total)
+
+            def advance_progress() -> None:
+                progress.advance(task_id)
+
+            with quiet_info_logs("retrocast"):
+                output_path, stats = run_ingest(advance_progress)
+    else:
+        output_path, stats = run_ingest()
+
+    write_manifest(
+        output_dir / "manifest.json",
+        action="ingest:v2",
+        sources=[raw_path, task_path],
+        outputs=[output_path],
+        root_dir=paths["raw"].parent.resolve(),
+        parameters={
+            "model": model_name,
+            "benchmark": benchmark_name,
+            "adapter": normalize_adapter_slug(adapter_name),
+            "artifact": args.artifact,
+            "mode": args.mode,
+        },
+        statistics=stats,
+    )
+    logger.info("Ingested %s/%s to %s", model_name, benchmark_name, output_path)
+
+
+def handle_score(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    paths = get_paths(Path(config.get("data_dir", DEFAULT_DATA_DIR)))
+    for model_name in _resolve_models(args, paths, stage="score"):
+        for benchmark_name in _resolve_benchmarks(args, paths):
+            _score_one(model_name, benchmark_name, paths, args)
+
+
+def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], args: argparse.Namespace) -> None:
+    task_path = paths["benchmarks"] / f"{benchmark_name}.json.gz"
+    candidates_path = paths["processed"] / benchmark_name / model_name / "candidates.json.gz"
+    routes_path = paths["processed"] / benchmark_name / model_name / "routes.json.gz"
+    if candidates_path.exists():
+        predictions = load_collected_candidates(candidates_path)
+        prediction_path = candidates_path
+    elif routes_path.exists():
+        predictions = {
+            target_id: [Candidate(rank=index, route=route) for index, route in enumerate(routes, start=1)]
+            for target_id, routes in load_collected_routes(routes_path).items()
+        }
+        prediction_path = routes_path
+    else:
+        logger.warning("Skipping %s/%s: no processed candidates or routes", model_name, benchmark_name)
+        return
+
+    task = load_benchmark(task_path)
+    stock_name = _resolve_stock_name(task, args.stock) or "task"
+    stock: set[Any] = set()
+    stock_path: Path | None = None
+    if stock_name != "task":
+        stock_path = paths["stocks"] / f"{stock_name}.csv.gz"
+        stock = set(load_stock_file(stock_path, return_as="inchikey"))
+    match_level = InChIKeyLevel.NO_STEREO if args.ignore_stereo else InChIKeyLevel.FULL
+    evaluation = score(
+        predictions,
+        task,
+        constraint_checker=TaskConstraintChecker(
+            stock=stock, stock_name=None if stock_name == "task" else stock_name, match_level=match_level
+        ),
+        acceptable_match_level=match_level,
+    )
+
+    output_dir = paths["scored"] / benchmark_name / model_name / stock_name
+    output_path = output_dir / "evaluation.json.gz"
+    save_evaluation(evaluation, output_path)
+    sources = [task_path, prediction_path] + ([stock_path] if stock_path is not None else [])
+    write_manifest(
+        output_dir / "manifest.json",
+        action="score:v2",
+        sources=sources,
+        outputs=[output_path],
+        root_dir=paths["raw"].parent.resolve(),
+        parameters={
+            "model": model_name,
+            "benchmark": benchmark_name,
+            "stock": stock_name,
+            "ignore_stereo": args.ignore_stereo,
+        },
+        statistics=evaluation_statistics(evaluation),
+    )
+    logger.info("Scored %s/%s using %s to %s", model_name, benchmark_name, stock_name, output_path)
+
+
+def handle_analyze(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    paths = get_paths(Path(config.get("data_dir", DEFAULT_DATA_DIR)))
+    for model_name in _resolve_models(args, paths, stage="analyze"):
+        for benchmark_name in _resolve_benchmarks(args, paths):
+            _analyze_one(model_name, benchmark_name, paths, args)
+
+
+def _analyze_one(model_name: str, benchmark_name: str, paths: dict[str, Path], args: argparse.Namespace) -> None:
+    scored_base = paths["scored"] / benchmark_name / model_name
+    if not scored_base.exists():
+        logger.warning("Skipping %s/%s: no scored directory", model_name, benchmark_name)
+        return
+    stock_names = [args.stock] if args.stock else [path.name for path in scored_base.iterdir() if path.is_dir()]
+    for stock_name in stock_names:
+        evaluation_path = scored_base / stock_name / "evaluation.json.gz"
+        if not evaluation_path.exists():
+            logger.warning("Skipping missing evaluation %s", evaluation_path)
+            continue
+        evaluation = load_evaluation(evaluation_path)
+        report = analyze(evaluation, ks=args.top_k, n_boot=args.n_boot)
+        output_dir = paths["results"] / benchmark_name / model_name / stock_name
+        analysis_path = output_dir / "analysis.json.gz"
+        markdown_path = output_dir / "report.md"
+        save_analysis_report(report, analysis_path)
+        markdown_path.write_text(
+            generate_markdown_report(
+                report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}"
+            ),
+            encoding="utf-8",
+        )
+        write_manifest(
+            output_dir / "manifest.json",
+            action="analyze:v2",
+            sources=[evaluation_path],
+            outputs=[analysis_path, markdown_path],
+            root_dir=paths["raw"].parent.resolve(),
+            parameters={
+                "model": model_name,
+                "benchmark": benchmark_name,
+                "stock": stock_name,
+                "top_k": args.top_k,
+                "n_boot": args.n_boot,
+            },
+            statistics={"n_metrics": len(report.metrics), "n_strata": len(report.by_stratum)},
+        )
+        console.print(
+            create_analysis_table(report, title=f"Analysis Results: {model_name} / {benchmark_name} / {stock_name}")
+        )
+        console.print(f"\n[dim]Full report saved to: {output_dir}[/]\n")
+
+
+def handle_config(config: dict[str, Any]) -> None:
+    data_dir = Path(config.get("data_dir", DEFAULT_DATA_DIR))
+    paths = get_paths(data_dir)
+    console.print()
+    console.print("[bold]RetroCast Schema V2 Configuration[/bold]")
+    console.print("=" * 40)
+    console.print(f"\n[bold]Data directory:[/bold] {data_dir.resolve()}")
+    console.print(f"  Source: {config.get('_data_dir_source', 'unknown')}")
+    console.print("\n[bold]Resolved paths:[/bold]")
+    max_key_len = max(len(name) for name in paths)
+    for name, path in paths.items():
+        exists_marker = "[green]exists[/green]" if path.exists() else "[dim]missing[/dim]"
+        console.print(f"  {name:<{max_key_len}}: {path} ({exists_marker})")
+    console.print()
+
+
+def handle_list_adapters() -> None:
+    console.print("Available schema v2 adapters:")
+    for name in sorted(ADAPTER_TYPES):
+        console.print(f"  - {name}")
+    aliases = ", ".join(f"{alias} -> {canonical}" for alias, canonical in sorted(DEPRECATED_ADAPTER_SLUGS.items()))
+    if aliases:
+        console.print(f"Deprecated aliases: {aliases}")
+
+
+def _resolve_models(args: argparse.Namespace, paths: dict[str, Path], *, stage: str) -> list[str]:
+    if getattr(args, "model", None):
+        return [validate_directory_name(args.model, param_name="model")]
+    if stage == "ingest":
+        base = paths["raw"]
+    elif stage == "score":
+        base = paths["processed"]
+    else:
+        base = paths["scored"]
+    models = set()
+    if base.exists():
+        for benchmark_dir in base.iterdir():
+            if not benchmark_dir.is_dir():
+                continue
+            if stage == "ingest":
+                models.add(benchmark_dir.name)
+            else:
+                for model_dir in benchmark_dir.iterdir():
+                    if model_dir.is_dir():
+                        models.add(model_dir.name)
+    return sorted(validate_directory_name(model, param_name="model") for model in models)
+
+
+def _resolve_benchmarks(args: argparse.Namespace, paths: dict[str, Path]) -> list[str]:
+    if getattr(args, "dataset", None):
+        return [validate_filename(args.dataset, param_name="dataset")]
+    if not paths["benchmarks"].exists():
+        return []
+    return sorted(
+        validate_filename(path.name.removesuffix(".json.gz"), param_name="dataset")
+        for path in paths["benchmarks"].glob("*.json.gz")
+    )
+
+
+def _manifest_directive(path: Path, key: str) -> str | None:
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    value = payload.get("directives", {}).get(key)
+    return str(value) if value is not None else None
+
+
+def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | None:
+    if stock_override is not None:
+        return stock_override
+    stock_names = set()
+    for target_id in task.targets:
+        stock = task.effective_constraints(target_id).stock
+        if stock is not None:
+            stock_names.add(stock)
+    if len(stock_names) == 1:
+        return next(iter(stock_names))
+    return None
+
+
+def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:
+    return [candidate for candidates in candidates_by_target.values() for candidate in candidates]
+
+
+def _flatten_collected_routes(routes_by_target: Mapping[str, Sequence[Route]]) -> list[Route]:
+    return [route for routes in routes_by_target.values() for route in routes]
+
+
+if __name__ == "__main__":
+    main()

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -298,29 +298,22 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
 
     predictions = load_collected_candidates(candidates_path)
     task = load_benchmark(task_path)
-    stock_name = _resolve_stock_name(task, args.stock)
-    stock: set[InChIKeyStr] = set()
-    stock_path: Path | None = None
-    if stock_name is not None:
-        stock_path = paths["stocks"] / f"{stock_name}.csv.gz"
-        stock = set(load_stock_file(stock_path, return_as="inchikey"))
+    stock_registry, stock_paths, output_label = _load_stock_registry(task, paths, stock_override=args.stock)
     match_level = InChIKeyLevel.NO_STEREO if args.ignore_stereo else InChIKeyLevel.FULL
     evaluation = score(
         predictions=predictions,
         task=task,
         constraint_checker=TaskConstraintChecker(
-            stock=stock,
-            stock_name=stock_name,
+            stocks=stock_registry,
             match_level=match_level,
         ),
         acceptable_match_level=match_level,
     )
 
-    output_label = stock_name or "task"
     output_dir = paths["scored"] / benchmark_name / model_name / output_label
     output_path = output_dir / "evaluation.json.gz"
     save_evaluation(evaluation, output_path)
-    sources = [task_path, candidates_path] + ([stock_path] if stock_path is not None else [])
+    sources = [task_path, candidates_path, *stock_paths]
     write_manifest(
         output_dir / "manifest.json",
         action="score:v2",
@@ -457,17 +450,42 @@ def _manifest_directive(path: Path, key: str) -> str | None:
     return str(value) if value is not None else None
 
 
-def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | None:
+def _load_stock_registry(
+    task: Benchmark,
+    paths: dict[str, Path],
+    *,
+    stock_override: str | None,
+) -> tuple[dict[str, set[InChIKeyStr]], list[Path], str]:
+    stock_names = _effective_stock_names(task)
     if stock_override is not None:
-        return stock_override
+        stock_path = paths["stocks"] / f"{stock_override}.csv.gz"
+        stock = set(load_stock_file(stock_path, return_as="inchikey"))
+        registry_names = stock_names or {stock_override}
+        return {stock_name: stock for stock_name in registry_names}, [stock_path], stock_override
+
+    stock_paths = []
+    stock_registry = {}
+    for stock_name in sorted(stock_names):
+        stock_path = paths["stocks"] / f"{stock_name}.csv.gz"
+        stock_registry[stock_name] = set(load_stock_file(stock_path, return_as="inchikey"))
+        stock_paths.append(stock_path)
+
+    if not stock_names:
+        output_label = "task"
+    elif len(stock_names) == 1:
+        output_label = next(iter(stock_names))
+    else:
+        output_label = "mixed-stock"
+    return stock_registry, stock_paths, output_label
+
+
+def _effective_stock_names(task: Benchmark) -> set[str]:
     stock_names = set()
     for target_id in task.targets:
         stock = task.effective_constraints(target_id).stock
         if stock is not None:
             stock_names.add(stock)
-    if len(stock_names) == 1:
-        return next(iter(stock_names))
-    return None
+    return stock_names
 
 
 @contextmanager

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -4,6 +4,8 @@ import argparse
 import json
 import logging
 import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -245,18 +247,18 @@ def _ingest_one(
         benchmark_targets=task.targets,
     )
 
-    if show_route_progress:
-        with create_cli_progress(console=console, unit="routes") as progress, quiet_info_logs("retrocast"):
-            task_id = progress.add_task(f"Ingesting {model_name}/{benchmark_name}", total=progress_total)
-            collected = ingest_candidates(
-                raw_payload,
-                adapter,
-                task,
-                mode=args.mode,
-                progress_callback=lambda: progress.advance(task_id),
-            )
-    else:
-        collected = ingest_candidates(raw_payload, adapter, task, mode=args.mode)
+    with _route_progress(
+        enabled=show_route_progress,
+        description=f"Ingesting {model_name}/{benchmark_name}",
+        total=progress_total,
+    ) as advance_progress:
+        collected = ingest_candidates(
+            raw_payload=raw_payload,
+            adapter=adapter,
+            task=task,
+            mode=args.mode,
+            progress_callback=advance_progress,
+        )
 
     output_path = output_dir / "candidates.json.gz"
     save_collected_candidates(collected, output_path)
@@ -462,6 +464,22 @@ def _resolve_stock_name(task: Benchmark, stock_override: str | None) -> str | No
     if len(stock_names) == 1:
         return next(iter(stock_names))
     return None
+
+
+@contextmanager
+def _route_progress(
+    *,
+    enabled: bool,
+    description: str,
+    total: int | None,
+) -> Iterator[Callable[[], None] | None]:
+    if not enabled:
+        yield None
+        return
+
+    with create_cli_progress(console=console, unit="routes") as progress, quiet_info_logs("retrocast"):
+        task_id = progress.add_task(description, total=total)
+        yield lambda: progress.advance(task_id)
 
 
 def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:

--- a/src/retrocast/v2/cli/main.py
+++ b/src/retrocast/v2/cli/main.py
@@ -43,7 +43,6 @@ from retrocast.v2.io import (
     save_evaluation,
 )
 from retrocast.v2.metrics.constraints import TaskConstraintChecker
-from retrocast.v2.models import Candidate
 from retrocast.v2.models.route import InChIKeyLevel
 from retrocast.v2.models.task import Benchmark
 from retrocast.v2.workflow import (
@@ -148,7 +147,7 @@ def _add_model_dataset_args(parser: argparse.ArgumentParser) -> None:
 def _load_config(config_path: Path) -> dict[str, Any]:
     if not config_path.exists():
         return {}
-    with open(config_path, encoding="utf-8") as handle:
+    with open(config_path) as handle:
         return yaml.safe_load(handle) or {}
 
 
@@ -356,10 +355,7 @@ def _analyze_one(model_name: str, benchmark_name: str, paths: dict[str, Path], a
         markdown_path = output_dir / "report.md"
         save_analysis_report(report, analysis_path)
         markdown_path.write_text(
-            generate_markdown_report(
-                report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}"
-            ),
-            encoding="utf-8",
+            generate_markdown_report(report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}")
         )
         write_manifest(
             output_dir / "manifest.json",
@@ -416,17 +412,19 @@ def _resolve_models(args: argparse.Namespace, paths: dict[str, Path], *, stage: 
         base = paths["processed"]
     else:
         base = paths["scored"]
+    if not base.exists():
+        return []
+
     models = set()
-    if base.exists():
-        for benchmark_dir in base.iterdir():
-            if not benchmark_dir.is_dir():
-                continue
-            if stage == "ingest":
-                models.add(benchmark_dir.name)
-            else:
-                for model_dir in benchmark_dir.iterdir():
-                    if model_dir.is_dir():
-                        models.add(model_dir.name)
+    for benchmark_dir in base.iterdir():
+        if not benchmark_dir.is_dir():
+            continue
+        if stage == "ingest":
+            models.add(benchmark_dir.name)
+        else:
+            for model_dir in benchmark_dir.iterdir():
+                if model_dir.is_dir():
+                    models.add(model_dir.name)
     return sorted(validate_directory_name(model, param_name="model") for model in models)
 
 
@@ -444,7 +442,7 @@ def _resolve_benchmarks(args: argparse.Namespace, paths: dict[str, Path]) -> lis
 def _manifest_directive(path: Path, key: str) -> str | None:
     if not path.exists():
         return None
-    with open(path, encoding="utf-8") as handle:
+    with open(path) as handle:
         payload = json.load(handle)
     value = payload.get("directives", {}).get(key)
     return str(value) if value is not None else None
@@ -496,10 +494,6 @@ def _route_progress(
     with create_cli_progress(console=console, unit="routes") as progress, quiet_info_logs("retrocast"):
         task_id = progress.add_task(description, total=total)
         yield lambda: progress.advance(task_id)
-
-
-def _flatten_candidates(candidates_by_target: dict[str, list[Candidate]]) -> list[Candidate]:
-    return [candidate for candidates in candidates_by_target.values() for candidate in candidates]
 
 
 if __name__ == "__main__":

--- a/src/retrocast/v2/cli/manifest.py
+++ b/src/retrocast/v2/cli/manifest.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from retrocast import __version__
+from retrocast.io.provenance import calculate_file_hash
+from retrocast.models.provenance import FileInfo, Manifest
+
+
+def write_manifest(
+    path: Path,
+    *,
+    action: str,
+    sources: list[Path],
+    outputs: list[Path],
+    root_dir: Path,
+    parameters: dict[str, Any] | None = None,
+    statistics: dict[str, Any] | None = None,
+    summary: dict[str, Any] | None = None,
+) -> None:
+    manifest = Manifest(
+        schema_version="2",
+        retrocast_version=__version__,
+        created_at=datetime.now(UTC),
+        action=action,
+        parameters=parameters or {},
+        source_files=[_file_info(source, root_dir) for source in sources if source.exists()],
+        output_files=[_file_info(output, root_dir) for output in outputs],
+        statistics=statistics or {},
+        summary=summary or {},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+
+def manifest_sidecar_path(output_path: Path) -> Path:
+    for suffix in (".jsonl.gz", ".json.gz", ".csv.gz", ".txt.gz"):
+        if output_path.name.endswith(suffix):
+            return output_path.with_name(f"{output_path.name.removesuffix(suffix)}.manifest.json")
+    return output_path.with_name(f"{output_path.stem}.manifest.json")
+
+
+def _file_info(path: Path, root_dir: Path) -> FileInfo:
+    return FileInfo(path=_relative_path(path, root_dir), file_hash=calculate_file_hash(path))
+
+
+def _relative_path(path: Path, root_dir: Path) -> str:
+    resolved_root = root_dir.resolve()
+    resolved_path = path.resolve()
+    try:
+        return str(resolved_path.relative_to(resolved_root))
+    except ValueError:
+        return str(resolved_path)

--- a/src/retrocast/v2/cli/report.py
+++ b/src/retrocast/v2/cli/report.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+
+from rich.markup import escape
+from rich.table import Table
+
+from retrocast.v2.models.analysis import AnalysisReport, MetricSummary
+
+_SOLV_RATE = re.compile(r"^solv_(\d+)\[(.+)]_rate$")
+_MRR_SOLV = re.compile(r"^mrr_solv_(\d+)\[(.+)]$")
+_TOP_K = re.compile(r"^acceptable_reconstruction_top_(\d+)\[(.+)]$")
+
+
+def create_analysis_table(report: AnalysisReport, *, title: str = "Analysis Results") -> Table:
+    """Create the compact CLI table; stratified diagnostics stay in report.md."""
+    table = Table(title=escape(title), header_style="bold magenta", show_lines=False)
+    table.add_column("Metric", style="bold", min_width=32)
+    table.add_column("Value", justify="right")
+    table.add_column("95% CI", justify="center")
+    table.add_column("N", justify="right")
+
+    solv_metrics = _matching_metrics(report.metrics, _SOLV_RATE)
+    if solv_metrics:
+        table.add_row("[dim]Solv-N hierarchy[/]", "", "", "")
+        for name, metric, match in solv_metrics:
+            table.add_row(_solv_label(match), _format_value(name, metric), _format_ci(name, metric), str(metric.count))
+
+    mrr_metrics = _matching_metrics(report.metrics, _MRR_SOLV)
+    if mrr_metrics:
+        table.add_section()
+        table.add_row("[dim]Rank within Solv-N hierarchy[/]", "", "", "")
+        for name, metric, match in mrr_metrics:
+            table.add_row(_mrr_label(match), _format_value(name, metric), _format_ci(name, metric), str(metric.count))
+
+    top_k_metrics = _matching_metrics(report.metrics, _TOP_K)
+    if top_k_metrics:
+        table.add_section()
+        table.add_row("[dim]Benchmark route reconstruction[/]", "", "", "")
+        for name, metric, match in top_k_metrics:
+            table.add_row(_top_k_label(match), _format_value(name, metric), _format_ci(name, metric), str(metric.count))
+
+    return table
+
+
+def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation Report") -> str:
+    lines = [f"# {title}", "", "## Overall", ""]
+    lines.extend(_markdown_metric_table(report.metrics))
+    if report.by_stratum:
+        lines.extend(["", "## By Stratum", ""])
+        for stratum in sorted(report.by_stratum):
+            lines.extend([f"### {stratum}", ""])
+            lines.extend(_markdown_metric_table(report.by_stratum[stratum]))
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _markdown_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
+    lines = ["| Metric | Value | 95% CI | N |", "| --- | ---: | :---: | ---: |"]
+    for name, metric, match in _ordered_metrics(metrics):
+        lines.append(
+            f"| {_display_metric_name(name, match)} | {_format_value(name, metric, rich=False)} | "
+            f"{_format_ci(name, metric, rich=False)} | {metric.count} |"
+        )
+    return lines
+
+
+def _ordered_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, MetricSummary, re.Match[str]]]:
+    ordered = []
+    for pattern in (_SOLV_RATE, _MRR_SOLV, _TOP_K):
+        ordered.extend(_matching_metrics(metrics, pattern))
+    return ordered
+
+
+def _matching_metrics(
+    metrics: dict[str, MetricSummary], pattern: re.Pattern[str]
+) -> list[tuple[str, MetricSummary, re.Match[str]]]:
+    matches = []
+    for name, metric in metrics.items():
+        match = pattern.match(name)
+        if match is not None:
+            matches.append((name, metric, match))
+    return sorted(matches, key=lambda item: int(item[2].group(1)))
+
+
+def _display_metric_name(name: str, match: re.Match[str]) -> str:
+    if _SOLV_RATE.match(name):
+        return _plain_solv_label(match)
+    if _MRR_SOLV.match(name):
+        return _plain_mrr_label(match)
+    return _plain_top_k_label(match)
+
+
+def _solv_label(match: re.Match[str]) -> str:
+    return escape(_plain_solv_label(match))
+
+
+def _mrr_label(match: re.Match[str]) -> str:
+    return escape(_plain_mrr_label(match))
+
+
+def _top_k_label(match: re.Match[str]) -> str:
+    return escape(_plain_top_k_label(match))
+
+
+def _plain_solv_label(match: re.Match[str]) -> str:
+    return f"Solv-{match.group(1)}[{match.group(2)}]"
+
+
+def _plain_mrr_label(match: re.Match[str]) -> str:
+    return f"MRR Solv-{match.group(1)}[{match.group(2)}]"
+
+
+def _plain_top_k_label(match: re.Match[str]) -> str:
+    return f"Top-{match.group(1)}"
+
+
+def _format_value(name: str, metric: MetricSummary, *, rich: bool = True) -> str:
+    value = f"{metric.value:.3f}" if name.startswith("mrr_") else f"{metric.value:.1%}"
+    return f"[green]{value}[/]" if rich else value
+
+
+def _format_ci(name: str, metric: MetricSummary, *, rich: bool = True) -> str:
+    if metric.ci_low is None or metric.ci_high is None:
+        return ""
+    if name.startswith("mrr_"):
+        value = f"[{metric.ci_low:.3f}, {metric.ci_high:.3f}]"
+    else:
+        value = f"[{metric.ci_low:.1%}, {metric.ci_high:.1%}]"
+    return f"[green]{value}[/]" if rich else value

--- a/src/retrocast/v2/io/__init__.py
+++ b/src/retrocast/v2/io/__init__.py
@@ -1,23 +1,39 @@
 """Schema v2 IO helpers."""
 
 from retrocast.v2.io.data import (
+    load_analysis_report,
     load_benchmark,
+    load_candidates,
     load_collected_candidates,
     load_collected_routes,
+    load_evaluation,
+    load_routes,
     load_task,
+    save_analysis_report,
     save_benchmark,
+    save_candidates,
     save_collected_candidates,
     save_collected_routes,
+    save_evaluation,
+    save_routes,
     save_task,
 )
 
 __all__ = [
+    "load_analysis_report",
     "load_benchmark",
+    "load_candidates",
     "load_collected_candidates",
     "load_collected_routes",
+    "load_evaluation",
+    "load_routes",
     "load_task",
+    "save_analysis_report",
     "save_benchmark",
+    "save_candidates",
     "save_collected_candidates",
     "save_collected_routes",
+    "save_evaluation",
+    "save_routes",
     "save_task",
 ]

--- a/src/retrocast/v2/io/data.py
+++ b/src/retrocast/v2/io/data.py
@@ -7,13 +7,21 @@ from typing import TypeVar
 from pydantic import TypeAdapter, ValidationError
 
 from retrocast.exceptions import ArtifactDecodeError, ArtifactFormatError, ArtifactNotFoundError, ArtifactWriteError
+from retrocast.v2.models.analysis import AnalysisReport
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.models.evaluation import Evaluation
+from retrocast.v2.models.route import Route
 from retrocast.v2.models.task import Benchmark, Task
 from retrocast.v2.workflow.collect import CollectedCandidates, CollectedRoutes
 
 _TASK_ADAPTER = TypeAdapter(Task)
 _BENCHMARK_ADAPTER = TypeAdapter(Benchmark)
+_ROUTE_LIST_ADAPTER = TypeAdapter(list[Route])
+_CANDIDATE_LIST_ADAPTER = TypeAdapter(list[Candidate])
 _COLLECTED_ROUTES_ADAPTER = TypeAdapter(CollectedRoutes)
 _COLLECTED_CANDIDATES_ADAPTER = TypeAdapter(CollectedCandidates)
+_EVALUATION_ADAPTER = TypeAdapter(Evaluation)
+_ANALYSIS_REPORT_ADAPTER = TypeAdapter(AnalysisReport)
 
 T = TypeVar("T")
 
@@ -34,6 +42,22 @@ def save_benchmark(benchmark: Benchmark, path: Path) -> None:
     _save_model(benchmark, path, _BENCHMARK_ADAPTER, artifact="benchmark")
 
 
+def load_routes(path: Path) -> list[Route]:
+    return _load_model(path, _ROUTE_LIST_ADAPTER, artifact="routes")
+
+
+def save_routes(routes: list[Route], path: Path) -> None:
+    _save_model(routes, path, _ROUTE_LIST_ADAPTER, artifact="routes")
+
+
+def load_candidates(path: Path) -> list[Candidate]:
+    return _load_model(path, _CANDIDATE_LIST_ADAPTER, artifact="candidates")
+
+
+def save_candidates(candidates: list[Candidate], path: Path) -> None:
+    _save_model(candidates, path, _CANDIDATE_LIST_ADAPTER, artifact="candidates")
+
+
 def load_collected_routes(path: Path) -> CollectedRoutes:
     return _load_model(path, _COLLECTED_ROUTES_ADAPTER, artifact="collected_routes")
 
@@ -48,6 +72,22 @@ def load_collected_candidates(path: Path) -> CollectedCandidates:
 
 def save_collected_candidates(candidates: CollectedCandidates, path: Path) -> None:
     _save_model(candidates, path, _COLLECTED_CANDIDATES_ADAPTER, artifact="collected_candidates")
+
+
+def load_evaluation(path: Path) -> Evaluation:
+    return _load_model(path, _EVALUATION_ADAPTER, artifact="evaluation")
+
+
+def save_evaluation(evaluation: Evaluation, path: Path) -> None:
+    _save_model(evaluation, path, _EVALUATION_ADAPTER, artifact="evaluation")
+
+
+def load_analysis_report(path: Path) -> AnalysisReport:
+    return _load_model(path, _ANALYSIS_REPORT_ADAPTER, artifact="analysis_report")
+
+
+def save_analysis_report(report: AnalysisReport, path: Path) -> None:
+    _save_model(report, path, _ANALYSIS_REPORT_ADAPTER, artifact="analysis_report")
 
 
 def _load_model(path: Path, adapter: TypeAdapter[T], *, artifact: str) -> T:

--- a/src/retrocast/v2/metrics/constraints.py
+++ b/src/retrocast/v2/metrics/constraints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Protocol
 
 from retrocast.chem import reduce_inchikey
@@ -30,6 +30,7 @@ class TaskConstraintChecker:
         *,
         stock: set[InChIKeyStr] | None = None,
         stock_name: str | None = None,
+        stocks: Mapping[str, set[InChIKeyStr]] | None = None,
         match_level: InChIKeyLevel = InChIKeyLevel.FULL,
         checks: Sequence[ConstraintCheck] | None = None,
     ) -> None:
@@ -37,7 +38,7 @@ class TaskConstraintChecker:
             list(checks)
             if checks is not None
             else [
-                StockTerminationCheck(stock=stock, stock_name=stock_name, match_level=match_level),
+                StockTerminationCheck(stock=stock, stock_name=stock_name, stocks=stocks, match_level=match_level),
                 RequiredLeavesCheck(match_level=match_level),
                 RouteDepthCheck(),
             ]
@@ -49,9 +50,12 @@ class TaskConstraintChecker:
         *,
         stock: set[InChIKeyStr] | None = None,
         stock_name: str | None = None,
+        stocks: Mapping[str, set[InChIKeyStr]] | None = None,
         match_level: InChIKeyLevel = InChIKeyLevel.FULL,
     ) -> TaskConstraintChecker:
-        return cls(checks=[StockTerminationCheck(stock=stock, stock_name=stock_name, match_level=match_level)])
+        return cls(
+            checks=[StockTerminationCheck(stock=stock, stock_name=stock_name, stocks=stocks, match_level=match_level)]
+        )
 
     def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult:
         checks = []
@@ -69,28 +73,45 @@ class StockTerminationCheck:
         *,
         stock: set[InChIKeyStr] | None = None,
         stock_name: str | None = None,
+        stocks: Mapping[str, set[InChIKeyStr]] | None = None,
         match_level: InChIKeyLevel = InChIKeyLevel.FULL,
     ) -> None:
         self.stock_name = stock_name
         self.match_level = match_level
         self._stock_keys = {str(reduce_inchikey(inchikey, match_level)) for inchikey in stock or set()}
+        self._stock_keys_by_name = (
+            {
+                stock_name: {str(reduce_inchikey(inchikey, match_level)) for inchikey in stock_values}
+                for stock_name, stock_values in stocks.items()
+            }
+            if stocks is not None
+            else None
+        )
 
     def check_route(self, route: Route, constraints: TaskConstraints) -> list[CheckResult]:
         if constraints.stock is None:
             return []
+        if self._stock_keys_by_name is not None:
+            stock_keys = self._stock_keys_by_name.get(constraints.stock, set())
+            if not stock_keys:
+                return [self._no_stock_keys_check(constraints.stock)]
+            return self._check_stock(route, stock_keys=stock_keys)
         if not self._stock_keys:
-            return [
-                CheckResult(
-                    code="constraint.stock_termination.no_stock_keys",
-                    status=CheckStatus.FAIL,
-                    details={"stock": constraints.stock},
-                )
-            ]
+            return [self._no_stock_keys_check(constraints.stock)]
         return self._check_stock(route, constraints.stock)
 
-    def _check_stock(self, route: Route, expected_stock: str) -> list[CheckResult]:
+    def _no_stock_keys_check(self, stock_name: str) -> CheckResult:
+        return CheckResult(
+            code="constraint.stock_termination.no_stock_keys",
+            status=CheckStatus.FAIL,
+            details={"stock": stock_name},
+        )
+
+    def _check_stock(
+        self, route: Route, expected_stock: str | None = None, *, stock_keys: set[str] | None = None
+    ) -> list[CheckResult]:
         checks = []
-        if self.stock_name is not None and expected_stock != self.stock_name:
+        if expected_stock is not None and self.stock_name is not None and expected_stock != self.stock_name:
             checks.append(
                 CheckResult(
                     code="constraint.stock_termination.stock_mismatch",
@@ -99,9 +120,10 @@ class StockTerminationCheck:
                 )
             )
 
+        active_stock_keys = self._stock_keys if stock_keys is None else stock_keys
         missing_leaves = []
         for leaf in route.iter_leaves():
-            if leaf.key(self.match_level) not in self._stock_keys:
+            if leaf.key(self.match_level) not in active_stock_keys:
                 missing_leaves.append(leaf.value.inchikey)
         missing_leaves = sorted(set(missing_leaves))
         if missing_leaves:

--- a/src/retrocast/v2/models/task.py
+++ b/src/retrocast/v2/models/task.py
@@ -80,7 +80,7 @@ class Task(BaseModel):
         if len(stocks) == 1:
             parts.append(next(iter(stocks)))
         elif len(stocks) > 1:
-            parts.append("mixed-stock")
+            parts.append("stocks")
         if has_leaf:
             parts.append("leaf")
         if has_depth:

--- a/src/retrocast/v2/workflow/__init__.py
+++ b/src/retrocast/v2/workflow/__init__.py
@@ -16,11 +16,13 @@ from retrocast.v2.workflow.score import (
     score_candidate,
     score_target,
 )
+from retrocast.v2.workflow.stats import CandidateRunStatistics, candidate_statistics, collected_candidate_statistics
 
 __all__ = [
     "CollectedCandidates",
     "CollectedRoutes",
     "ConstraintChecker",
+    "CandidateRunStatistics",
     "TierChecker",
     "adapt_candidates",
     "adapt_route",
@@ -28,6 +30,8 @@ __all__ = [
     "analyze",
     "collect_candidates",
     "collect_routes",
+    "candidate_statistics",
+    "collected_candidate_statistics",
     "ingest_candidates",
     "ingest_routes",
     "score",

--- a/src/retrocast/v2/workflow/adapt.py
+++ b/src/retrocast/v2/workflow/adapt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import ValidationError
@@ -34,13 +35,18 @@ def adapt_routes(
     mode: AdaptMode = "strict",
     target: Target | None = None,
     source_key: str | None = None,
+    progress_callback: Callable[[], None] | None = None,
 ) -> list[Route]:
     """Adapt raw planner output into valid canonical routes."""
     routes: list[Route] = []
     for entry in adapter.iter_raw_routes(raw_payload, source_key=source_key):
-        route = adapt_route(entry.payload, adapter, mode=mode, target=target or _target_from_entry(entry))
-        if route is not None:
-            routes.append(route)
+        try:
+            route = adapt_route(entry.payload, adapter, mode=mode, target=target or _target_from_entry(entry))
+            if route is not None:
+                routes.append(route)
+        finally:
+            if progress_callback is not None:
+                progress_callback()
     return routes
 
 
@@ -51,20 +57,25 @@ def adapt_candidates(
     mode: AdaptMode = "strict",
     target: Target | None = None,
     source_key: str | None = None,
+    progress_callback: Callable[[], None] | None = None,
 ) -> list[Candidate]:
     """Adapt raw planner output while preserving failed candidate rank slots."""
     candidates: list[Candidate] = []
     for fallback_rank, entry in enumerate(adapter.iter_raw_routes(raw_payload, source_key=source_key), start=1):
-        rank = entry.source_order if entry.source_order is not None else fallback_rank
-        entry_target = target or _target_from_entry(entry)
         try:
-            route = adapter.cast(entry.payload, mode=mode, target=entry_target)
-        except (AdapterError, ChemError, ValidationError) as exc:
-            candidates.append(
-                Candidate(rank=rank, failure=_failure_from_exception(exc, target=entry_target, entry=entry))
-            )
-            continue
-        candidates.append(Candidate(rank=rank, route=route))
+            rank = entry.source_order if entry.source_order is not None else fallback_rank
+            entry_target = target or _target_from_entry(entry)
+            try:
+                route = adapter.cast(entry.payload, mode=mode, target=entry_target)
+            except (AdapterError, ChemError, ValidationError) as exc:
+                candidates.append(
+                    Candidate(rank=rank, failure=_failure_from_exception(exc, target=entry_target, entry=entry))
+                )
+                continue
+            candidates.append(Candidate(rank=rank, route=route))
+        finally:
+            if progress_callback is not None:
+                progress_callback()
     return candidates
 
 

--- a/src/retrocast/v2/workflow/ingest.py
+++ b/src/retrocast/v2/workflow/ingest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
 from retrocast.v2.adapters.base import Adapter, AdaptMode
@@ -20,11 +20,21 @@ def ingest_routes(
     task: Task,
     *,
     mode: AdaptMode = "strict",
+    progress_callback: Callable[[], None] | None = None,
 ) -> CollectedRoutes:
     """Adapt raw planner output into valid routes and collect them by target id."""
     routes = []
     for target, payload, source_key in _target_payloads(raw_payload, task):
-        routes.extend(adapt_routes(payload, adapter, mode=mode, target=target, source_key=source_key))
+        routes.extend(
+            adapt_routes(
+                payload,
+                adapter,
+                mode=mode,
+                target=target,
+                source_key=source_key,
+                progress_callback=progress_callback,
+            )
+        )
     return collect_routes(routes, task)
 
 
@@ -34,11 +44,21 @@ def ingest_candidates(
     task: Task,
     *,
     mode: AdaptMode = "strict",
+    progress_callback: Callable[[], None] | None = None,
 ) -> CollectedCandidates:
     """Adapt raw planner output into candidates and collect them by target id."""
     candidates = []
     for target, payload, source_key in _target_payloads(raw_payload, task):
-        candidates.extend(adapt_candidates(payload, adapter, mode=mode, target=target, source_key=source_key))
+        candidates.extend(
+            adapt_candidates(
+                payload,
+                adapter,
+                mode=mode,
+                target=target,
+                source_key=source_key,
+                progress_callback=progress_callback,
+            )
+        )
     return collect_candidates(candidates, task)
 
 

--- a/src/retrocast/v2/workflow/stats.py
+++ b/src/retrocast/v2/workflow/stats.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import statistics
+from collections.abc import Mapping, Sequence
+
+from pydantic import BaseModel, Field
+
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.models.evaluation import Evaluation, Tier
+
+
+class CandidateRunStatistics(BaseModel):
+    total_candidates_seen: int = 0
+    successful_candidates: int = 0
+    failed_candidates: int = 0
+    final_candidates_saved: int = 0
+    targets_with_at_least_one_candidate: set[str] = Field(default_factory=set)
+    candidates_per_target: dict[str, int] = Field(default_factory=dict)
+    failures_by_code: dict[str, int] = Field(default_factory=dict)
+    failures_by_target: dict[str, dict[str, int]] = Field(default_factory=dict)
+
+    @property
+    def num_targets_with_candidates(self) -> int:
+        return len(self.targets_with_at_least_one_candidate)
+
+    @property
+    def min_candidates_per_target(self) -> int:
+        return min(self.candidates_per_target.values()) if self.candidates_per_target else 0
+
+    @property
+    def max_candidates_per_target(self) -> int:
+        return max(self.candidates_per_target.values()) if self.candidates_per_target else 0
+
+    @property
+    def avg_candidates_per_target(self) -> float:
+        if not self.candidates_per_target:
+            return 0.0
+        return round(statistics.mean(self.candidates_per_target.values()), 2)
+
+    @property
+    def median_candidates_per_target(self) -> float:
+        if not self.candidates_per_target:
+            return 0.0
+        return round(statistics.median(self.candidates_per_target.values()), 2)
+
+    def to_manifest_dict(self) -> dict[str, object]:
+        return {
+            "total_candidates_seen": self.total_candidates_seen,
+            "successful_candidates": self.successful_candidates,
+            "failed_candidates": self.failed_candidates,
+            "final_candidates_saved": self.final_candidates_saved,
+            "num_targets_with_at_least_one_candidate": self.num_targets_with_candidates,
+            "min_candidates_per_target": self.min_candidates_per_target,
+            "max_candidates_per_target": self.max_candidates_per_target,
+            "avg_candidates_per_target": self.avg_candidates_per_target,
+            "median_candidates_per_target": self.median_candidates_per_target,
+            "failures_by_code": dict(sorted(self.failures_by_code.items())),
+        }
+
+
+def candidate_statistics(candidates: Sequence[Candidate]) -> CandidateRunStatistics:
+    stats = CandidateRunStatistics(total_candidates_seen=len(candidates), final_candidates_saved=len(candidates))
+    for candidate in candidates:
+        if candidate.failure is None:
+            stats.successful_candidates += 1
+        else:
+            stats.failed_candidates += 1
+            code = str(candidate.failure.code)
+            stats.failures_by_code[code] = stats.failures_by_code.get(code, 0) + 1
+    return stats
+
+
+def collected_candidate_statistics(candidates_by_target: Mapping[str, Sequence[Candidate]]) -> CandidateRunStatistics:
+    flat_candidates = [candidate for candidates in candidates_by_target.values() for candidate in candidates]
+    stats = candidate_statistics(flat_candidates)
+    for target_id, candidates in candidates_by_target.items():
+        if candidates:
+            stats.targets_with_at_least_one_candidate.add(target_id)
+            stats.candidates_per_target[target_id] = len(candidates)
+        for candidate in candidates:
+            if candidate.failure is None:
+                continue
+            code = str(candidate.failure.code)
+            target_failures = stats.failures_by_target.setdefault(target_id, {})
+            target_failures[code] = target_failures.get(code, 0) + 1
+    return stats
+
+
+def evaluation_statistics(evaluation: Evaluation) -> dict[str, object]:
+    candidates = [candidate for target in evaluation.targets.values() for candidate in target.candidates]
+    stats: dict[str, object] = {
+        "n_targets": len(evaluation.targets),
+        "n_candidates": len(candidates),
+        "n_failed_candidates": sum(1 for candidate in candidates if candidate.failed_adaptation()),
+    }
+    for tier in evaluation.tiers:
+        key = int(tier)
+        stats[f"n_solv_{key}"] = sum(
+            1
+            for target in evaluation.targets.values()
+            if any(candidate.satisfies_solv(Tier(key)) for candidate in target.candidates)
+        )
+    return stats

--- a/tests/v2/adapters/test_paroutes.py
+++ b/tests/v2/adapters/test_paroutes.py
@@ -138,6 +138,7 @@ class TestPaRoutesAdapterContract(AdapterContractSuite):
         route = adapter.cast(raw_paroutes_route, target=target_for(raw_paroutes_route, "paroutes-ex-1"))
 
         assert route.annotations["patent_id"] == "US123"
+        assert route.target.product_of is not None
         assert len(route.target.product_of.reactants) == 2
 
 

--- a/tests/v2/cli/__init__.py
+++ b/tests/v2/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Schema v2 CLI tests."""

--- a/tests/v2/cli/test_cli.py
+++ b/tests/v2/cli/test_cli.py
@@ -82,6 +82,26 @@ def run_cli(monkeypatch, *args: str) -> None:
     main()
 
 
+def test_v2_config_cli_reports_resolved_data_dir(tmp_path, monkeypatch, capsys) -> None:
+    data_dir = tmp_path / "data"
+
+    run_cli(monkeypatch, "--data-dir", str(data_dir), "config")
+
+    output = capsys.readouterr().out
+    assert "RetroCast Schema V2 Configuration" in output
+    assert str(data_dir.resolve()) in output.replace("\n", "")
+    assert "benchmarks" in output
+    assert "processed" in output
+
+
+def test_v2_list_adapters_cli_reports_canonical_names_and_aliases(monkeypatch, capsys) -> None:
+    run_cli(monkeypatch, "list-adapters")
+
+    output = capsys.readouterr().out
+    assert "paroutes" in output
+    assert "retro-star -> retrostar" in output
+
+
 def test_v2_adapt_cli_writes_candidates_and_manifest(tmp_path, monkeypatch) -> None:
     raw_path = tmp_path / "raw.json.gz"
     output_path = tmp_path / "candidates.json.gz"
@@ -134,19 +154,11 @@ def test_v2_collect_cli_writes_collected_candidates_and_manifest(tmp_path, monke
 
 def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
     data_dir = tmp_path / "data"
-    raw_dir = data_dir / "2-raw" / "test-model" / "small"
-    raw_dir.mkdir(parents=True)
     (data_dir / "1-benchmarks" / "definitions").mkdir(parents=True)
     write_stock(data_dir / "1-benchmarks" / "stocks" / "test-stock.csv.gz")
 
     save_benchmark(benchmark(), data_dir / "1-benchmarks" / "definitions" / "small.json.gz")
-    save_json_gz({"ethanol": raw_route()}, raw_dir / "results.json.gz")
-    (raw_dir / "manifest.json").write_text(
-        json.dumps(
-            {"schema_version": "2", "directives": {"adapter": "paroutes", "raw_results_filename": "results.json.gz"}}
-        ),
-        encoding="utf-8",
-    )
+    write_raw_job(data_dir, model="test-model", dataset="small")
 
     run_cli(monkeypatch, "--data-dir", str(data_dir), "ingest", "--model", "test-model", "--dataset", "small")
     candidates_path = data_dir / "3-processed" / "small" / "test-model" / "candidates.json.gz"
@@ -178,5 +190,30 @@ def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
     assert (analysis_path.parent / "manifest.json").exists()
 
 
+def test_v2_ingest_cli_discovers_all_models_and_datasets(tmp_path, monkeypatch) -> None:
+    data_dir = tmp_path / "data"
+    (data_dir / "1-benchmarks" / "definitions").mkdir(parents=True)
+    save_benchmark(benchmark(), data_dir / "1-benchmarks" / "definitions" / "small.json.gz")
+    write_raw_job(data_dir, model="model-a", dataset="small")
+    write_raw_job(data_dir, model="model-b", dataset="small")
+
+    run_cli(monkeypatch, "--data-dir", str(data_dir), "ingest", "--all-models", "--all-datasets", "--no-progress")
+
+    assert (data_dir / "3-processed" / "small" / "model-a" / "candidates.json.gz").exists()
+    assert (data_dir / "3-processed" / "small" / "model-b" / "candidates.json.gz").exists()
+
+
 def load_candidates_from_raw(raw: dict) -> list[Candidate]:
     return adapt_candidates({"ethanol": raw}, PaRoutesAdapter(), target=benchmark().targets["ethanol"])
+
+
+def write_raw_job(data_dir: Path, *, model: str, dataset: str) -> None:
+    raw_dir = data_dir / "2-raw" / model / dataset
+    raw_dir.mkdir(parents=True)
+    save_json_gz({"ethanol": raw_route()}, raw_dir / "results.json.gz")
+    (raw_dir / "manifest.json").write_text(
+        json.dumps(
+            {"schema_version": "2", "directives": {"adapter": "paroutes", "raw_results_filename": "results.json.gz"}}
+        ),
+        encoding="utf-8",
+    )

--- a/tests/v2/cli/test_cli.py
+++ b/tests/v2/cli/test_cli.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import json
+import sys
+from pathlib import Path
+
+from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.io.blob import save_json_gz
+from retrocast.typing import InChIKeyStr, SmilesStr
+from retrocast.v2.cli.main import main
+from retrocast.v2.io import (
+    load_analysis_report,
+    load_candidates,
+    load_collected_candidates,
+    load_evaluation,
+    save_benchmark,
+)
+from retrocast.v2.models import Benchmark, Target, TaskConstraints
+
+
+def raw_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CCO",
+                "metadata": {"ID": "US123;1", "rsmi": "C.CC>>CCO"},
+                "children": [
+                    {"type": "mol", "smiles": "C", "in_stock": True, "children": []},
+                    {
+                        "type": "mol",
+                        "smiles": "CC",
+                        "children": [
+                            {
+                                "type": "reaction",
+                                "smiles": "CC",
+                                "metadata": {"ID": "US123;2", "rsmi": "C>>CC"},
+                                "children": [{"type": "mol", "smiles": "C", "in_stock": True, "children": []}],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def invalid_raw_route() -> dict:
+    route = raw_route()
+    route["children"][0]["children"][1]["smiles"] = "not-smiles"
+    return route
+
+
+def benchmark() -> Benchmark:
+    smiles = canonicalize_smiles("CCO")
+    target = Target(id="ethanol", smiles=SmilesStr(smiles), inchikey=InChIKeyStr(get_inchi_key(smiles)))
+    return Benchmark(
+        name="small",
+        targets={target.id: target},
+        default_constraints=TaskConstraints(stock="test-stock"),
+    )
+
+
+def write_stock(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["SMILES", "InChIKey"])
+        writer.writerow(["C", get_inchi_key("C")])
+
+
+def run_cli(monkeypatch, *args: str) -> None:
+    monkeypatch.setattr(sys, "argv", ["retrocast", *args])
+    main()
+
+
+def test_v2_adapt_cli_writes_candidates_and_manifest(tmp_path, monkeypatch) -> None:
+    raw_path = tmp_path / "raw.json.gz"
+    output_path = tmp_path / "candidates.json.gz"
+    save_json_gz({"ok": raw_route(), "bad": invalid_raw_route()}, raw_path)
+
+    run_cli(
+        monkeypatch,
+        "adapt",
+        "--input",
+        str(raw_path),
+        "--output",
+        str(output_path),
+        "--adapter",
+        "paroutes",
+    )
+
+    candidates = load_candidates(output_path)
+    assert len(candidates) == 2
+    assert any(candidate.failure is not None for candidate in candidates)
+    manifest = json.loads((tmp_path / "candidates.manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "2"
+    assert manifest["statistics"]["failures_by_code"]
+
+
+def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
+    data_dir = tmp_path / "data"
+    raw_dir = data_dir / "2-raw" / "test-model" / "small"
+    raw_dir.mkdir(parents=True)
+    (data_dir / "1-benchmarks" / "definitions").mkdir(parents=True)
+    write_stock(data_dir / "1-benchmarks" / "stocks" / "test-stock.csv.gz")
+
+    save_benchmark(benchmark(), data_dir / "1-benchmarks" / "definitions" / "small.json.gz")
+    save_json_gz({"ethanol": raw_route()}, raw_dir / "results.json.gz")
+    (raw_dir / "manifest.json").write_text(
+        json.dumps(
+            {"schema_version": "2", "directives": {"adapter": "paroutes", "raw_results_filename": "results.json.gz"}}
+        ),
+        encoding="utf-8",
+    )
+
+    run_cli(monkeypatch, "--data-dir", str(data_dir), "ingest", "--model", "test-model", "--dataset", "small")
+    candidates_path = data_dir / "3-processed" / "small" / "test-model" / "candidates.json.gz"
+    assert len(load_collected_candidates(candidates_path)["ethanol"]) == 1
+    assert (candidates_path.parent / "manifest.json").exists()
+
+    run_cli(monkeypatch, "--data-dir", str(data_dir), "score", "--model", "test-model", "--dataset", "small")
+    evaluation_path = data_dir / "4-scored" / "small" / "test-model" / "test-stock" / "evaluation.json.gz"
+    evaluation = load_evaluation(evaluation_path)
+    assert evaluation.schema_version == "2"
+    assert evaluation.targets["ethanol"].candidates[0].satisfies_task()
+
+    run_cli(
+        monkeypatch,
+        "--data-dir",
+        str(data_dir),
+        "analyze",
+        "--model",
+        "test-model",
+        "--dataset",
+        "small",
+        "--n-boot",
+        "10",
+    )
+    analysis_path = data_dir / "5-results" / "small" / "test-model" / "test-stock" / "analysis.json.gz"
+    report = load_analysis_report(analysis_path)
+    assert report.metrics["solv_0[test-stock]_rate"].value == 1.0
+    assert (analysis_path.parent / "report.md").exists()
+    assert (analysis_path.parent / "manifest.json").exists()

--- a/tests/v2/cli/test_cli.py
+++ b/tests/v2/cli/test_cli.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.io.blob import save_json_gz
 from retrocast.typing import InChIKeyStr, SmilesStr
@@ -92,6 +94,17 @@ def test_v2_config_cli_reports_resolved_data_dir(tmp_path, monkeypatch, capsys) 
     assert str(data_dir.resolve()) in output.replace("\n", "")
     assert "benchmarks" in output
     assert "processed" in output
+
+
+def test_v2_config_cli_reports_malformed_yaml_as_cli_error(tmp_path, monkeypatch, caplog) -> None:
+    config_path = tmp_path / "retrocast-config.yaml"
+    config_path.write_text("data_dir: [unterminated", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli(monkeypatch, "--config", str(config_path), "config")
+
+    assert exc_info.value.code == 1
+    assert "Failed to parse config file" in caplog.text
 
 
 def test_v2_list_adapters_cli_reports_canonical_names_and_aliases(monkeypatch, capsys) -> None:

--- a/tests/v2/cli/test_cli.py
+++ b/tests/v2/cli/test_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from retrocast.chem import canonicalize_smiles, get_inchi_key
 from retrocast.io.blob import save_json_gz
 from retrocast.typing import InChIKeyStr, SmilesStr
+from retrocast.v2.adapters import PaRoutesAdapter
 from retrocast.v2.cli.main import main
 from retrocast.v2.io import (
     load_analysis_report,
@@ -16,8 +17,11 @@ from retrocast.v2.io import (
     load_collected_candidates,
     load_evaluation,
     save_benchmark,
+    save_candidates,
 )
 from retrocast.v2.models import Benchmark, Target, TaskConstraints
+from retrocast.v2.models.candidates import Candidate
+from retrocast.v2.workflow import adapt_candidates
 
 
 def raw_route() -> dict:
@@ -102,6 +106,32 @@ def test_v2_adapt_cli_writes_candidates_and_manifest(tmp_path, monkeypatch) -> N
     assert manifest["statistics"]["failures_by_code"]
 
 
+def test_v2_collect_cli_writes_collected_candidates_and_manifest(tmp_path, monkeypatch) -> None:
+    candidates_path = tmp_path / "candidates.json.gz"
+    benchmark_path = tmp_path / "small.json.gz"
+    output_path = tmp_path / "collected.json.gz"
+    candidates = load_candidates_from_raw(raw_route())
+    save_candidates(candidates, candidates_path)
+    save_benchmark(benchmark(), benchmark_path)
+
+    run_cli(
+        monkeypatch,
+        "collect",
+        "--input",
+        str(candidates_path),
+        "--benchmark",
+        str(benchmark_path),
+        "--output",
+        str(output_path),
+    )
+
+    collected = load_collected_candidates(output_path)
+    assert list(collected) == ["ethanol"]
+    assert len(collected["ethanol"]) == 1
+    manifest = json.loads((tmp_path / "collected.manifest.json").read_text(encoding="utf-8"))
+    assert manifest["action"] == "[cli:v2]collect"
+
+
 def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
     data_dir = tmp_path / "data"
     raw_dir = data_dir / "2-raw" / "test-model" / "small"
@@ -146,3 +176,7 @@ def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
     assert report.metrics["solv_0[test-stock]_rate"].value == 1.0
     assert (analysis_path.parent / "report.md").exists()
     assert (analysis_path.parent / "manifest.json").exists()
+
+
+def load_candidates_from_raw(raw: dict) -> list[Candidate]:
+    return adapt_candidates({"ethanol": raw}, PaRoutesAdapter(), target=benchmark().targets["ethanol"])

--- a/tests/v2/cli/test_manifest.py
+++ b/tests/v2/cli/test_manifest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+
+from retrocast.v2.cli.manifest import manifest_sidecar_path, write_manifest
+
+
+def test_manifest_sidecar_path_handles_unknown_suffix(tmp_path) -> None:
+    assert manifest_sidecar_path(tmp_path / "artifact.bin") == tmp_path / "artifact.manifest.json"
+
+
+def test_write_manifest_keeps_absolute_paths_outside_root(tmp_path) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside.txt"
+    output = root / "out.txt"
+    manifest_path = root / "manifest.json"
+    outside.write_text("source", encoding="utf-8")
+    output.parent.mkdir(parents=True)
+    output.write_text("output", encoding="utf-8")
+
+    write_manifest(
+        manifest_path,
+        action="test:v2",
+        sources=[outside],
+        outputs=[output],
+        root_dir=root,
+    )
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["source_files"][0]["path"] == str(outside.resolve())
+    assert payload["output_files"][0]["path"] == "out.txt"

--- a/tests/v2/cli/test_report.py
+++ b/tests/v2/cli/test_report.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from rich.console import Console
+
+from retrocast.v2.cli.report import create_analysis_table, generate_markdown_report
+from retrocast.v2.models.analysis import AnalysisReport, MetricSummary
+
+
+def report_with_all_metric_groups() -> AnalysisReport:
+    return AnalysisReport(
+        metrics={
+            "solv_0[test-stock]_rate": MetricSummary(value=1.0, count=4, ci_low=0.8, ci_high=1.0),
+            "mrr_solv_0[test-stock]": MetricSummary(value=0.5, count=4, ci_low=0.25, ci_high=0.75),
+            "acceptable_reconstruction_top_3[test-stock]": MetricSummary(value=0.75, count=4),
+        },
+        by_stratum={
+            "depth=2": {
+                "acceptable_reconstruction_top_1[test-stock]": MetricSummary(value=0.25, count=2),
+            }
+        },
+    )
+
+
+def test_generate_markdown_report_includes_strata_and_metric_groups() -> None:
+    markdown = generate_markdown_report(report_with_all_metric_groups(), title="Small Run")
+
+    assert "# Small Run" in markdown
+    assert "Solv-0[test-stock]" in markdown
+    assert "MRR Solv-0[test-stock]" in markdown
+    assert "Top-3" in markdown
+    assert "## By Stratum" in markdown
+    assert "### depth=2" in markdown
+    assert "| Top-1 | 25.0% |  | 2 |" in markdown
+
+
+def test_create_analysis_table_renders_top_k_without_ci() -> None:
+    console = Console(record=True, width=120)
+    console.print(create_analysis_table(report_with_all_metric_groups()))
+
+    output = console.export_text()
+    assert "Benchmark route reconstruction" in output
+    assert "Top-3" in output
+    assert "75.0%" in output

--- a/tests/v2/metrics/test_constraints.py
+++ b/tests/v2/metrics/test_constraints.py
@@ -58,6 +58,28 @@ def test_stock_constraint_fails_clearly_without_stock_keys() -> None:
     assert result.checks[0].code == "constraint.stock_termination.no_stock_keys"
 
 
+def test_stock_constraint_selects_stock_by_task_constraint_name() -> None:
+    checker = TaskConstraintChecker(
+        stocks={
+            "stock-a": stock_for("C"),
+            "stock-b": stock_for("C", "CO"),
+        }
+    )
+
+    assert checker.check_route(route(), TaskConstraints(stock="stock-a")).status == CheckStatus.FAIL
+    assert checker.check_route(route(), TaskConstraints(stock="stock-b")).status == CheckStatus.PASS
+
+
+def test_stock_constraint_fails_clearly_when_named_stock_is_missing() -> None:
+    result = TaskConstraintChecker(stocks={"stock-a": stock_for("C", "CO")}).check_route(
+        route(), TaskConstraints(stock="stock-b")
+    )
+
+    assert result.status == CheckStatus.FAIL
+    assert result.checks[0].code == "constraint.stock_termination.no_stock_keys"
+    assert result.checks[0].details == {"stock": "stock-b"}
+
+
 def test_required_leaf_constraint_fails_when_required_leaf_is_missing() -> None:
     result = TaskConstraintChecker().check_route(route(), TaskConstraints(required_leaves_smiles=[SmilesStr("CC")]))
 

--- a/tests/v2/models/test_task.py
+++ b/tests/v2/models/test_task.py
@@ -81,7 +81,7 @@ def test_task_metric_label_overrides_derived_metric_label() -> None:
 
 
 @pytest.mark.unit
-def test_task_metric_label_marks_multiple_stocks_as_mixed() -> None:
+def test_task_metric_label_marks_multiple_stocks_as_stocks() -> None:
     t1 = Target(id="t1", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
     t2 = Target(id="t2", smiles=SmilesStr("CC"), inchikey=get_inchi_key("CC"))
     task = Task(
@@ -93,7 +93,23 @@ def test_task_metric_label_marks_multiple_stocks_as_mixed() -> None:
         },
     )
 
-    assert task.derived_metric_label() == "mixed-stock"
+    assert task.derived_metric_label() == "stocks"
+
+
+@pytest.mark.unit
+def test_task_metric_label_without_stock_uses_leaf_and_depth_constraints() -> None:
+    t1 = Target(id="t1", smiles=SmilesStr("CCO"), inchikey=get_inchi_key("CCO"))
+    t2 = Target(id="t2", smiles=SmilesStr("CC"), inchikey=get_inchi_key("CC"))
+    task = Task(
+        name="bidirectional",
+        targets={"t1": t1, "t2": t2},
+        constraints={
+            "t1": TaskConstraints(required_leaves_smiles=[SmilesStr("C")]),
+            "t2": TaskConstraints(route_depth=2),
+        },
+    )
+
+    assert task.derived_metric_label() == "leaf+depth"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
why: schema v2 had typed workflow pieces, but no clean project CLI path for running raw planner output through candidate collection, scoring, and analysis. Wiring v2 into the old CLI would keep v1 assumptions in the command boundary.

what changed: added a schema-v2 argparse CLI, adapter registry, typed IO helpers for candidate/evaluation/analysis artifacts, manifest/statistics reporting, route progress callbacks, stock-registry scoring, and CLI smoke coverage for adapt plus ingest/score/analyze. The `retrocast` entry point now targets the v2 CLI.

risk: the main behavior change is the console entry point switching from v1 to v2. Artifact flow is intentionally candidate-first: raw -> candidates -> collected candidates -> evaluation -> analysis. Adapter-specific raw shape stays owned by v2 adapters rather than CLI flags. Stock scoring now supports target-specific stock names through a registry.

verification: `uv run ruff check src/retrocast/v2 tests/v2`; `uv run ty check src/retrocast/v2 tests/v2`; `uv run pytest tests/v2`.

follow-ups: old v1 CLI tests are not updated in this PR because the executable entry point now points at v2 by design.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782614920&installation_id=125602297&pr_number=115&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F115&signature=a443294f240616aa11834aac1533ece884f4d909581a05435f03e11d3cff5974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New v2 command-line interface featuring `adapt`, `collect`, `ingest`, `score`, and `analyze` subcommands for complete workflow execution
  * Adapter registry system with support for deprecated adapter name resolution
  * Automatic manifest generation for tracking workflow steps, parameters, and statistics
  * Analysis report generation with metric tables and markdown output
  * Enhanced constraint checking with multi-stock support and improved error reporting

* **Tests**
  * Added comprehensive CLI integration tests and constraint validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/project-procrustes/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a full schema v2 CLI (`retrocast.v2.cli.main`) with `adapt`, `collect`, `ingest`, `score`, and `analyze` subcommands, and redirects the `retrocast` console entry point from the v1 CLI to v2. Supporting modules cover an adapter registry, typed IO helpers, manifest/report generation, multi-stock constraint checking, and per-run statistics.

- **Entry-point switch**: `pyproject.toml` now points `retrocast` at `retrocast.v2.cli.main:main`; v1 CLI tests are intentionally left unchanged per the PR description.
- **Multi-stock scoring**: `StockTerminationCheck` and `TaskConstraintChecker` gain a `stocks` registry parameter that selects InChIKey sets by constraint name at check time, tested with new unit tests.
- **Progress callbacks**: `adapt_routes` and `adapt_candidates` now accept an optional `Callable[[], None]` advanced via `try/finally`, so the progress bar advances even on per-entry errors.

<h3>Confidence Score: 5/5</h3>

The workflow logic and data-path changes are well-tested end-to-end; the entry-point switch is the main behavioral change and is intentional.

No data-correctness or crash-inducing bugs were found in the new CLI, constraint, or IO code. The previously flagged issues (YAML error handling, markdown write encoding) are addressed. Remaining findings are minor consistency nits in manifest action names and a missing encoding argument on one JSON read.

No files require special attention beyond the two minor nits in main.py and stats.py.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/v2/cli/main.py | New 497-line v2 CLI: subcommands adapt/collect/ingest/score/analyze/config/list-adapters wired to workflow functions; previously-flagged issues (YAML error handling, write_text encoding) are addressed; minor inconsistency in manifest action name format and missing UTF-8 encoding on _manifest_directive JSON open. |
| src/retrocast/v2/adapters/registry.py | New adapter registry: slug normalization, deprecated-alias resolution, and get_adapter factory wrapping all adapters with AdapterResolutionError on unknown names. |
| src/retrocast/v2/metrics/constraints.py | Multi-stock support added via stocks registry parameter; StockTerminationCheck correctly dispatches to per-name stock sets and returns no_stock_keys error for unknown names; tests confirm new and old paths. |
| src/retrocast/v2/workflow/adapt.py | Progress callback added via try/finally in both adapt_routes and adapt_candidates; the continue inside the outer try in adapt_candidates correctly triggers the finally before advancing to the next iteration. |
| src/retrocast/v2/workflow/stats.py | New statistics helpers for candidates, collected candidates, and evaluation artifacts; candidates_per_target counts all candidates including failures, which may mislead readers of manifest statistics. |
| src/retrocast/v2/cli/manifest.py | Clean manifest writer: hashes source files, handles paths outside root dir gracefully, writes UTF-8 JSON with path.parent.mkdir guard. |
| src/retrocast/v2/cli/report.py | Analysis report renderer: Rich table and markdown generation with regex-based metric name categorization; Rich markup properly escaped with rich.markup.escape. |
| src/retrocast/v2/models/task.py | Single rename: derived_metric_label() now returns 'stocks' instead of 'mixed-stock' for multi-stock benchmarks; tests updated to match. |
| tests/v2/cli/test_cli.py | Comprehensive integration tests cover the full ingest→score→analyze pipeline, YAML error reporting, adapt+collect individual commands, and multi-model discovery. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["retrocast v2 CLI\nmain()"]
    CLI --> adapt["adapt\nraw JSON → candidates.json.gz"]
    CLI --> collect["collect\ncandidates + benchmark → collected.json.gz"]
    CLI --> ingest["ingest\n(adapt + collect in one step)"]
    CLI --> score["score\ncollected → evaluation.json.gz"]
    CLI --> analyze["analyze\nevaluation → analysis.json.gz + report.md"]
    CLI --> config["config / list-adapters"]

    adapt --> registry["AdapterRegistry\nget_adapter(slug)"]
    ingest --> registry
    registry --> adapters["v2 Adapters\n(paroutes, retrostar, ...)"]    

    score --> stocks["_load_stock_registry\n-> stocks dict"]
    stocks --> checker["TaskConstraintChecker\nstocks= registry"]
    checker --> stc["StockTerminationCheck\n_stock_keys_by_name lookup"]

    adapt --> manifest["write_manifest\nmanifest.json sidecar"]
    collect --> manifest
    ingest --> manifest
    score --> manifest
    analyze --> manifest
    analyze --> report["generate_markdown_report\nreport.md"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/retrocast/v2/cli/main.py:450-451
The manifest JSON file is opened without specifying `encoding="utf-8"`, making it inconsistent with every other file-read in this module and with the UTF-8 writes in `manifest.py`. On a Windows system with a non-UTF-8 locale, model names or benchmark names containing non-ASCII characters in a manifest would cause a `UnicodeDecodeError` here, silently falling through to the `None` fallback (adapter or filename) rather than raising a clear error.

```suggestion
    with open(path, encoding="utf-8") as handle:
        payload = json.load(handle)
```

### Issue 2 of 3
src/retrocast/v2/workflow/stats.py:1294-1307
**`candidates_per_target` counts failure slots, not successful routes**

`candidates_per_target[target_id] = len(candidates)` includes `Candidate` objects whose `failure` field is set. Similarly, `targets_with_at_least_one_candidate` is populated as long as any candidate (success or failure) exists for a target. The manifest statistics therefore report a target as having candidates even when every entry is a parse failure, and the min/max/avg/median derived from `candidates_per_target` reflect total attempts rather than usable routes. Readers scanning the manifest to assess data quality may overestimate coverage.

### Issue 3 of 3
src/retrocast/v2/cli/main.py:296-305
**Inconsistent action name format across manifest entries**

`handle_adapt` writes `action="[cli:v2]adapt"` and `handle_collect` writes `action="[cli:v2]collect"`, while `_ingest_one`, `_score_one`, and `_analyze_one` use the format `"ingest:v2"`, `"score:v2"`, and `"analyze:v2"`. Any tooling or queries that filter manifest files by the `action` field will need to handle two different naming conventions from the same CLI.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address v2 CLI review comments"](https://github.com/ischemist/project-procrustes/commit/5363884530cc49753c2083a14ec8212d04f89ed1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34504848)</sub>

<!-- /greptile_comment -->