### PR TITLE
feat: add route embedding audit

### DIFF
--- a/data/retrocast/releases/paroutes-training-sets/v2026-05-12/route-holdout-n1-n5/route-embedding-audit.md
+++ b/data/retrocast/releases/paroutes-training-sets/v2026-05-12/route-holdout-n1-n5/route-embedding-audit.md
@@ -1,0 +1,165 @@
+# route embedding audit: route-holdout-n1-n5
+
+- match level: `full`
+- allow leaf extension: `true`
+- partial minimum reactions: 2 reactions
+- training routes: 169 126
+- training route signatures: 163 636
+- training reaction signatures: 306 049
+
+terms: a query route is the route being searched for. a container route is a training route where an embedding is found.
+
+| metric | mkt-cnv-160 | n1-routes | n5-routes |
+| --- | ---: | ---: | ---: |
+| query routes | 160 | 10 000 | 10 000 |
+| reaction signatures in training | 380 / 733 (51.8%) | 8 879 / 30 877 (28.8%) | 11 613 / 35 893 (32.4%) |
+| exact route signatures | 0 / 160 (0.0%) | 0 / 10 000 (0.0%) | 0 / 10 000 (0.0%) |
+| full route embeddings | 3 / 160 (1.9%) | 276 / 10 000 (2.8%) | 218 / 10 000 (2.2%) |
+| routes with internal subroute embedding | 78 / 160 (48.8%) | 2 508 / 10 000 (25.1%) | 3 765 / 10 000 (37.6%) |
+
+## mkt-cnv-160
+
+### overlap summary
+
+380 / 733 (51.8%) reaction signatures are present in training; 0 / 160 (0.0%) query routes have exact route-signature matches.
+
+3 / 160 (1.9%) query routes are fully embedded somewhere inside training routes. these produce 3 total matching occurrences. 3 query routes have a root-shifted full embedding; 1 query route has a leaf-extended full embedding. 0 occurrences share the training target (distance 0 from the root); 1 occurrence is embedded at distance 1 (a prefix of a root child); 2 occurrences are embedded at distance 2 (a prefix of a child of a root child).
+
+78 / 160 (48.8%) query routes have at least one embedded internal subroute of 2+ reactions. there are 274 non-root internal subroutes with at least 2 reactions. 154 / 274 (56.2%) of those internal subroutes are embedded. there are 1 825 total partial matching occurrences (11.85 matches per embedded internal subroute).
+
+### best-match coverage
+
+when overlap exists, how large and how specific is the largest overlap? each query route is compared to the single container route that embeds the largest part of it.
+
+basis: full routes + internal subroutes with 2+ reactions.
+
+#### matched fraction of query route
+
+matched reactions divided by all reactions in the query route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (160) | 26.7% | 0.0% | 66.7% |
+| query routes with any embedding (78) | 54.8% | 50.0% | 83.3% |
+
+#### matched fraction of training route
+
+matched reactions divided by all reactions in the container route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (160) | 37.8% | 0.0% | 100.0% |
+| query routes with any embedding (78) | 77.6% | 75.0% | 100.0% |
+
+query routes with any embedding match 13.60 unique training routes and 23.44 total occurrences per query route on average.
+
+### largest embedded fraction of query-route reactions
+
+largest embedded match reactions divided by all reactions in the query route.
+
+| largest embedded fraction of query-route reactions | query routes |
+| --- | ---: |
+| 0% | 82 |
+| (0,25%] | 0 |
+| (25,50%] | 44 |
+| (50,75%] | 22 |
+| (75,100%) | 9 |
+| 100% | 3 |
+
+## n1-routes
+
+### overlap summary
+
+8 879 / 30 877 (28.8%) reaction signatures are present in training; 0 / 10 000 (0.0%) query routes have exact route-signature matches.
+
+276 / 10 000 (2.8%) query routes are fully embedded somewhere inside training routes. these produce 541 total matching occurrences. 181 query routes have a root-shifted full embedding; 105 query routes have a leaf-extended full embedding. 100 occurrences share the training target (distance 0 from the root); 299 occurrences are embedded at distance 1 (a prefix of a root child); 98 occurrences are embedded at distance 2 (a prefix of a child of a root child); 27 occurrences are embedded at distance 3 (a prefix of a depth-3 subtree); 10 occurrences are embedded at distance 4 (a prefix of a depth-4 subtree); 5 occurrences are embedded at distance 5 (a prefix of a depth-5 subtree); 2 occurrences are embedded at distance 6 (a prefix of a depth-6 subtree).
+
+2 508 / 10 000 (25.1%) query routes have at least one embedded internal subroute of 2+ reactions. there are 11 216 non-root internal subroutes with at least 2 reactions. 3 933 / 11 216 (35.1%) of those internal subroutes are embedded. there are 25 709 total partial matching occurrences (6.54 matches per embedded internal subroute).
+
+### best-match coverage
+
+when overlap exists, how large and how specific is the largest overlap? each query route is compared to the single container route that embeds the largest part of it.
+
+basis: full routes + internal subroutes with 2+ reactions.
+
+#### matched fraction of query route
+
+matched reactions divided by all reactions in the query route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (10 000) | 17.7% | 0.0% | 66.7% |
+| query routes with any embedding (2 581) | 68.7% | 66.7% | 100.0% |
+
+#### matched fraction of training route
+
+matched reactions divided by all reactions in the container route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (10 000) | 19.1% | 0.0% | 75.0% |
+| query routes with any embedding (2 581) | 74.1% | 66.7% | 100.0% |
+
+query routes with any embedding match 6.36 unique training routes and 10.17 total occurrences per query route on average.
+
+### largest embedded fraction of query-route reactions
+
+largest embedded match reactions divided by all reactions in the query route.
+
+| largest embedded fraction of query-route reactions | query routes |
+| --- | ---: |
+| 0% | 7 419 |
+| (0,25%] | 3 |
+| (25,50%] | 490 |
+| (50,75%] | 1 588 |
+| (75,100%) | 224 |
+| 100% | 276 |
+
+## n5-routes
+
+### overlap summary
+
+11 613 / 35 893 (32.4%) reaction signatures are present in training; 0 / 10 000 (0.0%) query routes have exact route-signature matches.
+
+218 / 10 000 (2.2%) query routes are fully embedded somewhere inside training routes. these produce 285 total matching occurrences. 138 query routes have a root-shifted full embedding; 85 query routes have a leaf-extended full embedding. 87 occurrences share the training target (distance 0 from the root); 131 occurrences are embedded at distance 1 (a prefix of a root child); 49 occurrences are embedded at distance 2 (a prefix of a child of a root child); 11 occurrences are embedded at distance 3 (a prefix of a depth-3 subtree); 6 occurrences are embedded at distance 4 (a prefix of a depth-4 subtree); 1 occurrence is embedded at distance 5 (a prefix of a depth-5 subtree).
+
+3 765 / 10 000 (37.6%) query routes have at least one embedded internal subroute of 2+ reactions. there are 17 377 non-root internal subroutes with at least 2 reactions. 6 688 / 17 377 (38.5%) of those internal subroutes are embedded. there are 47 579 total partial matching occurrences (7.11 matches per embedded internal subroute).
+
+### best-match coverage
+
+when overlap exists, how large and how specific is the largest overlap? each query route is compared to the single container route that embeds the largest part of it.
+
+basis: full routes + internal subroutes with 2+ reactions.
+
+#### matched fraction of query route
+
+matched reactions divided by all reactions in the query route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (10 000) | 25.0% | 0.0% | 75.0% |
+| query routes with any embedding (3 781) | 66.2% | 66.7% | 83.3% |
+
+#### matched fraction of training route
+
+matched reactions divided by all reactions in the container route.
+
+| population | mean | median | p90 |
+| --- | ---: | ---: | ---: |
+| all query routes (10 000) | 27.9% | 0.0% | 80.0% |
+| query routes with any embedding (3 781) | 73.8% | 75.0% | 100.0% |
+
+query routes with any embedding match 7.55 unique training routes and 12.66 total occurrences per query route on average.
+
+### largest embedded fraction of query-route reactions
+
+largest embedded match reactions divided by all reactions in the query route.
+
+| largest embedded fraction of query-route reactions | query routes |
+| --- | ---: |
+| 0% | 6 219 |
+| (0,25%] | 5 |
+| (25,50%] | 1 019 |
+| (50,75%] | 2 050 |
+| (75,100%) | 489 |
+| 100% | 218 |

--- a/data/retrocast/releases/paroutes-training-sets/v2026-05-12/route-holdout-n1-n5/route-embedding-audit.md
+++ b/data/retrocast/releases/paroutes-training-sets/v2026-05-12/route-holdout-n1-n5/route-embedding-audit.md
@@ -25,6 +25,18 @@ terms: a query route is the route being searched for. a container route is a tra
 
 3 / 160 (1.9%) query routes are fully embedded somewhere inside training routes. these produce 3 total matching occurrences. 3 query routes have a root-shifted full embedding; 1 query route has a leaf-extended full embedding. 0 occurrences share the training target (distance 0 from the root); 1 occurrence is embedded at distance 1 (a prefix of a root child); 2 occurrences are embedded at distance 2 (a prefix of a child of a root child).
 
+### root-prefix overlap
+
+query route prefixes are compared to training route prefixes with `route.signature(depth=k)`.
+
+| prefix depth | query routes with depth | found at training root | found anywhere in training |
+| ---: | ---: | ---: | ---: |
+| 1 | 160 | 8 / 160 (5.0%) | 11 / 160 (6.9%) |
+| 2 | 160 | 4 / 160 (2.5%) | 7 / 160 (4.4%) |
+| 3 | 120 | 3 / 120 (2.5%) | 6 / 120 (5.0%) |
+| 4 | 80 | 1 / 80 (1.2%) | 4 / 80 (5.0%) |
+| 5 | 40 | 0 / 40 (0.0%) | 1 / 40 (2.5%) |
+
 78 / 160 (48.8%) query routes have at least one embedded internal subroute of 2+ reactions. there are 274 non-root internal subroutes with at least 2 reactions. 154 / 274 (56.2%) of those internal subroutes are embedded. there are 1 825 total partial matching occurrences (11.85 matches per embedded internal subroute).
 
 ### best-match coverage
@@ -74,6 +86,23 @@ largest embedded match reactions divided by all reactions in the query route.
 
 276 / 10 000 (2.8%) query routes are fully embedded somewhere inside training routes. these produce 541 total matching occurrences. 181 query routes have a root-shifted full embedding; 105 query routes have a leaf-extended full embedding. 100 occurrences share the training target (distance 0 from the root); 299 occurrences are embedded at distance 1 (a prefix of a root child); 98 occurrences are embedded at distance 2 (a prefix of a child of a root child); 27 occurrences are embedded at distance 3 (a prefix of a depth-3 subtree); 10 occurrences are embedded at distance 4 (a prefix of a depth-4 subtree); 5 occurrences are embedded at distance 5 (a prefix of a depth-5 subtree); 2 occurrences are embedded at distance 6 (a prefix of a depth-6 subtree).
 
+### root-prefix overlap
+
+query route prefixes are compared to training route prefixes with `route.signature(depth=k)`.
+
+| prefix depth | query routes with depth | found at training root | found anywhere in training |
+| ---: | ---: | ---: | ---: |
+| 1 | 10 000 | 460 / 10 000 (4.6%) | 675 / 10 000 (6.8%) |
+| 2 | 10 000 | 399 / 10 000 (4.0%) | 586 / 10 000 (5.9%) |
+| 3 | 7 119 | 153 / 7 119 (2.1%) | 285 / 7 119 (4.0%) |
+| 4 | 2 680 | 59 / 2 680 (2.2%) | 99 / 2 680 (3.7%) |
+| 5 | 900 | 19 / 900 (2.1%) | 29 / 900 (3.2%) |
+| 6 | 310 | 7 / 310 (2.3%) | 14 / 310 (4.5%) |
+| 7 | 97 | 1 / 97 (1.0%) | 4 / 97 (4.1%) |
+| 8 | 32 | 1 / 32 (3.1%) | 1 / 32 (3.1%) |
+| 9 | 11 | 0 / 11 (0.0%) | 0 / 11 (0.0%) |
+| 10 | 1 | 0 / 1 (0.0%) | 0 / 1 (0.0%) |
+
 2 508 / 10 000 (25.1%) query routes have at least one embedded internal subroute of 2+ reactions. there are 11 216 non-root internal subroutes with at least 2 reactions. 3 933 / 11 216 (35.1%) of those internal subroutes are embedded. there are 25 709 total partial matching occurrences (6.54 matches per embedded internal subroute).
 
 ### best-match coverage
@@ -122,6 +151,23 @@ largest embedded match reactions divided by all reactions in the query route.
 11 613 / 35 893 (32.4%) reaction signatures are present in training; 0 / 10 000 (0.0%) query routes have exact route-signature matches.
 
 218 / 10 000 (2.2%) query routes are fully embedded somewhere inside training routes. these produce 285 total matching occurrences. 138 query routes have a root-shifted full embedding; 85 query routes have a leaf-extended full embedding. 87 occurrences share the training target (distance 0 from the root); 131 occurrences are embedded at distance 1 (a prefix of a root child); 49 occurrences are embedded at distance 2 (a prefix of a child of a root child); 11 occurrences are embedded at distance 3 (a prefix of a depth-3 subtree); 6 occurrences are embedded at distance 4 (a prefix of a depth-4 subtree); 1 occurrence is embedded at distance 5 (a prefix of a depth-5 subtree).
+
+### root-prefix overlap
+
+query route prefixes are compared to training route prefixes with `route.signature(depth=k)`.
+
+| prefix depth | query routes with depth | found at training root | found anywhere in training |
+| ---: | ---: | ---: | ---: |
+| 1 | 10 000 | 515 / 10 000 (5.1%) | 680 / 10 000 (6.8%) |
+| 2 | 10 000 | 449 / 10 000 (4.5%) | 593 / 10 000 (5.9%) |
+| 3 | 9 291 | 219 / 9 291 (2.4%) | 346 / 9 291 (3.7%) |
+| 4 | 5 131 | 87 / 5 131 (1.7%) | 143 / 5 131 (2.8%) |
+| 5 | 1 874 | 28 / 1 874 (1.5%) | 49 / 1 874 (2.6%) |
+| 6 | 618 | 11 / 618 (1.8%) | 15 / 618 (2.4%) |
+| 7 | 183 | 1 / 183 (0.5%) | 1 / 183 (0.5%) |
+| 8 | 58 | 0 / 58 (0.0%) | 0 / 58 (0.0%) |
+| 9 | 16 | 0 / 16 (0.0%) | 0 / 16 (0.0%) |
+| 10 | 3 | 0 / 3 (0.0%) | 0 / 3 (0.0%) |
 
 3 765 / 10 000 (37.6%) query routes have at least one embedded internal subroute of 2+ reactions. there are 17 377 non-root internal subroutes with at least 2 reactions. 6 688 / 17 377 (38.5%) of those internal subroutes are embedded. there are 47 579 total partial matching occurrences (7.11 matches per embedded internal subroute).
 

--- a/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+++ b/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
@@ -3,15 +3,11 @@ audit route-pattern embeddings between a paroutes training release and query rou
 
 usage:
     uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
-    uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py --include-partial
-    uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py --release-path path/to/all.jsonl.gz
 """
 
 from __future__ import annotations
 
-import argparse
 from pathlib import Path
-from typing import cast
 
 from retrocast.chem import InChIKeyLevel
 from retrocast.curation.training import adapt_training_routes
@@ -23,154 +19,73 @@ from retrocast.curation.training.embedding_audit import (
 )
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
 from retrocast.io import load_benchmark, load_training_route_records, save_jsonl_gz
+from retrocast.paths import benchmark_definitions_dir, paroutes_assets_dir, paroutes_training_release_file
 from retrocast.utils.logging import configure_script_logging, logger
 
-BASE_DIR = Path(__file__).resolve().parents[3]
-DATA_DIR = BASE_DIR / "data" / "retrocast"
-RAW_DIR = DATA_DIR / "0-assets" / "paroutes"
-BENCHMARK_DIR = DATA_DIR / "1-benchmarks" / "definitions"
 RELEASE_VERSION = "v2026-05-12"
-DEFAULT_RELEASE_PATH = (
-    DATA_DIR / "releases" / "paroutes-training-sets" / RELEASE_VERSION / "route-holdout-n1-n5" / "all.jsonl.gz"
-)
-DEFAULT_BENCHMARK_PATHS = (BENCHMARK_DIR / "mkt-cnv-160.json.gz",)
-DEFAULT_RAW_HOLDOUTS = ("n1", "n5")
+RELEASE_NAME = "route-holdout-n1-n5"
+RELEASE_PATH = paroutes_training_release_file(RELEASE_VERSION, RELEASE_NAME)
+BENCHMARK_PATHS = (benchmark_definitions_dir() / "mkt-cnv-160.json.gz",)
+RAW_HOLDOUTS = ("n1", "n5")
+ROUTE_SELECTION: BenchmarkRouteSelection = "primary"
+MATCH_LEVEL = InChIKeyLevel.FULL
+INCLUDE_PARTIAL = True
+PARTIAL_MIN_REACTIONS = 2
+ALLOW_LEAF_EXTENSION = True
+SHOW_PROGRESS = True
+OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-audit.md"
+LEDGER_OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-ledger.jsonl.gz"
 
 
 def main() -> None:
     configure_script_logging()
-    parser = argparse.ArgumentParser(description="audit route embeddings in a paroutes training release.")
-    parser.add_argument(
-        "--release-path",
-        type=Path,
-        default=DEFAULT_RELEASE_PATH,
-        help=f"training route release all.jsonl.gz. default: {DEFAULT_RELEASE_PATH}",
-    )
-    parser.add_argument(
-        "--benchmark-path",
-        action="append",
-        type=Path,
-        default=None,
-        help="benchmark definition to audit. may be passed more than once. default: mkt-cnv-160.",
-    )
-    parser.add_argument(
-        "--route-selection",
-        choices=("primary", "all"),
-        default="primary",
-        help="which acceptable benchmark routes to audit. default: primary.",
-    )
-    parser.add_argument(
-        "--raw-dir",
-        type=Path,
-        default=RAW_DIR,
-        help=f"raw paroutes asset directory. default: {RAW_DIR}",
-    )
-    parser.add_argument(
-        "--raw-holdout",
-        action="append",
-        choices=DEFAULT_RAW_HOLDOUTS,
-        default=None,
-        help="raw paroutes holdout to audit. may be passed more than once. default: n1 and n5.",
-    )
-    parser.add_argument(
-        "--skip-raw-holdouts",
-        action="store_true",
-        help="only audit benchmark query routes.",
-    )
-    parser.add_argument(
-        "--match-level",
-        choices=tuple(level.value for level in InChIKeyLevel),
-        default=InChIKeyLevel.FULL.value,
-        help="molecule identity level. default: full.",
-    )
-    parser.add_argument(
-        "--include-partial",
-        action="store_true",
-        help="also report non-root query subroute embeddings.",
-    )
-    parser.add_argument(
-        "--partial-min-reactions",
-        type=int,
-        default=2,
-        help="minimum reactions in a partial query subroute. default: 2.",
-    )
-    parser.add_argument(
-        "--disallow-leaf-extension",
-        action="store_true",
-        help="require query leaves to also be leaves in the training route.",
-    )
-    parser.add_argument(
-        "--output-path",
-        type=Path,
-        default=None,
-        help="markdown report path. default: <release-dir>/route-embedding-audit.md.",
-    )
-    parser.add_argument(
-        "--ledger-output-path",
-        type=Path,
-        default=None,
-        help="compressed jsonl ledger path. default: <release-dir>/route-embedding-ledger.jsonl.gz.",
-    )
-    parser.add_argument("--no-progress", action="store_true", help="disable progress bars.")
-    args = parser.parse_args()
-
-    queries = _load_queries(args)
-    training_records = load_training_route_records(args.release_path)
+    queries = _load_queries()
+    training_records = load_training_route_records(RELEASE_PATH)
     audit = build_route_embedding_audit(
-        release_name=args.release_path.parent.name,
+        release_name=RELEASE_NAME,
         training_records=training_records,
         queries_by_source=queries,
-        match_level=InChIKeyLevel(args.match_level),
-        allow_leaf_extension=not args.disallow_leaf_extension,
-        include_partial=args.include_partial,
-        partial_min_reactions=args.partial_min_reactions,
+        match_level=MATCH_LEVEL,
+        allow_leaf_extension=ALLOW_LEAF_EXTENSION,
+        include_partial=INCLUDE_PARTIAL,
+        partial_min_reactions=PARTIAL_MIN_REACTIONS,
     )
 
-    output_path = args.output_path or args.release_path.parent / "route-embedding-audit.md"
-    ledger_output_path = args.ledger_output_path or args.release_path.parent / "route-embedding-ledger.jsonl.gz"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    ledger_output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(render_route_embedding_audit_markdown(audit), encoding="utf-8")
-    ledger_rows = save_jsonl_gz(audit.ledger_rows, ledger_output_path)
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    LEDGER_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(render_route_embedding_audit_markdown(audit), encoding="utf-8")
+    ledger_rows = save_jsonl_gz(audit.ledger_rows, LEDGER_OUTPUT_PATH)
     logger.info(
-        "wrote route embedding audit to %s and %s (%s ledger rows)", output_path, ledger_output_path, ledger_rows
+        "wrote route embedding audit to %s and %s (%s ledger rows)", OUTPUT_PATH, LEDGER_OUTPUT_PATH, ledger_rows
     )
 
 
-def _load_queries(args: argparse.Namespace) -> dict[str, list[QueryRoute]]:
+def _load_queries() -> dict[str, list[QueryRoute]]:
     queries: dict[str, list[QueryRoute]] = {}
-    benchmark_paths = args.benchmark_path or list(DEFAULT_BENCHMARK_PATHS)
-    for path in benchmark_paths:
+    for path in BENCHMARK_PATHS:
         source = _artifact_name(path)
-        queries[source] = _load_benchmark_queries(path, source, route_selection=args.route_selection)
+        queries[source] = _load_benchmark_queries(path, source)
 
-    if args.skip_raw_holdouts:
-        return queries
-
-    for dataset in args.raw_holdout or list(DEFAULT_RAW_HOLDOUTS):
+    for dataset in RAW_HOLDOUTS:
         source = f"{dataset}-routes"
-        queries[source] = _load_raw_paroutes_queries(
-            raw_dir=args.raw_dir,
-            dataset=dataset,
-            show_progress=not args.no_progress,
-        )
+        queries[source] = _load_raw_paroutes_queries(dataset=dataset)
     return queries
 
 
-def _load_benchmark_queries(path: Path, source: str, *, route_selection: str) -> list[QueryRoute]:
+def _load_benchmark_queries(path: Path, source: str) -> list[QueryRoute]:
     benchmark = load_benchmark(path)
     queries = benchmark_query_routes(
         benchmark,
         source=source,
-        route_selection=cast(BenchmarkRouteSelection, route_selection),
+        route_selection=ROUTE_SELECTION,
     )
     logger.info("loaded %s query routes from %s", len(queries), path)
     return queries
 
 
-def _load_raw_paroutes_queries(*, raw_dir: Path, dataset: str, show_progress: bool) -> list[QueryRoute]:
-    path = raw_dir / f"{dataset}-routes.json.gz"
-    adaptation = adapt_training_routes(path, dataset=dataset, show_progress=show_progress)
+def _load_raw_paroutes_queries(*, dataset: str) -> list[QueryRoute]:
+    path = paroutes_assets_dir() / f"{dataset}-routes.json.gz"
+    adaptation = adapt_training_routes(path, dataset=dataset, show_progress=SHOW_PROGRESS)
     logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
     return [
         QueryRoute(

--- a/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+++ b/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
@@ -7,27 +7,23 @@ usage:
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import Literal
 
 from retrocast.chem import InChIKeyLevel
 from retrocast.curation.training import adapt_training_routes
-from retrocast.curation.training.embedding_audit import (
-    BenchmarkRouteSelection,
-    QueryRoute,
-    benchmark_query_routes,
-    build_route_embedding_audit,
-)
+from retrocast.curation.training.embedding_audit import build_route_embedding_audit
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
 from retrocast.io import load_benchmark, load_training_route_records, save_jsonl_gz
+from retrocast.models.route import Route
 from retrocast.paths import benchmark_definitions_dir, paroutes_assets_dir, paroutes_training_release_file
 from retrocast.utils.logging import configure_script_logging, logger
 
 RELEASE_VERSION = "v2026-05-12"
 RELEASE_NAME = "route-holdout-n1-n5"
 RELEASE_PATH = paroutes_training_release_file(RELEASE_VERSION, RELEASE_NAME)
-BENCHMARK_PATHS = (benchmark_definitions_dir() / "mkt-cnv-160.json.gz",)
+BENCHMARKS = {"mkt-cnv-160": benchmark_definitions_dir() / "mkt-cnv-160.json.gz"}
 RAW_HOLDOUTS = ("n1", "n5")
-ROUTE_SELECTION: BenchmarkRouteSelection = "primary"
+ROUTE_SELECTION: Literal["primary", "all"] = "primary"
 MATCH_LEVEL = InChIKeyLevel.FULL
 INCLUDE_PARTIAL = True
 PARTIAL_MIN_REACTIONS = 2
@@ -39,7 +35,25 @@ LEDGER_OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-ledger.jsonl.gz"
 
 def main() -> None:
     configure_script_logging()
-    queries = _load_queries()
+    queries: dict[str, dict[str, Route]] = {}
+    for source, path in BENCHMARKS.items():
+        benchmark_queries: dict[str, Route] = {}
+        for target in load_benchmark(path).targets.values():
+            routes = target.acceptable_routes if ROUTE_SELECTION == "all" else target.acceptable_routes[:1]
+            for index, route in enumerate(routes, start=1):
+                query_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
+                benchmark_queries[query_id] = route
+        queries[source] = benchmark_queries
+        logger.info("loaded %s query routes from %s", len(benchmark_queries), path)
+
+    for dataset in RAW_HOLDOUTS:
+        path = paroutes_assets_dir() / f"{dataset}-routes.json.gz"
+        adaptation = adapt_training_routes(path, dataset=dataset, show_progress=SHOW_PROGRESS)
+        queries[f"{dataset}-routes"] = {
+            f"{dataset}-{route.source.raw_index + 1:05d}": route.route for route in adaptation.routes
+        }
+        logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
+
     training_records = load_training_route_records(RELEASE_PATH)
     audit = build_route_embedding_audit(
         release_name=RELEASE_NAME,
@@ -58,51 +72,6 @@ def main() -> None:
     logger.info(
         "wrote route embedding audit to %s and %s (%s ledger rows)", OUTPUT_PATH, LEDGER_OUTPUT_PATH, ledger_rows
     )
-
-
-def _load_queries() -> dict[str, list[QueryRoute]]:
-    queries: dict[str, list[QueryRoute]] = {}
-    for path in BENCHMARK_PATHS:
-        source = _artifact_name(path)
-        queries[source] = _load_benchmark_queries(path, source)
-
-    for dataset in RAW_HOLDOUTS:
-        source = f"{dataset}-routes"
-        queries[source] = _load_raw_paroutes_queries(dataset=dataset)
-    return queries
-
-
-def _load_benchmark_queries(path: Path, source: str) -> list[QueryRoute]:
-    benchmark = load_benchmark(path)
-    queries = benchmark_query_routes(
-        benchmark,
-        source=source,
-        route_selection=ROUTE_SELECTION,
-    )
-    logger.info("loaded %s query routes from %s", len(queries), path)
-    return queries
-
-
-def _load_raw_paroutes_queries(*, dataset: str) -> list[QueryRoute]:
-    path = paroutes_assets_dir() / f"{dataset}-routes.json.gz"
-    adaptation = adapt_training_routes(path, dataset=dataset, show_progress=SHOW_PROGRESS)
-    logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
-    return [
-        QueryRoute(
-            source=f"{dataset}-routes",
-            id=f"{dataset}-{route.source.raw_index + 1:05d}",
-            route=route.route,
-        )
-        for route in adaptation.routes
-    ]
-
-
-def _artifact_name(path: Path) -> str:
-    name = path.name
-    for suffix in (".json.gz", ".jsonl.gz", ".json"):
-        if name.endswith(suffix):
-            return name[: -len(suffix)]
-    return path.stem
 
 
 if __name__ == "__main__":

--- a/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+++ b/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
@@ -1,0 +1,194 @@
+"""
+audit route-pattern embeddings between a paroutes training release and query routes.
+
+usage:
+    uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+    uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py --include-partial
+    uv run scripts/paroutes/training-set-prep/05-audit-route-embeddings.py --release-path path/to/all.jsonl.gz
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import cast
+
+from retrocast.chem import InChIKeyLevel
+from retrocast.curation.training import adapt_training_routes
+from retrocast.curation.training.embedding_audit import (
+    BenchmarkRouteSelection,
+    QueryRoute,
+    benchmark_query_routes,
+    build_route_embedding_audit,
+)
+from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
+from retrocast.io import load_benchmark, load_training_route_records, save_jsonl_gz
+from retrocast.utils.logging import configure_script_logging, logger
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+DATA_DIR = BASE_DIR / "data" / "retrocast"
+RAW_DIR = DATA_DIR / "0-assets" / "paroutes"
+BENCHMARK_DIR = DATA_DIR / "1-benchmarks" / "definitions"
+RELEASE_VERSION = "v2026-05-12"
+DEFAULT_RELEASE_PATH = (
+    DATA_DIR / "releases" / "paroutes-training-sets" / RELEASE_VERSION / "route-holdout-n1-n5" / "all.jsonl.gz"
+)
+DEFAULT_BENCHMARK_PATHS = (BENCHMARK_DIR / "mkt-cnv-160.json.gz",)
+DEFAULT_RAW_HOLDOUTS = ("n1", "n5")
+
+
+def main() -> None:
+    configure_script_logging()
+    parser = argparse.ArgumentParser(description="audit route embeddings in a paroutes training release.")
+    parser.add_argument(
+        "--release-path",
+        type=Path,
+        default=DEFAULT_RELEASE_PATH,
+        help=f"training route release all.jsonl.gz. default: {DEFAULT_RELEASE_PATH}",
+    )
+    parser.add_argument(
+        "--benchmark-path",
+        action="append",
+        type=Path,
+        default=None,
+        help="benchmark definition to audit. may be passed more than once. default: mkt-cnv-160.",
+    )
+    parser.add_argument(
+        "--route-selection",
+        choices=("primary", "all"),
+        default="primary",
+        help="which acceptable benchmark routes to audit. default: primary.",
+    )
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=RAW_DIR,
+        help=f"raw paroutes asset directory. default: {RAW_DIR}",
+    )
+    parser.add_argument(
+        "--raw-holdout",
+        action="append",
+        choices=DEFAULT_RAW_HOLDOUTS,
+        default=None,
+        help="raw paroutes holdout to audit. may be passed more than once. default: n1 and n5.",
+    )
+    parser.add_argument(
+        "--skip-raw-holdouts",
+        action="store_true",
+        help="only audit benchmark query routes.",
+    )
+    parser.add_argument(
+        "--match-level",
+        choices=tuple(level.value for level in InChIKeyLevel),
+        default=InChIKeyLevel.FULL.value,
+        help="molecule identity level. default: full.",
+    )
+    parser.add_argument(
+        "--include-partial",
+        action="store_true",
+        help="also report non-root query subroute embeddings.",
+    )
+    parser.add_argument(
+        "--partial-min-reactions",
+        type=int,
+        default=2,
+        help="minimum reactions in a partial query subroute. default: 2.",
+    )
+    parser.add_argument(
+        "--disallow-leaf-extension",
+        action="store_true",
+        help="require query leaves to also be leaves in the training route.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=None,
+        help="markdown report path. default: <release-dir>/route-embedding-audit.md.",
+    )
+    parser.add_argument(
+        "--ledger-output-path",
+        type=Path,
+        default=None,
+        help="compressed jsonl ledger path. default: <release-dir>/route-embedding-ledger.jsonl.gz.",
+    )
+    parser.add_argument("--no-progress", action="store_true", help="disable progress bars.")
+    args = parser.parse_args()
+
+    queries = _load_queries(args)
+    training_records = load_training_route_records(args.release_path)
+    audit = build_route_embedding_audit(
+        release_name=args.release_path.parent.name,
+        training_records=training_records,
+        queries_by_source=queries,
+        match_level=InChIKeyLevel(args.match_level),
+        allow_leaf_extension=not args.disallow_leaf_extension,
+        include_partial=args.include_partial,
+        partial_min_reactions=args.partial_min_reactions,
+    )
+
+    output_path = args.output_path or args.release_path.parent / "route-embedding-audit.md"
+    ledger_output_path = args.ledger_output_path or args.release_path.parent / "route-embedding-ledger.jsonl.gz"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_route_embedding_audit_markdown(audit), encoding="utf-8")
+    ledger_rows = save_jsonl_gz(audit.ledger_rows, ledger_output_path)
+    logger.info(
+        "wrote route embedding audit to %s and %s (%s ledger rows)", output_path, ledger_output_path, ledger_rows
+    )
+
+
+def _load_queries(args: argparse.Namespace) -> dict[str, list[QueryRoute]]:
+    queries: dict[str, list[QueryRoute]] = {}
+    benchmark_paths = args.benchmark_path or list(DEFAULT_BENCHMARK_PATHS)
+    for path in benchmark_paths:
+        source = _artifact_name(path)
+        queries[source] = _load_benchmark_queries(path, source, route_selection=args.route_selection)
+
+    if args.skip_raw_holdouts:
+        return queries
+
+    for dataset in args.raw_holdout or list(DEFAULT_RAW_HOLDOUTS):
+        source = f"{dataset}-routes"
+        queries[source] = _load_raw_paroutes_queries(
+            raw_dir=args.raw_dir,
+            dataset=dataset,
+            show_progress=not args.no_progress,
+        )
+    return queries
+
+
+def _load_benchmark_queries(path: Path, source: str, *, route_selection: str) -> list[QueryRoute]:
+    benchmark = load_benchmark(path)
+    queries = benchmark_query_routes(
+        benchmark,
+        source=source,
+        route_selection=cast(BenchmarkRouteSelection, route_selection),
+    )
+    logger.info("loaded %s query routes from %s", len(queries), path)
+    return queries
+
+
+def _load_raw_paroutes_queries(*, raw_dir: Path, dataset: str, show_progress: bool) -> list[QueryRoute]:
+    path = raw_dir / f"{dataset}-routes.json.gz"
+    adaptation = adapt_training_routes(path, dataset=dataset, show_progress=show_progress)
+    logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
+    return [
+        QueryRoute(
+            source=f"{dataset}-routes",
+            id=f"{dataset}-{route.source.raw_index + 1:05d}",
+            route=route.route,
+        )
+        for route in adaptation.routes
+    ]
+
+
+def _artifact_name(path: Path) -> str:
+    name = path.name
+    for suffix in (".json.gz", ".jsonl.gz", ".json"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return path.stem
+
+
+if __name__ == "__main__":
+    main()

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -5,6 +5,7 @@ import re
 from rich.markup import escape
 from rich.table import Table
 
+from retrocast.markdown import MarkdownRow, markdown_table
 from retrocast.models.analysis import AnalysisReport, MetricSummary
 
 _SOLV_RATE = re.compile(r"^solv_(\d+)\[(.+)]_rate$")
@@ -74,9 +75,18 @@ def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation
     lines.extend(_markdown_metric_table(report.metrics))
     runtime_rows = _runtime_rows(report, rich=False)
     if runtime_rows:
-        lines.extend(["", "## Runtime", "", "| Metric | Seconds | Timed Targets |", "| --- | ---: | ---: |"])
-        for label, value in runtime_rows:
-            lines.append(f"| {label} | {value} | {report.runtime.timed_target_count} |")
+        lines.extend(
+            [
+                "",
+                "## Runtime",
+                "",
+                markdown_table(
+                    ["Metric", "Seconds", "Timed Targets"],
+                    [(label, value, report.runtime.timed_target_count) for label, value in runtime_rows],
+                    align=["left", "right", "right"],
+                ),
+            ]
+        )
     if report.by_stratum:
         lines.extend(["", "## By Stratum", ""])
         for stratum in sorted(report.by_stratum):
@@ -87,13 +97,22 @@ def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation
 
 
 def _markdown_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
-    lines = ["| Metric | Value | 95% CI | N | Flags |", "| --- | ---: | :---: | ---: | :---: |"]
+    rows: list[MarkdownRow] = []
     for name, metric, match in _ordered_metrics(metrics):
-        lines.append(
-            f"| {_display_metric_name(name, match)} | {_format_value(name, metric, rich=False)} | "
-            f"{_format_ci(name, metric, rich=False)} | {metric.count} | {_format_reliability(metric, rich=False)} |"
+        rows.append(
+            (
+                _display_metric_name(name, match),
+                _format_value(name, metric, rich=False),
+                _format_ci(name, metric, rich=False),
+                metric.count,
+                _format_reliability(metric, rich=False),
+            )
         )
-    return lines
+    return markdown_table(
+        ["Metric", "Value", "95% CI", "N", "Flags"],
+        rows,
+        align=["left", "right", "center", "right", "center"],
+    ).splitlines()
 
 
 def _runtime_rows(report: AnalysisReport, *, rich: bool = True) -> list[tuple[str, str]]:

--- a/src/retrocast/curation/training/audit.py
+++ b/src/retrocast/curation/training/audit.py
@@ -10,6 +10,7 @@ from retrocast.curation.training.records import TrainingReactionRecord
 from retrocast.curation.training.route_release import _route_transform_key
 from retrocast.exceptions import TrainingReleaseError
 from retrocast.io import iter_jsonl_gz, load_lines_gz, load_training_route_records
+from retrocast.markdown import MarkdownRow, markdown_table
 
 
 @dataclass(frozen=True)
@@ -82,29 +83,50 @@ def build_route_release_split_audit(*, release_name: str, route_records: list[An
 
 
 def render_route_release_split_audit_markdown(*, release_root_name: str, audits: list[dict[str, Any]]) -> str:
-    lines = [f"# training release audit: {release_root_name}", "", "| release | total | training | validation | val% |"]
-    lines.append("| --- | ---: | ---: | ---: | ---: |")
-    for audit in audits:
-        lines.append(
-            f"| {audit['release_name']} | {audit['total']} | {audit['training']} | {audit['validation']} | {_format_percent(_fraction(audit['validation'], audit['total']))} |"
-        )
+    lines = [
+        f"# training release audit: {release_root_name}",
+        "",
+        markdown_table(
+            ["release", "total", "training", "validation", "val%"],
+            [
+                (
+                    audit["release_name"],
+                    audit["total"],
+                    audit["training"],
+                    audit["validation"],
+                    _format_percent(_fraction(audit["validation"], audit["total"])),
+                )
+                for audit in audits
+            ],
+            align=["left", "right", "right", "right", "right"],
+        ),
+    ]
     lines.append("")
     for audit in audits:
         lines.extend(
             [
                 f"## {audit['release_name']}",
                 "",
-                "| depth | total | training | validation |",
-                "| ---: | ---: | ---: | ---: |",
+                markdown_table(
+                    ["depth", "total", "training", "validation"],
+                    [(row["depth"], row["total"], row["training"], row["validation"]) for row in audit["by_depth"]],
+                    align=["right", "right", "right", "right"],
+                ),
             ]
         )
-        for row in audit["by_depth"]:
-            lines.append(f"| {row['depth']} | {row['total']} | {row['training']} | {row['validation']} |")
-        lines.extend(["", "| convergent | total | training | validation |", "| --- | ---: | ---: | ---: |"])
-        for row in audit["by_convergence"]:
-            lines.append(
-                f"| {_format_bool(row['convergent'])} | {row['total']} | {row['training']} | {row['validation']} |"
-            )
+        lines.extend(
+            [
+                "",
+                markdown_table(
+                    ["convergent", "total", "training", "validation"],
+                    [
+                        (_format_bool(row["convergent"]), row["total"], row["training"], row["validation"])
+                        for row in audit["by_convergence"]
+                    ],
+                    align=["left", "right", "right", "right"],
+                ),
+            ]
+        )
         lines.append("")
     return "\n".join(lines)
 
@@ -212,25 +234,44 @@ def audit_single_step_release_if_present(*, release_root: Path, parent_route_ids
 
 
 def render_sanity_checks_markdown(sanity_checks: dict[str, dict[str, Any]]) -> str:
-    lines = [
-        "## sanity checks",
-        "",
-        "| release | records | training | validation | holdout refs |",
-        "| --- | ---: | ---: | ---: | ---: |",
-    ]
-    for name, checks in sorted(sanity_checks.items()):
-        lines.append(
-            f"| {name} | {checks['all_count']} | {checks['training_count']} | {checks['validation_count']} | {checks['holdout_count']} |"
+    rows: list[MarkdownRow] = [
+        (
+            name,
+            checks["all_count"],
+            checks["training_count"],
+            checks["validation_count"],
+            checks["holdout_count"],
         )
-    return "\n".join(lines) + "\n"
+        for name, checks in sorted(sanity_checks.items())
+    ]
+    return (
+        "## sanity checks\n\n"
+        + markdown_table(
+            ["release", "records", "training", "validation", "holdout refs"],
+            rows,
+            align=["left", "right", "right", "right", "right"],
+        )
+        + "\n"
+    )
 
 
 def render_single_step_sanity_markdown(checks: dict[str, Any]) -> str:
     return (
         "## single-step sanity\n\n"
-        "| release | records | training | validation | parent routes |\n"
-        "| --- | ---: | ---: | ---: | ---: |\n"
-        f"| {checks['release_name']} | {checks['records']} | {checks['training']} | {checks['validation']} | {checks['parent_routes']} |\n"
+        + markdown_table(
+            ["release", "records", "training", "validation", "parent routes"],
+            [
+                (
+                    checks["release_name"],
+                    checks["records"],
+                    checks["training"],
+                    checks["validation"],
+                    checks["parent_routes"],
+                )
+            ],
+            align=["left", "right", "right", "right", "right"],
+        )
+        + "\n"
     )
 
 

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -11,47 +11,22 @@ from pydantic import BaseModel, ConfigDict
 from retrocast.chem import InChIKeyLevel
 from retrocast.curation.embedding import route_embeds_at, subtree_reaction_count
 from retrocast.curation.training.records import TrainingRouteRecord
-from retrocast.exceptions import InvalidRouteEmbeddingQueryError
 from retrocast.models.route import MoleculeView, Route, RoutePath
-from retrocast.models.task import Benchmark
 
 EmbeddingMatchKind = Literal["full_route", "internal_subroute"]
-BenchmarkRouteSelection = Literal["primary", "all"]
 
 
-@dataclass(frozen=True, slots=True)
-class QueryRoute:
-    source: str
-    id: str
-    route: Route
-
-
-def benchmark_query_routes(
-    benchmark: Benchmark,
-    *,
-    source: str,
-    route_selection: BenchmarkRouteSelection = "primary",
-) -> list[QueryRoute]:
-    queries: list[QueryRoute] = []
-    for target in benchmark.targets.values():
-        routes = target.acceptable_routes if route_selection == "all" else target.acceptable_routes[:1]
-        for index, route in enumerate(routes, start=1):
-            query_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
-            queries.append(QueryRoute(source=source, id=query_id, route=route))
-    return queries
-
-
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class TrainingRouteOccurrence:
     record: TrainingRouteRecord
     molecule: MoleculeView
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class TrainingEmbeddingIndex:
     route_signatures: set[str]
     reaction_signatures: set[str]
-    by_reaction_root: Mapping[tuple[str, str], tuple[TrainingRouteOccurrence, ...]]
+    by_reaction_root: Mapping[str, tuple[TrainingRouteOccurrence, ...]]
 
 
 class RouteEmbeddingLedgerRow(BaseModel):
@@ -73,7 +48,7 @@ class RouteEmbeddingLedgerRow(BaseModel):
     leaf_extension_container_paths: tuple[str, ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class FullEmbeddingSummary:
     query_routes_with_embedding: int
     embedding_occurrences: int
@@ -82,7 +57,7 @@ class FullEmbeddingSummary:
     root_distance_counts: tuple[tuple[int, int], ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class InternalSubrouteEmbeddingSummary:
     min_reactions: int
     checked_internal_subroutes: int
@@ -91,7 +66,7 @@ class InternalSubrouteEmbeddingSummary:
     embedding_occurrences: int
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class CoverageSummary:
     basis: str
     all_query_routes: int
@@ -105,7 +80,7 @@ class CoverageSummary:
     matched_fraction_histogram: tuple[tuple[str, int], ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class QuerySetAudit:
     source: str
     query_routes: int
@@ -117,7 +92,7 @@ class QuerySetAudit:
     coverage: CoverageSummary
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class RouteEmbeddingAudit:
     release_name: str
     match_level: str
@@ -130,7 +105,7 @@ class RouteEmbeddingAudit:
     ledger_rows: tuple[RouteEmbeddingLedgerRow, ...]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _QueryCoverageRow:
     matched_fraction_of_query_route: float
     matched_fraction_of_container_route: float
@@ -142,13 +117,12 @@ def build_route_embedding_audit(
     *,
     release_name: str,
     training_records: Sequence[TrainingRouteRecord],
-    queries_by_source: Mapping[str, Sequence[QueryRoute]],
+    queries_by_source: Mapping[str, Mapping[str, Route]],
     match_level: InChIKeyLevel = InChIKeyLevel.FULL,
     allow_leaf_extension: bool = True,
     include_partial: bool = False,
     partial_min_reactions: int = 2,
 ) -> RouteEmbeddingAudit:
-    _validate_queries(queries_by_source)
     index = build_training_embedding_index(training_records, match_level)
     query_sets: list[QuerySetAudit] = []
     ledger_rows: list[RouteEmbeddingLedgerRow] = []
@@ -184,7 +158,7 @@ def build_training_embedding_index(
 ) -> TrainingEmbeddingIndex:
     route_signatures: set[str] = set()
     reaction_signatures: set[str] = set()
-    by_reaction_root: dict[tuple[str, str], list[TrainingRouteOccurrence]] = defaultdict(list)
+    by_reaction_root: dict[str, list[TrainingRouteOccurrence]] = defaultdict(list)
 
     for record in records:
         route_signatures.add(record.route.signature(match_level))
@@ -193,7 +167,7 @@ def build_training_embedding_index(
             occurrence = TrainingRouteOccurrence(record=record, molecule=molecule)
             reaction = molecule.produced_by()
             if reaction is not None:
-                by_reaction_root[(molecule.key(match_level), reaction.signature(match_level))].append(occurrence)
+                by_reaction_root[reaction.signature(match_level)].append(occurrence)
 
     return TrainingEmbeddingIndex(
         route_signatures=route_signatures,
@@ -205,7 +179,7 @@ def build_training_embedding_index(
 def _audit_query_set(
     *,
     source: str,
-    queries: Sequence[QueryRoute],
+    queries: Mapping[str, Route],
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
@@ -213,6 +187,7 @@ def _audit_query_set(
     partial_min_reactions: int,
 ) -> tuple[QuerySetAudit, tuple[RouteEmbeddingLedgerRow, ...]]:
     full_rows = _full_route_ledger_rows(
+        source=source,
         queries=queries,
         index=index,
         match_level=match_level,
@@ -222,6 +197,7 @@ def _audit_query_set(
     internal_rows: tuple[RouteEmbeddingLedgerRow, ...] = ()
     if include_partial:
         internal_summary, internal_rows = _internal_subroute_audit(
+            source=source,
             queries=queries,
             index=index,
             match_level=match_level,
@@ -230,16 +206,16 @@ def _audit_query_set(
         )
 
     rows = (*full_rows, *internal_rows)
-    query_ids = [query.id for query in queries]
+    query_ids = list(queries)
     query_reaction_signatures = {
-        signature for query in queries for signature in query.route.reaction_signatures(match_level)
+        signature for route in queries.values() for signature in route.reaction_signatures(match_level)
     }
     query_set = QuerySetAudit(
         source=source,
         query_routes=len(queries),
         query_reaction_signatures=len(query_reaction_signatures),
         exact_route_signature_overlap=sum(
-            query.route.signature(match_level) in index.route_signatures for query in queries
+            route.signature(match_level) in index.route_signatures for route in queries.values()
         ),
         reaction_signature_overlap=len(query_reaction_signatures & index.reaction_signatures),
         full_embeddings=_summarize_full_embeddings(full_rows),
@@ -259,17 +235,20 @@ def _audit_query_set(
 
 def _full_route_ledger_rows(
     *,
-    queries: Sequence[QueryRoute],
+    source: str,
+    queries: Mapping[str, Route],
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
 ) -> tuple[RouteEmbeddingLedgerRow, ...]:
     rows: list[RouteEmbeddingLedgerRow] = []
-    for query in queries:
+    for query_id, route in queries.items():
         rows.extend(
             _embedding_rows(
-                query=query,
-                query_molecule=query.route.molecule_at(RoutePath.target()),
+                query_source=source,
+                query_id=query_id,
+                query_route=route,
+                query_molecule=route.molecule_at(RoutePath.target()),
                 match_kind="full_route",
                 index=index,
                 match_level=match_level,
@@ -281,7 +260,8 @@ def _full_route_ledger_rows(
 
 def _internal_subroute_audit(
     *,
-    queries: Sequence[QueryRoute],
+    source: str,
+    queries: Mapping[str, Route],
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
@@ -289,15 +269,17 @@ def _internal_subroute_audit(
 ) -> tuple[InternalSubrouteEmbeddingSummary, tuple[RouteEmbeddingLedgerRow, ...]]:
     checked = 0
     rows: list[RouteEmbeddingLedgerRow] = []
-    embedded_subroutes: set[tuple[str, str, str]] = set()
-    for query in queries:
-        for molecule in query.route.iter_molecules():
+    embedded_subroutes: set[tuple[str, str]] = set()
+    for query_id, route in queries.items():
+        for molecule in route.iter_molecules():
             if molecule.path == RoutePath.target() or subtree_reaction_count(molecule) < partial_min_reactions:
                 continue
             checked += 1
-            subroute_key = (query.source, query.id, molecule.path.id())
+            subroute_key = (query_id, molecule.path.id())
             subroute_rows = _embedding_rows(
-                query=query,
+                query_source=source,
+                query_id=query_id,
+                query_route=route,
                 query_molecule=molecule,
                 match_kind="internal_subroute",
                 index=index,
@@ -313,7 +295,7 @@ def _internal_subroute_audit(
             min_reactions=partial_min_reactions,
             checked_internal_subroutes=checked,
             embedded_internal_subroutes=len(embedded_subroutes),
-            query_routes_with_embedding=len({query_id for _, query_id, _ in embedded_subroutes}),
+            query_routes_with_embedding=len({query_id for query_id, _ in embedded_subroutes}),
             embedding_occurrences=len(rows),
         ),
         tuple(rows),
@@ -322,7 +304,9 @@ def _internal_subroute_audit(
 
 def _embedding_rows(
     *,
-    query: QueryRoute,
+    query_source: str,
+    query_id: str,
+    query_route: Route,
     query_molecule: MoleculeView,
     match_kind: EmbeddingMatchKind,
     index: TrainingEmbeddingIndex,
@@ -330,7 +314,7 @@ def _embedding_rows(
     allow_leaf_extension: bool,
 ) -> tuple[RouteEmbeddingLedgerRow, ...]:
     rows: list[RouteEmbeddingLedgerRow] = []
-    query_route_reactions = _route_reaction_count(query.route)
+    query_route_reactions = sum(1 for _ in query_route.iter_reactions())
     query_subroute_reactions = subtree_reaction_count(query_molecule)
     for occurrence in _candidate_occurrences(query_molecule, index, match_level):
         match = route_embeds_at(
@@ -342,12 +326,12 @@ def _embedding_rows(
         if match is None:
             continue
 
-        container_route_reactions = _route_reaction_count(occurrence.record.route)
+        container_route_reactions = sum(1 for _ in occurrence.record.route.iter_reactions())
         container_subtree_reactions = subtree_reaction_count(occurrence.molecule)
         rows.append(
             RouteEmbeddingLedgerRow(
-                query_source=query.source,
-                query_id=query.id,
+                query_source=query_source,
+                query_id=query_id,
                 query_path=match.query_path.id(),
                 query_route_reactions=query_route_reactions,
                 query_subroute_reactions=query_subroute_reactions,
@@ -375,13 +359,13 @@ def _candidate_occurrences(
     reaction = query_root.produced_by()
     if reaction is None:
         return ()
-    return index.by_reaction_root.get((query_root.key(match_level), reaction.signature(match_level)), ())
+    return index.by_reaction_root.get(reaction.signature(match_level), ())
 
 
 def _summarize_full_embeddings(rows: Sequence[RouteEmbeddingLedgerRow]) -> FullEmbeddingSummary:
     root_distance_counts: dict[int, int] = defaultdict(int)
     for row in rows:
-        root_distance_counts[_path_depth(row.container_path)] += 1
+        root_distance_counts[RoutePath.parse(row.container_path).depth()] += 1
 
     return FullEmbeddingSummary(
         query_routes_with_embedding=len({row.query_id for row in rows}),
@@ -474,52 +458,20 @@ def _coverage_bucket(value: float) -> str:
     return "100%"
 
 
-def _route_reaction_count(route: Route) -> int:
-    return sum(1 for _ in route.iter_reactions())
-
-
-def _validate_queries(queries_by_source: Mapping[str, Sequence[QueryRoute]]) -> None:
-    for source, queries in queries_by_source.items():
-        for query in queries:
-            if _route_reaction_count(query.route):
-                continue
-            raise InvalidRouteEmbeddingQueryError(
-                "route embedding audit queries must contain at least one reaction",
-                context={
-                    "query_source": source,
-                    "query_id": query.id,
-                    "query_target_smiles": str(query.route.target.smiles),
-                    "query_target_inchikey": str(query.route.target.inchikey),
-                },
-            )
-
-
-def _path_depth(path: str) -> int:
-    return RoutePath.parse(path).depth()
-
-
 def _mean(values: Sequence[float | int]) -> float:
     return sum(values) / len(values) if values else 0.0
 
 
 def _fraction_stats(values: Sequence[float]) -> tuple[float, float, float]:
-    return (_mean(values), _median(values), _p90(values))
-
-
-def _median(values: Sequence[float]) -> float:
     if not values:
-        return 0.0
+        return (0.0, 0.0, 0.0)
     sorted_values = sorted(values)
     midpoint = len(sorted_values) // 2
     if len(sorted_values) % 2:
-        return sorted_values[midpoint]
-    return (sorted_values[midpoint - 1] + sorted_values[midpoint]) / 2
-
-
-def _p90(values: Sequence[float]) -> float:
-    if not values:
-        return 0.0
-    return sorted(values)[ceil(0.9 * len(values)) - 1]
+        median = sorted_values[midpoint]
+    else:
+        median = (sorted_values[midpoint - 1] + sorted_values[midpoint]) / 2
+    return (_mean(values), median, sorted_values[ceil(0.9 * len(sorted_values)) - 1])
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -265,16 +265,13 @@ def _summarize_prefix_depths(
         eligible = [route for route in queries.values() if route.depth() >= depth]
         root_prefixes = index.root_prefix_signatures_by_depth.get(depth, set())
         subtree_prefixes = index.subtree_prefix_signatures_by_depth.get(depth, set())
+        signatures = [route.signature(match_level, depth=depth) for route in eligible]
         summaries.append(
             PrefixDepthSummary(
                 depth=depth,
                 query_routes=len(eligible),
-                root_prefix_signature_overlap=sum(
-                    route.signature(match_level, depth=depth) in root_prefixes for route in eligible
-                ),
-                subtree_prefix_signature_overlap=sum(
-                    route.signature(match_level, depth=depth) in subtree_prefixes for route in eligible
-                ),
+                root_prefix_signature_overlap=sum(signature in root_prefixes for signature in signatures),
+                subtree_prefix_signature_overlap=sum(signature in subtree_prefixes for signature in signatures),
             )
         )
     return tuple(summaries)

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -26,6 +26,8 @@ class TrainingRouteOccurrence:
 class TrainingEmbeddingIndex:
     route_signatures: set[str]
     reaction_signatures: set[str]
+    root_prefix_signatures_by_depth: Mapping[int, set[str]]
+    subtree_prefix_signatures_by_depth: Mapping[int, set[str]]
     by_reaction_root: Mapping[str, tuple[TrainingRouteOccurrence, ...]]
 
 
@@ -67,6 +69,14 @@ class InternalSubrouteEmbeddingSummary:
 
 
 @dataclass(slots=True)
+class PrefixDepthSummary:
+    depth: int
+    query_routes: int
+    root_prefix_signature_overlap: int
+    subtree_prefix_signature_overlap: int
+
+
+@dataclass(slots=True)
 class CoverageSummary:
     basis: str
     all_query_routes: int
@@ -87,6 +97,7 @@ class QuerySetAudit:
     query_reaction_signatures: int
     exact_route_signature_overlap: int
     reaction_signature_overlap: int
+    prefix_depths: tuple[PrefixDepthSummary, ...]
     full_embeddings: FullEmbeddingSummary
     internal_subroute_embeddings: InternalSubrouteEmbeddingSummary | None
     coverage: CoverageSummary
@@ -158,12 +169,18 @@ def build_training_embedding_index(
 ) -> TrainingEmbeddingIndex:
     route_signatures: set[str] = set()
     reaction_signatures: set[str] = set()
+    root_prefix_signatures_by_depth: dict[int, set[str]] = defaultdict(set)
+    subtree_prefix_signatures_by_depth: dict[int, set[str]] = defaultdict(set)
     by_reaction_root: dict[str, list[TrainingRouteOccurrence]] = defaultdict(list)
 
     for record in records:
         route_signatures.add(record.route.signature(match_level))
         reaction_signatures.update(record.route.reaction_signatures(match_level))
+        for depth in range(1, record.route.depth() + 1):
+            root_prefix_signatures_by_depth[depth].add(record.route.signature(match_level, depth=depth))
         for molecule in record.route.iter_molecules():
+            for depth in range(1, molecule.depth() + 1):
+                subtree_prefix_signatures_by_depth[depth].add(molecule.subtree_signature(match_level, depth=depth))
             occurrence = TrainingRouteOccurrence(record=record, molecule=molecule)
             reaction = molecule.produced_by()
             if reaction is not None:
@@ -172,6 +189,8 @@ def build_training_embedding_index(
     return TrainingEmbeddingIndex(
         route_signatures=route_signatures,
         reaction_signatures=reaction_signatures,
+        root_prefix_signatures_by_depth=dict(root_prefix_signatures_by_depth),
+        subtree_prefix_signatures_by_depth=dict(subtree_prefix_signatures_by_depth),
         by_reaction_root={key: tuple(value) for key, value in by_reaction_root.items()},
     )
 
@@ -218,6 +237,7 @@ def _audit_query_set(
             route.signature(match_level) in index.route_signatures for route in queries.values()
         ),
         reaction_signature_overlap=len(query_reaction_signatures & index.reaction_signatures),
+        prefix_depths=_summarize_prefix_depths(queries=queries, index=index, match_level=match_level),
         full_embeddings=_summarize_full_embeddings(full_rows),
         internal_subroute_embeddings=internal_summary,
         coverage=_summarize_coverage(
@@ -231,6 +251,33 @@ def _audit_query_set(
         ),
     )
     return query_set, rows
+
+
+def _summarize_prefix_depths(
+    *,
+    queries: Mapping[str, Route],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+) -> tuple[PrefixDepthSummary, ...]:
+    max_depth = max((route.depth() for route in queries.values()), default=0)
+    summaries: list[PrefixDepthSummary] = []
+    for depth in range(1, max_depth + 1):
+        eligible = [route for route in queries.values() if route.depth() >= depth]
+        root_prefixes = index.root_prefix_signatures_by_depth.get(depth, set())
+        subtree_prefixes = index.subtree_prefix_signatures_by_depth.get(depth, set())
+        summaries.append(
+            PrefixDepthSummary(
+                depth=depth,
+                query_routes=len(eligible),
+                root_prefix_signature_overlap=sum(
+                    route.signature(match_level, depth=depth) in root_prefixes for route in eligible
+                ),
+                subtree_prefix_signature_overlap=sum(
+                    route.signature(match_level, depth=depth) in subtree_prefixes for route in eligible
+                ),
+            )
+        )
+    return tuple(summaries)
 
 
 def _full_route_ledger_rows(

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import ceil
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from retrocast.chem import InChIKeyLevel
+from retrocast.curation.embedding import route_embeds_at, subtree_reaction_count
+from retrocast.curation.training.records import TrainingRouteRecord
+from retrocast.exceptions import InvalidRouteEmbeddingQueryError
+from retrocast.models.route import MoleculeView, Route, RoutePath
+from retrocast.models.task import Benchmark
+
+EmbeddingMatchKind = Literal["full_route", "internal_subroute"]
+BenchmarkRouteSelection = Literal["primary", "all"]
+
+
+@dataclass(frozen=True, slots=True)
+class QueryRoute:
+    source: str
+    id: str
+    route: Route
+
+
+def benchmark_query_routes(
+    benchmark: Benchmark,
+    *,
+    source: str,
+    route_selection: BenchmarkRouteSelection = "primary",
+) -> list[QueryRoute]:
+    queries: list[QueryRoute] = []
+    for target in benchmark.targets.values():
+        routes = target.acceptable_routes if route_selection == "all" else target.acceptable_routes[:1]
+        for index, route in enumerate(routes, start=1):
+            query_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
+            queries.append(QueryRoute(source=source, id=query_id, route=route))
+    return queries
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingRouteOccurrence:
+    record: TrainingRouteRecord
+    molecule: MoleculeView
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingEmbeddingIndex:
+    route_signatures: set[str]
+    reaction_signatures: set[str]
+    by_reaction_root: Mapping[tuple[str, str], tuple[TrainingRouteOccurrence, ...]]
+
+
+class RouteEmbeddingLedgerRow(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    query_source: str
+    query_id: str
+    query_path: str
+    query_route_reactions: int
+    query_subroute_reactions: int
+    container_route_id: str
+    container_split: str
+    container_path: str
+    container_route_reactions: int
+    container_subtree_reactions: int
+    match_kind: EmbeddingMatchKind
+    matched_reactions: int
+    leaf_extension_query_paths: tuple[str, ...]
+    leaf_extension_container_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FullEmbeddingSummary:
+    query_routes_with_embedding: int
+    embedding_occurrences: int
+    query_routes_with_root_shifted_embedding: int
+    query_routes_with_leaf_extended_embedding: int
+    root_distance_counts: tuple[tuple[int, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InternalSubrouteEmbeddingSummary:
+    min_reactions: int
+    checked_internal_subroutes: int
+    embedded_internal_subroutes: int
+    query_routes_with_embedding: int
+    embedding_occurrences: int
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageSummary:
+    basis: str
+    all_query_routes: int
+    embedded_query_routes: int
+    all_query_fraction_stats: tuple[float, float, float]
+    embedded_query_fraction_stats: tuple[float, float, float]
+    all_container_fraction_stats: tuple[float, float, float]
+    embedded_container_fraction_stats: tuple[float, float, float]
+    embedded_mean_training_routes_per_query: float
+    embedded_mean_occurrences_per_query: float
+    matched_fraction_histogram: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class QuerySetAudit:
+    source: str
+    query_routes: int
+    query_reaction_signatures: int
+    exact_route_signature_overlap: int
+    reaction_signature_overlap: int
+    full_embeddings: FullEmbeddingSummary
+    internal_subroute_embeddings: InternalSubrouteEmbeddingSummary | None
+    coverage: CoverageSummary
+
+
+@dataclass(frozen=True, slots=True)
+class RouteEmbeddingAudit:
+    release_name: str
+    match_level: str
+    allow_leaf_extension: bool
+    partial_min_reactions: int | None
+    training_routes: int
+    training_route_signatures: int
+    training_reaction_signatures: int
+    query_sets: tuple[QuerySetAudit, ...]
+    ledger_rows: tuple[RouteEmbeddingLedgerRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _QueryCoverageRow:
+    matched_fraction_of_query_route: float
+    matched_fraction_of_container_route: float
+    training_routes: int
+    occurrences: int
+
+
+def build_route_embedding_audit(
+    *,
+    release_name: str,
+    training_records: Sequence[TrainingRouteRecord],
+    queries_by_source: Mapping[str, Sequence[QueryRoute]],
+    match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    allow_leaf_extension: bool = True,
+    include_partial: bool = False,
+    partial_min_reactions: int = 2,
+) -> RouteEmbeddingAudit:
+    _validate_queries(queries_by_source)
+    index = build_training_embedding_index(training_records, match_level)
+    query_sets: list[QuerySetAudit] = []
+    ledger_rows: list[RouteEmbeddingLedgerRow] = []
+    for source, queries in sorted(queries_by_source.items()):
+        query_set, rows = _audit_query_set(
+            source=source,
+            queries=queries,
+            index=index,
+            match_level=match_level,
+            allow_leaf_extension=allow_leaf_extension,
+            include_partial=include_partial,
+            partial_min_reactions=partial_min_reactions,
+        )
+        query_sets.append(query_set)
+        ledger_rows.extend(rows)
+
+    return RouteEmbeddingAudit(
+        release_name=release_name,
+        match_level=match_level.value,
+        allow_leaf_extension=allow_leaf_extension,
+        partial_min_reactions=partial_min_reactions if include_partial else None,
+        training_routes=len(training_records),
+        training_route_signatures=len(index.route_signatures),
+        training_reaction_signatures=len(index.reaction_signatures),
+        query_sets=tuple(query_sets),
+        ledger_rows=tuple(ledger_rows),
+    )
+
+
+def build_training_embedding_index(
+    records: Sequence[TrainingRouteRecord],
+    match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+) -> TrainingEmbeddingIndex:
+    route_signatures: set[str] = set()
+    reaction_signatures: set[str] = set()
+    by_reaction_root: dict[tuple[str, str], list[TrainingRouteOccurrence]] = defaultdict(list)
+
+    for record in records:
+        route_signatures.add(record.route.signature(match_level))
+        reaction_signatures.update(record.route.reaction_signatures(match_level))
+        for molecule in record.route.iter_molecules():
+            occurrence = TrainingRouteOccurrence(record=record, molecule=molecule)
+            reaction = molecule.produced_by()
+            if reaction is not None:
+                by_reaction_root[(molecule.key(match_level), reaction.signature(match_level))].append(occurrence)
+
+    return TrainingEmbeddingIndex(
+        route_signatures=route_signatures,
+        reaction_signatures=reaction_signatures,
+        by_reaction_root={key: tuple(value) for key, value in by_reaction_root.items()},
+    )
+
+
+def _audit_query_set(
+    *,
+    source: str,
+    queries: Sequence[QueryRoute],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    allow_leaf_extension: bool,
+    include_partial: bool,
+    partial_min_reactions: int,
+) -> tuple[QuerySetAudit, tuple[RouteEmbeddingLedgerRow, ...]]:
+    full_rows = _full_route_ledger_rows(
+        queries=queries,
+        index=index,
+        match_level=match_level,
+        allow_leaf_extension=allow_leaf_extension,
+    )
+    internal_summary = None
+    internal_rows: tuple[RouteEmbeddingLedgerRow, ...] = ()
+    if include_partial:
+        internal_summary, internal_rows = _internal_subroute_audit(
+            queries=queries,
+            index=index,
+            match_level=match_level,
+            allow_leaf_extension=allow_leaf_extension,
+            partial_min_reactions=partial_min_reactions,
+        )
+
+    rows = (*full_rows, *internal_rows)
+    query_ids = [query.id for query in queries]
+    query_reaction_signatures = {
+        signature for query in queries for signature in query.route.reaction_signatures(match_level)
+    }
+    query_set = QuerySetAudit(
+        source=source,
+        query_routes=len(queries),
+        query_reaction_signatures=len(query_reaction_signatures),
+        exact_route_signature_overlap=sum(
+            query.route.signature(match_level) in index.route_signatures for query in queries
+        ),
+        reaction_signature_overlap=len(query_reaction_signatures & index.reaction_signatures),
+        full_embeddings=_summarize_full_embeddings(full_rows),
+        internal_subroute_embeddings=internal_summary,
+        coverage=_summarize_coverage(
+            query_ids=query_ids,
+            rows=rows,
+            basis=(
+                f"full routes + internal subroutes with {partial_min_reactions}+ reactions"
+                if include_partial
+                else "full routes only"
+            ),
+        ),
+    )
+    return query_set, rows
+
+
+def _full_route_ledger_rows(
+    *,
+    queries: Sequence[QueryRoute],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    allow_leaf_extension: bool,
+) -> tuple[RouteEmbeddingLedgerRow, ...]:
+    rows: list[RouteEmbeddingLedgerRow] = []
+    for query in queries:
+        rows.extend(
+            _embedding_rows(
+                query=query,
+                query_molecule=query.route.molecule_at(RoutePath.target()),
+                match_kind="full_route",
+                index=index,
+                match_level=match_level,
+                allow_leaf_extension=allow_leaf_extension,
+            )
+        )
+    return tuple(rows)
+
+
+def _internal_subroute_audit(
+    *,
+    queries: Sequence[QueryRoute],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    allow_leaf_extension: bool,
+    partial_min_reactions: int,
+) -> tuple[InternalSubrouteEmbeddingSummary, tuple[RouteEmbeddingLedgerRow, ...]]:
+    checked = 0
+    rows: list[RouteEmbeddingLedgerRow] = []
+    embedded_subroutes: set[tuple[str, str, str]] = set()
+    for query in queries:
+        for molecule in query.route.iter_molecules():
+            if molecule.path == RoutePath.target() or subtree_reaction_count(molecule) < partial_min_reactions:
+                continue
+            checked += 1
+            subroute_key = (query.source, query.id, molecule.path.id())
+            subroute_rows = _embedding_rows(
+                query=query,
+                query_molecule=molecule,
+                match_kind="internal_subroute",
+                index=index,
+                match_level=match_level,
+                allow_leaf_extension=allow_leaf_extension,
+            )
+            rows.extend(subroute_rows)
+            if subroute_rows:
+                embedded_subroutes.add(subroute_key)
+
+    return (
+        InternalSubrouteEmbeddingSummary(
+            min_reactions=partial_min_reactions,
+            checked_internal_subroutes=checked,
+            embedded_internal_subroutes=len(embedded_subroutes),
+            query_routes_with_embedding=len({query_id for _, query_id, _ in embedded_subroutes}),
+            embedding_occurrences=len(rows),
+        ),
+        tuple(rows),
+    )
+
+
+def _embedding_rows(
+    *,
+    query: QueryRoute,
+    query_molecule: MoleculeView,
+    match_kind: EmbeddingMatchKind,
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    allow_leaf_extension: bool,
+) -> tuple[RouteEmbeddingLedgerRow, ...]:
+    rows: list[RouteEmbeddingLedgerRow] = []
+    query_route_reactions = _route_reaction_count(query.route)
+    query_subroute_reactions = subtree_reaction_count(query_molecule)
+    for occurrence in _candidate_occurrences(query_molecule, index, match_level):
+        match = route_embeds_at(
+            query_molecule,
+            occurrence.molecule,
+            match_level,
+            allow_leaf_extension=allow_leaf_extension,
+        )
+        if match is None:
+            continue
+
+        container_route_reactions = _route_reaction_count(occurrence.record.route)
+        container_subtree_reactions = subtree_reaction_count(occurrence.molecule)
+        rows.append(
+            RouteEmbeddingLedgerRow(
+                query_source=query.source,
+                query_id=query.id,
+                query_path=match.query_path.id(),
+                query_route_reactions=query_route_reactions,
+                query_subroute_reactions=query_subroute_reactions,
+                container_route_id=occurrence.record.id,
+                container_split=occurrence.record.split,
+                container_path=match.container_path.id(),
+                container_route_reactions=container_route_reactions,
+                container_subtree_reactions=container_subtree_reactions,
+                match_kind=match_kind,
+                matched_reactions=match.matched_reactions,
+                leaf_extension_query_paths=tuple(extension.query_leaf_path.id() for extension in match.leaf_extensions),
+                leaf_extension_container_paths=tuple(
+                    extension.container_path.id() for extension in match.leaf_extensions
+                ),
+            )
+        )
+    return tuple(rows)
+
+
+def _candidate_occurrences(
+    query_root: MoleculeView,
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+) -> Sequence[TrainingRouteOccurrence]:
+    reaction = query_root.produced_by()
+    if reaction is None:
+        return ()
+    return index.by_reaction_root.get((query_root.key(match_level), reaction.signature(match_level)), ())
+
+
+def _summarize_full_embeddings(rows: Sequence[RouteEmbeddingLedgerRow]) -> FullEmbeddingSummary:
+    root_distance_counts: dict[int, int] = defaultdict(int)
+    for row in rows:
+        root_distance_counts[_path_depth(row.container_path)] += 1
+
+    return FullEmbeddingSummary(
+        query_routes_with_embedding=len({row.query_id for row in rows}),
+        embedding_occurrences=len(rows),
+        query_routes_with_root_shifted_embedding=len(
+            {row.query_id for row in rows if row.container_path != RoutePath.target().id()}
+        ),
+        query_routes_with_leaf_extended_embedding=len({row.query_id for row in rows if row.leaf_extension_query_paths}),
+        root_distance_counts=tuple(
+            (distance, root_distance_counts[distance]) for distance in sorted(root_distance_counts)
+        ),
+    )
+
+
+def _summarize_coverage(
+    *,
+    query_ids: Sequence[str],
+    rows: Sequence[RouteEmbeddingLedgerRow],
+    basis: str,
+) -> CoverageSummary:
+    rows_by_query: dict[str, list[RouteEmbeddingLedgerRow]] = defaultdict(list)
+    for row in rows:
+        rows_by_query[row.query_id].append(row)
+
+    coverage_rows = [_query_coverage_row(rows_by_query.get(query_id, ())) for query_id in query_ids]
+    embedded_rows = [row for row in coverage_rows if row.occurrences]
+    return CoverageSummary(
+        basis=basis,
+        all_query_routes=len(coverage_rows),
+        embedded_query_routes=len(embedded_rows),
+        all_query_fraction_stats=_fraction_stats([row.matched_fraction_of_query_route for row in coverage_rows]),
+        embedded_query_fraction_stats=_fraction_stats([row.matched_fraction_of_query_route for row in embedded_rows]),
+        all_container_fraction_stats=_fraction_stats(
+            [row.matched_fraction_of_container_route for row in coverage_rows]
+        ),
+        embedded_container_fraction_stats=_fraction_stats(
+            [row.matched_fraction_of_container_route for row in embedded_rows]
+        ),
+        embedded_mean_training_routes_per_query=_mean([row.training_routes for row in embedded_rows]),
+        embedded_mean_occurrences_per_query=_mean([row.occurrences for row in embedded_rows]),
+        matched_fraction_histogram=_coverage_histogram(coverage_rows),
+    )
+
+
+def _query_coverage_row(rows: Sequence[RouteEmbeddingLedgerRow]) -> _QueryCoverageRow:
+    if not rows:
+        return _QueryCoverageRow(
+            matched_fraction_of_query_route=0.0,
+            matched_fraction_of_container_route=0.0,
+            training_routes=0,
+            occurrences=0,
+        )
+
+    best = max(
+        rows,
+        key=lambda row: (
+            _ratio(row.matched_reactions, row.query_route_reactions),
+            _ratio(row.matched_reactions, row.container_subtree_reactions),
+            _ratio(row.matched_reactions, row.container_route_reactions),
+            row.matched_reactions,
+        ),
+    )
+    return _QueryCoverageRow(
+        matched_fraction_of_query_route=_ratio(best.matched_reactions, best.query_route_reactions),
+        matched_fraction_of_container_route=_ratio(best.matched_reactions, best.container_route_reactions),
+        training_routes=len({row.container_route_id for row in rows}),
+        occurrences=len(rows),
+    )
+
+
+def _coverage_histogram(rows: Sequence[_QueryCoverageRow]) -> tuple[tuple[str, int], ...]:
+    buckets = ("0%", "(0,25%]", "(25,50%]", "(50,75%]", "(75,100%)", "100%")
+    counts = dict.fromkeys(buckets, 0)
+    for row in rows:
+        counts[_coverage_bucket(row.matched_fraction_of_query_route)] += 1
+    return tuple((bucket, counts[bucket]) for bucket in buckets)
+
+
+def _coverage_bucket(value: float) -> str:
+    if value == 0:
+        return "0%"
+    if value <= 0.25:
+        return "(0,25%]"
+    if value <= 0.50:
+        return "(25,50%]"
+    if value <= 0.75:
+        return "(50,75%]"
+    if value < 1.0:
+        return "(75,100%)"
+    return "100%"
+
+
+def _route_reaction_count(route: Route) -> int:
+    return sum(1 for _ in route.iter_reactions())
+
+
+def _validate_queries(queries_by_source: Mapping[str, Sequence[QueryRoute]]) -> None:
+    for source, queries in queries_by_source.items():
+        for query in queries:
+            if _route_reaction_count(query.route):
+                continue
+            raise InvalidRouteEmbeddingQueryError(
+                "route embedding audit queries must contain at least one reaction",
+                context={
+                    "query_source": source,
+                    "query_id": query.id,
+                    "query_target_smiles": str(query.route.target.smiles),
+                    "query_target_inchikey": str(query.route.target.inchikey),
+                },
+            )
+
+
+def _path_depth(path: str) -> int:
+    return RoutePath.parse(path).depth()
+
+
+def _mean(values: Sequence[float | int]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _fraction_stats(values: Sequence[float]) -> tuple[float, float, float]:
+    return (_mean(values), _median(values), _p90(values))
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    midpoint = len(sorted_values) // 2
+    if len(sorted_values) % 2:
+        return sorted_values[midpoint]
+    return (sorted_values[midpoint - 1] + sorted_values[midpoint]) / 2
+
+
+def _p90(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sorted(values)[ceil(0.9 * len(values)) - 1]
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -32,6 +32,7 @@ def render_route_embedding_audit_markdown(audit: RouteEmbeddingAudit) -> str:
     for query_set in audit.query_sets:
         lines.extend(["", f"## {query_set.source}", ""])
         lines.extend(["### overlap summary", "", _overlap_summary(query_set)])
+        lines.extend(["", _prefix_depth_summary(query_set)])
         if query_set.internal_subroute_embeddings is not None:
             lines.extend(["", _internal_subroute_summary(query_set, query_set.internal_subroute_embeddings)])
         lines.extend(["", _best_match_coverage(query_set.coverage)])
@@ -110,6 +111,30 @@ def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrou
         f"there are {_format_integer(summary.embedding_occurrences)} total partial matching occurrences "
         f"({matches_per_embedded_subroute:.2f} "
         "matches per embedded internal subroute)."
+    )
+
+
+def _prefix_depth_summary(query_set: QuerySetAudit) -> str:
+    return "\n".join(
+        [
+            "### root-prefix overlap",
+            "",
+            "query route prefixes are compared to training route prefixes with `route.signature(depth=k)`.",
+            "",
+            markdown_table(
+                ["prefix depth", "query routes with depth", "found at training root", "found anywhere in training"],
+                [
+                    (
+                        row.depth,
+                        _format_integer(row.query_routes),
+                        _format_count_rate(row.root_prefix_signature_overlap, row.query_routes),
+                        _format_count_rate(row.subtree_prefix_signature_overlap, row.query_routes),
+                    )
+                    for row in query_set.prefix_depths
+                ],
+                align=["right", "right", "right", "right"],
+            ),
+        ]
     )
 
 

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -95,6 +95,11 @@ def _overlap_summary(query_set: QuerySetAudit) -> str:
 
 
 def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrouteEmbeddingSummary) -> str:
+    matches_per_embedded_subroute = (
+        summary.embedding_occurrences / summary.embedded_internal_subroutes
+        if summary.embedded_internal_subroutes
+        else 0.0
+    )
     return (
         f"{_format_count_rate(summary.query_routes_with_embedding, query_set.query_routes)} "
         f"query routes have at least one embedded internal subroute of {summary.min_reactions}+ reactions. "
@@ -103,7 +108,7 @@ def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrou
         f"{_format_count_rate(summary.embedded_internal_subroutes, summary.checked_internal_subroutes)} "
         "of those internal subroutes are embedded. "
         f"there are {_format_integer(summary.embedding_occurrences)} total partial matching occurrences "
-        f"({_ratio(summary.embedding_occurrences, summary.embedded_internal_subroutes):.2f} "
+        f"({matches_per_embedded_subroute:.2f} "
         "matches per embedded internal subroute)."
     )
 
@@ -194,7 +199,8 @@ def _coverage_table(
 
 
 def _format_count_rate(count: int, denominator: int) -> str:
-    return f"{_format_integer(count)} / {_format_integer(denominator)} ({_format_percent(_ratio(count, denominator))})"
+    rate = count / denominator if denominator else 0.0
+    return f"{_format_integer(count)} / {_format_integer(denominator)} ({_format_percent(rate)})"
 
 
 def _format_internal_query_count(query_set: QuerySetAudit) -> str:
@@ -235,7 +241,3 @@ def _format_root_distance_sentence(counts: Sequence[tuple[int, int]]) -> str:
     if not pieces:
         return "no embeddings are below the target"
     return "; ".join(pieces)
-
-
-def _ratio(numerator: int, denominator: int) -> float:
-    return numerator / denominator if denominator else 0.0

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from retrocast.curation.training.embedding_audit import (
+    CoverageSummary,
+    InternalSubrouteEmbeddingSummary,
+    QuerySetAudit,
+    RouteEmbeddingAudit,
+)
+from retrocast.markdown import MarkdownAlign, MarkdownRow, markdown_table
+
+
+def render_route_embedding_audit_markdown(audit: RouteEmbeddingAudit) -> str:
+    lines = [
+        f"# route embedding audit: {audit.release_name}",
+        "",
+        f"- match level: `{audit.match_level}`",
+        f"- allow leaf extension: `{str(audit.allow_leaf_extension).lower()}`",
+        f"- partial minimum reactions: {_format_partial_min_reactions(audit.partial_min_reactions)}",
+        f"- training routes: {_format_integer(audit.training_routes)}",
+        f"- training route signatures: {_format_integer(audit.training_route_signatures)}",
+        f"- training reaction signatures: {_format_integer(audit.training_reaction_signatures)}",
+        "",
+        "terms: a query route is the route being searched for. "
+        "a container route is a training route where an embedding is found.",
+        "",
+        _summary_table(audit.query_sets),
+    ]
+
+    for query_set in audit.query_sets:
+        lines.extend(["", f"## {query_set.source}", ""])
+        lines.extend(["### overlap summary", "", _overlap_summary(query_set)])
+        if query_set.internal_subroute_embeddings is not None:
+            lines.extend(["", _internal_subroute_summary(query_set, query_set.internal_subroute_embeddings)])
+        lines.extend(["", _best_match_coverage(query_set.coverage)])
+    return "\n".join(lines) + "\n"
+
+
+def _summary_table(query_sets: Sequence[QuerySetAudit]) -> str:
+    align: list[MarkdownAlign] = ["left"]
+    for _ in query_sets:
+        align.append("right")
+    rows: list[MarkdownRow] = [
+        ("query routes", *(_format_integer(query_set.query_routes) for query_set in query_sets)),
+        (
+            "reaction signatures in training",
+            *(
+                _format_count_rate(query_set.reaction_signature_overlap, query_set.query_reaction_signatures)
+                for query_set in query_sets
+            ),
+        ),
+        (
+            "exact route signatures",
+            *(
+                _format_count_rate(query_set.exact_route_signature_overlap, query_set.query_routes)
+                for query_set in query_sets
+            ),
+        ),
+        (
+            "full route embeddings",
+            *(
+                _format_count_rate(query_set.full_embeddings.query_routes_with_embedding, query_set.query_routes)
+                for query_set in query_sets
+            ),
+        ),
+        (
+            "routes with internal subroute embedding",
+            *(_format_internal_query_count(query_set) for query_set in query_sets),
+        ),
+    ]
+    return markdown_table(["metric", *(query_set.source for query_set in query_sets)], rows, align=align)
+
+
+def _overlap_summary(query_set: QuerySetAudit) -> str:
+    full = query_set.full_embeddings
+    lines = [
+        f"{_format_count_rate(query_set.reaction_signature_overlap, query_set.query_reaction_signatures)} "
+        "reaction signatures are present in training; "
+        f"{_format_count_rate(query_set.exact_route_signature_overlap, query_set.query_routes)} "
+        "query routes have exact route-signature matches.",
+        "",
+    ]
+    if full.query_routes_with_embedding == 0:
+        lines.append("no query routes are fully embedded in training.")
+        return "\n".join(lines)
+
+    distance_counts = _root_distance_count_map(full.root_distance_counts)
+    lines.append(
+        f"{_format_count_rate(full.query_routes_with_embedding, query_set.query_routes)} "
+        "query routes are fully embedded somewhere inside training routes. "
+        f"these produce {_format_integer(full.embedding_occurrences)} total matching occurrences. "
+        f"{_format_plural(full.query_routes_with_root_shifted_embedding, 'query route has', 'query routes have')} "
+        "a root-shifted full embedding; "
+        f"{_format_plural(full.query_routes_with_leaf_extended_embedding, 'query route has', 'query routes have')} "
+        "a leaf-extended full embedding. "
+        f"{_format_plural(distance_counts.get(0, 0), 'occurrence shares', 'occurrences share')} "
+        "the training target (distance 0 from the root); "
+        f"{_format_root_distance_sentence(full.root_distance_counts)}."
+    )
+    return "\n".join(lines)
+
+
+def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrouteEmbeddingSummary) -> str:
+    return (
+        f"{_format_count_rate(summary.query_routes_with_embedding, query_set.query_routes)} "
+        f"query routes have at least one embedded internal subroute of {summary.min_reactions}+ reactions. "
+        f"there are {_format_integer(summary.checked_internal_subroutes)} non-root internal subroutes "
+        f"with at least {summary.min_reactions} reactions. "
+        f"{_format_count_rate(summary.embedded_internal_subroutes, summary.checked_internal_subroutes)} "
+        "of those internal subroutes are embedded. "
+        f"there are {_format_integer(summary.embedding_occurrences)} total partial matching occurrences "
+        f"({_format_number(_ratio(summary.embedding_occurrences, summary.embedded_internal_subroutes))} "
+        "matches per embedded internal subroute)."
+    )
+
+
+def _best_match_coverage(coverage: CoverageSummary) -> str:
+    lines = [
+        "### best-match coverage",
+        "",
+        "when overlap exists, how large and how specific is the largest overlap? "
+        "each query route is compared to the single container route that embeds the largest part of it.",
+        "",
+        f"basis: {coverage.basis}.",
+        "",
+        "#### matched fraction of query route",
+        "",
+        "matched reactions divided by all reactions in the query route.",
+        "",
+        _coverage_table(
+            all_query_routes=coverage.all_query_routes,
+            embedded_query_routes=coverage.embedded_query_routes,
+            all_values=coverage.all_query_fraction_stats,
+            embedded_values=coverage.embedded_query_fraction_stats,
+        ),
+        "",
+        "#### matched fraction of training route",
+        "",
+        "matched reactions divided by all reactions in the container route.",
+        "",
+        _coverage_table(
+            all_query_routes=coverage.all_query_routes,
+            embedded_query_routes=coverage.embedded_query_routes,
+            all_values=coverage.all_container_fraction_stats,
+            embedded_values=coverage.embedded_container_fraction_stats,
+        ),
+    ]
+    if coverage.embedded_query_routes:
+        lines.extend(
+            [
+                "",
+                f"query routes with any embedding match "
+                f"{_format_number(coverage.embedded_mean_training_routes_per_query)} "
+                "unique training routes and "
+                f"{_format_number(coverage.embedded_mean_occurrences_per_query)} "
+                "total occurrences per query route on average.",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "### largest embedded fraction of query-route reactions",
+            "",
+            "largest embedded match reactions divided by all reactions in the query route.",
+            "",
+            markdown_table(
+                ["largest embedded fraction of query-route reactions", "query routes"],
+                [
+                    (bucket, _format_integer(query_routes))
+                    for bucket, query_routes in coverage.matched_fraction_histogram
+                ],
+                align=["left", "right"],
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _coverage_table(
+    *,
+    all_query_routes: int,
+    embedded_query_routes: int,
+    all_values: tuple[float, float, float],
+    embedded_values: tuple[float, float, float],
+) -> str:
+    return markdown_table(
+        ["population", "mean", "median", "p90"],
+        [
+            (
+                f"all query routes ({_format_integer(all_query_routes)})",
+                *(_format_percent(value) for value in all_values),
+            ),
+            (
+                f"query routes with any embedding ({_format_integer(embedded_query_routes)})",
+                *(_format_percent(value) for value in embedded_values),
+            ),
+        ],
+        align=["left", "right", "right", "right"],
+    )
+
+
+def _format_count_rate(count: int, denominator: int) -> str:
+    return f"{_format_integer(count)} / {_format_integer(denominator)} ({_format_percent(_ratio(count, denominator))})"
+
+
+def _format_internal_query_count(query_set: QuerySetAudit) -> str:
+    if query_set.internal_subroute_embeddings is None:
+        return "not run"
+    return _format_count_rate(
+        query_set.internal_subroute_embeddings.query_routes_with_embedding, query_set.query_routes
+    )
+
+
+def _format_percent(value: float) -> str:
+    return f"{100 * value:.1f}%"
+
+
+def _format_number(value: float) -> str:
+    return f"{value:.2f}"
+
+
+def _format_integer(value: int) -> str:
+    return f"{value:,}".replace(",", " ")
+
+
+def _format_partial_min_reactions(value: int | None) -> str:
+    if value is None:
+        return "not run"
+    return f"{value} reactions"
+
+
+def _format_plural(value: int, singular: str, plural: str) -> str:
+    return f"{_format_integer(value)} {singular if value == 1 else plural}"
+
+
+def _root_distance_count_map(counts: Sequence[tuple[int, int]]) -> dict[int, int]:
+    return dict(counts)
+
+
+def _format_root_distance_sentence(counts: Sequence[tuple[int, int]]) -> str:
+    pieces = [
+        f"{_format_plural(occurrences, 'occurrence is', 'occurrences are')} embedded at distance "
+        f"{distance} (a prefix of {_root_distance_description(distance)})"
+        for distance, occurrences in counts
+        if distance > 0
+    ]
+    if not pieces:
+        return "no embeddings are below the target"
+    return "; ".join(pieces)
+
+
+def _root_distance_description(distance: int) -> str:
+    if distance == 1:
+        return "a root child"
+    if distance == 2:
+        return "a child of a root child"
+    return f"a depth-{distance} subtree"
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -17,7 +17,8 @@ def render_route_embedding_audit_markdown(audit: RouteEmbeddingAudit) -> str:
         "",
         f"- match level: `{audit.match_level}`",
         f"- allow leaf extension: `{str(audit.allow_leaf_extension).lower()}`",
-        f"- partial minimum reactions: {_format_partial_min_reactions(audit.partial_min_reactions)}",
+        "- partial minimum reactions: "
+        f"{f'{audit.partial_min_reactions} reactions' if audit.partial_min_reactions is not None else 'not run'}",
         f"- training routes: {_format_integer(audit.training_routes)}",
         f"- training route signatures: {_format_integer(audit.training_route_signatures)}",
         f"- training reaction signatures: {_format_integer(audit.training_reaction_signatures)}",
@@ -41,33 +42,25 @@ def _summary_table(query_sets: Sequence[QuerySetAudit]) -> str:
     align: list[MarkdownAlign] = ["left"]
     for _ in query_sets:
         align.append("right")
-    rows: list[MarkdownRow] = [
-        ("query routes", *(_format_integer(query_set.query_routes) for query_set in query_sets)),
-        (
+
+    def row(label: str, values: Sequence[object]) -> MarkdownRow:
+        return (label, *values)
+
+    rows = [
+        row("query routes", [_format_integer(q.query_routes) for q in query_sets]),
+        row(
             "reaction signatures in training",
-            *(
-                _format_count_rate(query_set.reaction_signature_overlap, query_set.query_reaction_signatures)
-                for query_set in query_sets
-            ),
+            [_format_count_rate(q.reaction_signature_overlap, q.query_reaction_signatures) for q in query_sets],
         ),
-        (
+        row(
             "exact route signatures",
-            *(
-                _format_count_rate(query_set.exact_route_signature_overlap, query_set.query_routes)
-                for query_set in query_sets
-            ),
+            [_format_count_rate(q.exact_route_signature_overlap, q.query_routes) for q in query_sets],
         ),
-        (
+        row(
             "full route embeddings",
-            *(
-                _format_count_rate(query_set.full_embeddings.query_routes_with_embedding, query_set.query_routes)
-                for query_set in query_sets
-            ),
+            [_format_count_rate(q.full_embeddings.query_routes_with_embedding, q.query_routes) for q in query_sets],
         ),
-        (
-            "routes with internal subroute embedding",
-            *(_format_internal_query_count(query_set) for query_set in query_sets),
-        ),
+        row("routes with internal subroute embedding", [_format_internal_query_count(q) for q in query_sets]),
     ]
     return markdown_table(["metric", *(query_set.source for query_set in query_sets)], rows, align=align)
 
@@ -85,7 +78,7 @@ def _overlap_summary(query_set: QuerySetAudit) -> str:
         lines.append("no query routes are fully embedded in training.")
         return "\n".join(lines)
 
-    distance_counts = _root_distance_count_map(full.root_distance_counts)
+    distance_counts = dict(full.root_distance_counts)
     lines.append(
         f"{_format_count_rate(full.query_routes_with_embedding, query_set.query_routes)} "
         "query routes are fully embedded somewhere inside training routes. "
@@ -110,7 +103,7 @@ def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrou
         f"{_format_count_rate(summary.embedded_internal_subroutes, summary.checked_internal_subroutes)} "
         "of those internal subroutes are embedded. "
         f"there are {_format_integer(summary.embedding_occurrences)} total partial matching occurrences "
-        f"({_format_number(_ratio(summary.embedding_occurrences, summary.embedded_internal_subroutes))} "
+        f"({_ratio(summary.embedding_occurrences, summary.embedded_internal_subroutes):.2f} "
         "matches per embedded internal subroute)."
     )
 
@@ -151,9 +144,9 @@ def _best_match_coverage(coverage: CoverageSummary) -> str:
             [
                 "",
                 f"query routes with any embedding match "
-                f"{_format_number(coverage.embedded_mean_training_routes_per_query)} "
+                f"{coverage.embedded_mean_training_routes_per_query:.2f} "
                 "unique training routes and "
-                f"{_format_number(coverage.embedded_mean_occurrences_per_query)} "
+                f"{coverage.embedded_mean_occurrences_per_query:.2f} "
                 "total occurrences per query route on average.",
             ]
         )
@@ -216,46 +209,32 @@ def _format_percent(value: float) -> str:
     return f"{100 * value:.1f}%"
 
 
-def _format_number(value: float) -> str:
-    return f"{value:.2f}"
-
-
 def _format_integer(value: int) -> str:
     return f"{value:,}".replace(",", " ")
-
-
-def _format_partial_min_reactions(value: int | None) -> str:
-    if value is None:
-        return "not run"
-    return f"{value} reactions"
 
 
 def _format_plural(value: int, singular: str, plural: str) -> str:
     return f"{_format_integer(value)} {singular if value == 1 else plural}"
 
 
-def _root_distance_count_map(counts: Sequence[tuple[int, int]]) -> dict[int, int]:
-    return dict(counts)
-
-
 def _format_root_distance_sentence(counts: Sequence[tuple[int, int]]) -> str:
-    pieces = [
-        f"{_format_plural(occurrences, 'occurrence is', 'occurrences are')} embedded at distance "
-        f"{distance} (a prefix of {_root_distance_description(distance)})"
-        for distance, occurrences in counts
-        if distance > 0
-    ]
+    pieces = []
+    for distance, occurrences in counts:
+        if distance == 0:
+            continue
+        if distance == 1:
+            description = "a root child"
+        elif distance == 2:
+            description = "a child of a root child"
+        else:
+            description = f"a depth-{distance} subtree"
+        pieces.append(
+            f"{_format_plural(occurrences, 'occurrence is', 'occurrences are')} embedded at distance "
+            f"{distance} (a prefix of {description})"
+        )
     if not pieces:
         return "no embeddings are below the target"
     return "; ".join(pieces)
-
-
-def _root_distance_description(distance: int) -> str:
-    if distance == 1:
-        return "a root child"
-    if distance == 2:
-        return "a child of a root child"
-    return f"a depth-{distance} subtree"
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/src/retrocast/markdown.py
+++ b/src/retrocast/markdown.py
@@ -19,14 +19,18 @@ def markdown_table(
         raise ValueError("markdown table alignment must match the header count")
 
     lines = [
-        "| " + " | ".join(str(value) for value in headers) + " |",
+        "| " + " | ".join(_cell(value) for value in headers) + " |",
         "| " + " | ".join(_alignment_marker(value) for value in alignment) + " |",
     ]
     for row in rows:
         if len(row) != column_count:
             raise ValueError("markdown table rows must match the header count")
-        lines.append("| " + " | ".join(str(value) for value in row) + " |")
+        lines.append("| " + " | ".join(_cell(value) for value in row) + " |")
     return "\n".join(lines)
+
+
+def _cell(value: object) -> str:
+    return str(value).replace("\r\n", " ").replace("\n", " ").replace("\r", " ").replace("|", r"\|")
 
 
 def _alignment_marker(value: MarkdownAlign) -> str:

--- a/src/retrocast/markdown.py
+++ b/src/retrocast/markdown.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+MarkdownAlign = Literal["left", "right", "center"]
+MarkdownRow = Sequence[object]
+
+
+def markdown_table(
+    headers: MarkdownRow,
+    rows: Sequence[MarkdownRow],
+    *,
+    align: Sequence[MarkdownAlign] | None = None,
+) -> str:
+    column_count = len(headers)
+    alignment: Sequence[MarkdownAlign] = align if align is not None else ("left",) * column_count
+    if len(alignment) != column_count:
+        raise ValueError("markdown table alignment must match the header count")
+
+    lines = [
+        "| " + " | ".join(str(value) for value in headers) + " |",
+        "| " + " | ".join(_alignment_marker(value) for value in alignment) + " |",
+    ]
+    for row in rows:
+        if len(row) != column_count:
+            raise ValueError("markdown table rows must match the header count")
+        lines.append("| " + " | ".join(str(value) for value in row) + " |")
+    return "\n".join(lines)
+
+
+def _alignment_marker(value: MarkdownAlign) -> str:
+    if value == "right":
+        return "---:"
+    if value == "center":
+        return ":---:"
+    return "---"

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from functools import cache
 from typing import Annotated, Any, Literal
 
 from pydantic import AfterValidator, BaseModel, Field
@@ -69,10 +70,12 @@ class RoutePath:
         return cls(kind=route_kind, indices=indices)
 
     @classmethod
+    @cache
     def target(cls) -> RoutePath:
         return cls(kind="m")
 
     @classmethod
+    @cache
     def root_reaction(cls) -> RoutePath:
         return cls(kind="r")
 

--- a/src/retrocast/paths.py
+++ b/src/retrocast/paths.py
@@ -192,6 +192,9 @@ def paroutes_training_release_file(
     *,
     data_dir: Path = DEFAULT_DATA_DIR,
 ) -> Path:
+    validate_directory_name(release_version, "release_version")
+    validate_directory_name(release_name, "release_name")
+    validate_filename(filename, "filename")
     return data_dir / "releases" / "paroutes-training-sets" / release_version / release_name / filename
 
 

--- a/src/retrocast/paths.py
+++ b/src/retrocast/paths.py
@@ -177,6 +177,24 @@ def get_paths(data_dir: Path) -> dict[str, Path]:
     }
 
 
+def benchmark_definitions_dir(data_dir: Path = DEFAULT_DATA_DIR) -> Path:
+    return data_dir / "1-benchmarks" / "definitions"
+
+
+def paroutes_assets_dir(data_dir: Path = DEFAULT_DATA_DIR) -> Path:
+    return data_dir / "0-assets" / "paroutes"
+
+
+def paroutes_training_release_file(
+    release_version: str,
+    release_name: str,
+    filename: str = "all.jsonl.gz",
+    *,
+    data_dir: Path = DEFAULT_DATA_DIR,
+) -> Path:
+    return data_dir / "releases" / "paroutes-training-sets" / release_version / release_name / filename
+
+
 def check_migration_needed(resolved_dir: Path) -> str | None:
     """
     Check if data exists at legacy location but not at resolved location.

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from retrocast.curation.training import TrainingRouteRecord
-from retrocast.curation.training.embedding_audit import build_route_embedding_audit
+from retrocast.curation.training.embedding_audit import RouteEmbeddingAudit, build_route_embedding_audit
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
 from retrocast.models.route import Molecule, Reaction, Route
 from retrocast.typing import InChIKeyStr, SmilesStr
@@ -12,22 +14,12 @@ KEY_C = "CCCCCCCCCCCCCC-UHFFFAOYSA-N"
 KEY_D = "DDDDDDDDDDDDDD-UHFFFAOYSA-N"
 
 
-def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() -> None:
-    training = route_record("container", route_c_b_a())
-    queries = {
-        "shifted": Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)])),
-        "leaf": Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)])),
-        "absent": Route(target=molecule("d", KEY_D, reactants=[molecule("a", KEY_A)])),
-    }
-
-    audit = build_route_embedding_audit(
-        release_name="route-holdout-n1-n5",
-        training_records=[training],
-        queries_by_source={"bench": queries},
-    )
-
+@pytest.mark.integration
+def test_route_embedding_audit_summarizes_full_matches() -> None:
+    audit = sample_full_match_audit()
     query_set = audit.query_sets[0]
     full = query_set.full_embeddings
+
     assert query_set.query_routes == 3
     assert query_set.reaction_signature_overlap == 2
     assert query_set.exact_route_signature_overlap == 0
@@ -50,7 +42,13 @@ def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() ->
         ("leaf", "rc:m:/", ("rc:m:/0",)),
     ]
 
+
+@pytest.mark.integration
+def test_route_embedding_report_renders_audit_summary() -> None:
+    audit = sample_full_match_audit()
+
     markdown = render_route_embedding_audit_markdown(audit)
+
     assert "# route embedding audit: route-holdout-n1-n5" in markdown
     assert "| full route embeddings | 2 / 3 (66.7%) |" in markdown
     assert "### root-prefix overlap" in markdown
@@ -59,6 +57,7 @@ def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() ->
     assert "1 query route has a leaf-extended full embedding" in markdown
 
 
+@pytest.mark.integration
 def test_route_embedding_audit_can_include_internal_subroutes() -> None:
     training = route_record("container", route_c_b_a())
 
@@ -91,6 +90,21 @@ def test_route_embedding_audit_can_include_internal_subroutes() -> None:
         (1, 1, 1, 1),
         (2, 1, 1, 1),
     ]
+
+
+def sample_full_match_audit() -> RouteEmbeddingAudit:
+    training = route_record("container", route_c_b_a())
+    queries = {
+        "shifted": Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)])),
+        "leaf": Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)])),
+        "absent": Route(target=molecule("d", KEY_D, reactants=[molecule("a", KEY_A)])),
+    }
+
+    return build_route_embedding_audit(
+        release_name="route-holdout-n1-n5",
+        training_records=[training],
+        queries_by_source={"bench": queries},
+    )
 
 
 def route_c_b_a() -> Route:

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -31,6 +31,15 @@ def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() ->
     assert query_set.query_routes == 3
     assert query_set.reaction_signature_overlap == 2
     assert query_set.exact_route_signature_overlap == 0
+    assert [
+        (
+            row.depth,
+            row.query_routes,
+            row.root_prefix_signature_overlap,
+            row.subtree_prefix_signature_overlap,
+        )
+        for row in query_set.prefix_depths
+    ] == [(1, 3, 1, 2)]
     assert full.query_routes_with_embedding == 2
     assert full.embedding_occurrences == 2
     assert full.query_routes_with_root_shifted_embedding == 1
@@ -44,6 +53,8 @@ def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() ->
     markdown = render_route_embedding_audit_markdown(audit)
     assert "# route embedding audit: route-holdout-n1-n5" in markdown
     assert "| full route embeddings | 2 / 3 (66.7%) |" in markdown
+    assert "### root-prefix overlap" in markdown
+    assert "| 1 | 3 | 1 / 3 (33.3%) | 2 / 3 (66.7%) |" in markdown
     assert "1 query route has a root-shifted full embedding" in markdown
     assert "1 query route has a leaf-extended full embedding" in markdown
 
@@ -68,6 +79,18 @@ def test_route_embedding_audit_can_include_internal_subroutes() -> None:
     assert internal.embedding_occurrences == 1
     assert [row.match_kind for row in audit.ledger_rows] == ["full_route", "internal_subroute"]
     assert query_set.coverage.embedded_mean_occurrences_per_query == 2
+    assert [
+        (
+            row.depth,
+            row.query_routes,
+            row.root_prefix_signature_overlap,
+            row.subtree_prefix_signature_overlap,
+        )
+        for row in query_set.prefix_depths
+    ] == [
+        (1, 1, 1, 1),
+        (2, 1, 1, 1),
+    ]
 
 
 def route_c_b_a() -> Route:

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from retrocast.chem import get_inchi_key
+from retrocast.curation.training import TrainingRouteRecord
+from retrocast.curation.training.embedding_audit import (
+    QueryRoute,
+    benchmark_query_routes,
+    build_route_embedding_audit,
+)
+from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
+from retrocast.exceptions import InvalidRouteEmbeddingQueryError
+from retrocast.models.route import Molecule, Reaction, Route
+from retrocast.models.task import Benchmark, Target
+from retrocast.typing import InChIKeyStr, SmilesStr
+
+KEY_A = "AAAAAAAAAAAAAA-UHFFFAOYSA-N"
+KEY_B = "BBBBBBBBBBBBBB-UHFFFAOYSA-N"
+KEY_C = "CCCCCCCCCCCCCC-UHFFFAOYSA-N"
+KEY_D = "DDDDDDDDDDDDDD-UHFFFAOYSA-N"
+
+
+def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() -> None:
+    training = route_record("container", route_c_b_a())
+    queries = [
+        QueryRoute(
+            source="bench", id="shifted", route=Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)]))
+        ),
+        QueryRoute(
+            source="bench", id="leaf", route=Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)]))
+        ),
+        QueryRoute(
+            source="bench", id="absent", route=Route(target=molecule("d", KEY_D, reactants=[molecule("a", KEY_A)]))
+        ),
+    ]
+
+    audit = build_route_embedding_audit(
+        release_name="route-holdout-n1-n5",
+        training_records=[training],
+        queries_by_source={"bench": queries},
+    )
+
+    query_set = audit.query_sets[0]
+    full = query_set.full_embeddings
+    assert query_set.query_routes == 3
+    assert query_set.reaction_signature_overlap == 2
+    assert query_set.exact_route_signature_overlap == 0
+    assert full.query_routes_with_embedding == 2
+    assert full.embedding_occurrences == 2
+    assert full.query_routes_with_root_shifted_embedding == 1
+    assert full.query_routes_with_leaf_extended_embedding == 1
+    assert full.root_distance_counts == ((0, 1), (1, 1))
+    assert [(row.query_id, row.container_path, row.leaf_extension_query_paths) for row in audit.ledger_rows] == [
+        ("shifted", "rc:m:/0", ()),
+        ("leaf", "rc:m:/", ("rc:m:/0",)),
+    ]
+
+    markdown = render_route_embedding_audit_markdown(audit)
+    assert "# route embedding audit: route-holdout-n1-n5" in markdown
+    assert "| full route embeddings | 2 / 3 (66.7%) |" in markdown
+    assert "1 query route has a root-shifted full embedding" in markdown
+    assert "1 query route has a leaf-extended full embedding" in markdown
+
+
+def test_route_embedding_audit_can_include_internal_subroutes() -> None:
+    training = route_record("container", route_c_b_a())
+    query = QueryRoute(source="bench", id="full", route=route_c_b_a())
+
+    audit = build_route_embedding_audit(
+        release_name="route-holdout-n1-n5",
+        training_records=[training],
+        queries_by_source={"bench": [query]},
+        include_partial=True,
+        partial_min_reactions=1,
+    )
+
+    query_set = audit.query_sets[0]
+    internal = query_set.internal_subroute_embeddings
+    assert internal is not None
+    assert internal.checked_internal_subroutes == 1
+    assert internal.embedded_internal_subroutes == 1
+    assert internal.query_routes_with_embedding == 1
+    assert internal.embedding_occurrences == 1
+    assert [row.match_kind for row in audit.ledger_rows] == ["full_route", "internal_subroute"]
+    assert query_set.coverage.embedded_mean_occurrences_per_query == 2
+
+
+def test_route_embedding_audit_rejects_molecule_only_queries() -> None:
+    query = QueryRoute(source="bench", id="molecule", route=Route(target=molecule("a", KEY_A)))
+
+    try:
+        build_route_embedding_audit(
+            release_name="route-holdout-n1-n5",
+            training_records=[route_record("container", route_c_b_a())],
+            queries_by_source={"bench": [query]},
+        )
+    except InvalidRouteEmbeddingQueryError as exc:
+        assert exc.context["query_source"] == "bench"
+        assert exc.context["query_id"] == "molecule"
+    else:
+        raise AssertionError("molecule-only query should fail")
+
+
+def test_benchmark_query_routes_selects_primary_or_all_acceptable_routes() -> None:
+    benchmark = Benchmark(
+        name="bench",
+        targets={
+            "target": Target(
+                id="target",
+                smiles=SmilesStr("C"),
+                inchikey=InChIKeyStr(get_inchi_key("C")),
+                acceptable_routes=[route_c_b_a(), route_c_b_a()],
+            )
+        },
+    )
+
+    primary = benchmark_query_routes(benchmark, source="bench", route_selection="primary")
+    all_routes = benchmark_query_routes(benchmark, source="bench", route_selection="all")
+
+    assert [(query.source, query.id) for query in primary] == [("bench", "target")]
+    assert [(query.source, query.id) for query in all_routes] == [("bench", "target:1"), ("bench", "target:2")]
+
+
+def route_c_b_a() -> Route:
+    return Route(
+        target=molecule(
+            "c",
+            KEY_C,
+            reactants=[molecule("b", KEY_B, reactants=[molecule("a", KEY_A)])],
+        )
+    )
+
+
+def molecule(label: str, key: str, *, reactants: list[Molecule] | None = None) -> Molecule:
+    return Molecule(
+        smiles=SmilesStr(label),
+        inchikey=InChIKeyStr(key),
+        product_of=Reaction(reactants=reactants) if reactants is not None else None,
+    )
+
+
+def route_record(name: str, route: Route) -> TrainingRouteRecord:
+    return TrainingRouteRecord(id=f"route-{name}", split="training", route=route)

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-from retrocast.chem import get_inchi_key
 from retrocast.curation.training import TrainingRouteRecord
-from retrocast.curation.training.embedding_audit import (
-    QueryRoute,
-    benchmark_query_routes,
-    build_route_embedding_audit,
-)
+from retrocast.curation.training.embedding_audit import build_route_embedding_audit
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
-from retrocast.exceptions import InvalidRouteEmbeddingQueryError
 from retrocast.models.route import Molecule, Reaction, Route
-from retrocast.models.task import Benchmark, Target
 from retrocast.typing import InChIKeyStr, SmilesStr
 
 KEY_A = "AAAAAAAAAAAAAA-UHFFFAOYSA-N"
@@ -21,17 +14,11 @@ KEY_D = "DDDDDDDDDDDDDD-UHFFFAOYSA-N"
 
 def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() -> None:
     training = route_record("container", route_c_b_a())
-    queries = [
-        QueryRoute(
-            source="bench", id="shifted", route=Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)]))
-        ),
-        QueryRoute(
-            source="bench", id="leaf", route=Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)]))
-        ),
-        QueryRoute(
-            source="bench", id="absent", route=Route(target=molecule("d", KEY_D, reactants=[molecule("a", KEY_A)]))
-        ),
-    ]
+    queries = {
+        "shifted": Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)])),
+        "leaf": Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)])),
+        "absent": Route(target=molecule("d", KEY_D, reactants=[molecule("a", KEY_A)])),
+    }
 
     audit = build_route_embedding_audit(
         release_name="route-holdout-n1-n5",
@@ -63,12 +50,11 @@ def test_route_embedding_audit_summarizes_full_matches_and_renders_markdown() ->
 
 def test_route_embedding_audit_can_include_internal_subroutes() -> None:
     training = route_record("container", route_c_b_a())
-    query = QueryRoute(source="bench", id="full", route=route_c_b_a())
 
     audit = build_route_embedding_audit(
         release_name="route-holdout-n1-n5",
         training_records=[training],
-        queries_by_source={"bench": [query]},
+        queries_by_source={"bench": {"full": route_c_b_a()}},
         include_partial=True,
         partial_min_reactions=1,
     )
@@ -82,42 +68,6 @@ def test_route_embedding_audit_can_include_internal_subroutes() -> None:
     assert internal.embedding_occurrences == 1
     assert [row.match_kind for row in audit.ledger_rows] == ["full_route", "internal_subroute"]
     assert query_set.coverage.embedded_mean_occurrences_per_query == 2
-
-
-def test_route_embedding_audit_rejects_molecule_only_queries() -> None:
-    query = QueryRoute(source="bench", id="molecule", route=Route(target=molecule("a", KEY_A)))
-
-    try:
-        build_route_embedding_audit(
-            release_name="route-holdout-n1-n5",
-            training_records=[route_record("container", route_c_b_a())],
-            queries_by_source={"bench": [query]},
-        )
-    except InvalidRouteEmbeddingQueryError as exc:
-        assert exc.context["query_source"] == "bench"
-        assert exc.context["query_id"] == "molecule"
-    else:
-        raise AssertionError("molecule-only query should fail")
-
-
-def test_benchmark_query_routes_selects_primary_or_all_acceptable_routes() -> None:
-    benchmark = Benchmark(
-        name="bench",
-        targets={
-            "target": Target(
-                id="target",
-                smiles=SmilesStr("C"),
-                inchikey=InChIKeyStr(get_inchi_key("C")),
-                acceptable_routes=[route_c_b_a(), route_c_b_a()],
-            )
-        },
-    )
-
-    primary = benchmark_query_routes(benchmark, source="bench", route_selection="primary")
-    all_routes = benchmark_query_routes(benchmark, source="bench", route_selection="all")
-
-    assert [(query.source, query.id) for query in primary] == [("bench", "target")]
-    assert [(query.source, query.id) for query in all_routes] == [("bench", "target:1"), ("bench", "target:2")]
 
 
 def route_c_b_a() -> Route:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -5,6 +5,7 @@ import pytest
 from retrocast.markdown import markdown_table
 
 
+@pytest.mark.unit
 def test_markdown_table_formats_alignment_and_cells() -> None:
     assert markdown_table(
         ["name", "count", "rate"],
@@ -19,9 +20,13 @@ def test_markdown_table_formats_alignment_and_cells() -> None:
     )
 
 
-def test_markdown_table_rejects_shape_mismatches() -> None:
+@pytest.mark.unit
+def test_markdown_table_rejects_alignment_shape_mismatch() -> None:
     with pytest.raises(ValueError, match="alignment"):
         markdown_table(["name"], [], align=["left", "right"])
 
+
+@pytest.mark.unit
+def test_markdown_table_rejects_row_shape_mismatch() -> None:
     with pytest.raises(ValueError, match="rows"):
         markdown_table(["name"], [("route", "extra")])

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from retrocast.markdown import markdown_table
+
+
+def test_markdown_table_formats_alignment_and_cells() -> None:
+    assert markdown_table(
+        ["name", "count", "rate"],
+        [("route", 12, "50.0%")],
+        align=["left", "right", "center"],
+    ) == "\n".join(
+        [
+            "| name | count | rate |",
+            "| --- | ---: | :---: |",
+            "| route | 12 | 50.0% |",
+        ]
+    )
+
+
+def test_markdown_table_rejects_shape_mismatches() -> None:
+    with pytest.raises(ValueError, match="alignment"):
+        markdown_table(["name"], [], align=["left", "right"])
+
+    with pytest.raises(ValueError, match="rows"):
+        markdown_table(["name"], [("route", "extra")])

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -21,6 +21,17 @@ def test_markdown_table_formats_alignment_and_cells() -> None:
 
 
 @pytest.mark.unit
+def test_markdown_table_escapes_cell_delimiters_and_line_breaks() -> None:
+    assert markdown_table(["source|name", "route"], [("line\nbreak", "a|b")]) == "\n".join(
+        [
+            r"| source\|name | route |",
+            "| --- | --- |",
+            r"| line break | a\|b |",
+        ]
+    )
+
+
+@pytest.mark.unit
 def test_markdown_table_rejects_alignment_shape_mismatch() -> None:
     with pytest.raises(ValueError, match="alignment"):
         markdown_table(["name"], [], align=["left", "right"])

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -128,6 +128,18 @@ class TestParoutesPaths:
             data_dir=Path("/data"),
         ) == Path("/data/releases/paroutes-training-sets/v1/route-holdout/manifest.json")
 
+    @pytest.mark.parametrize(
+        ("release_version", "release_name", "filename"),
+        [
+            ("../v1", "route-holdout", "manifest.json"),
+            ("v1", "../route-holdout", "manifest.json"),
+            ("v1", "route-holdout", "../manifest.json"),
+        ],
+    )
+    def test_rejects_unsafe_training_release_segments(self, release_version, release_name, filename):
+        with pytest.raises(SecurityError):
+            paroutes_training_release_file(release_version, release_name, filename)
+
 
 @pytest.mark.unit
 class TestCheckMigrationNeeded:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -10,10 +10,13 @@ from retrocast.exceptions import SecurityError
 from retrocast.paths import (
     DEFAULT_DATA_DIR,
     ENV_VAR_NAME,
+    benchmark_definitions_dir,
     check_migration_needed,
     ensure_path_within_root,
     get_data_dir_source,
     get_paths,
+    paroutes_assets_dir,
+    paroutes_training_release_file,
     resolve_cache_dir,
     resolve_data_dir,
     validate_directory_name,
@@ -107,6 +110,23 @@ class TestGetPaths:
         result = get_paths(Path("relative/path"))
 
         assert result["raw"] == Path("relative/path/2-raw")
+
+
+@pytest.mark.unit
+class TestParoutesPaths:
+    def test_returns_benchmark_definitions_dir(self):
+        assert benchmark_definitions_dir(Path("/data")) == Path("/data/1-benchmarks/definitions")
+
+    def test_returns_paroutes_assets_dir(self):
+        assert paroutes_assets_dir(Path("/data")) == Path("/data/0-assets/paroutes")
+
+    def test_returns_training_release_file(self):
+        assert paroutes_training_release_file(
+            "v1",
+            "route-holdout",
+            "manifest.json",
+            data_dir=Path("/data"),
+        ) == Path("/data/releases/paroutes-training-sets/v1/route-holdout/manifest.json")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## why
route holdout releases need a concrete contamination audit beyond exact route-signature overlap. exact signatures only catch identical rooted routes, but the real risk is looser embedding: benchmark or raw holdout routes can appear inside training routes with shifted roots, leaf extension, or shared internal subroutes.

## what changed
added a route-embedding audit that indexes training route signatures, reaction signatures, root prefixes, subtree prefixes, full-route embeddings, and optional internal-subroute embeddings. the audit emits typed ledger rows for exact match provenance and renders a readable markdown report for the paroutes training release.

added the paroutes audit script and checked in the generated `route-embedding-audit.md` for `v2026-05-12/route-holdout-n1-n5`. shared markdown table rendering now backs the new report plus existing release/evaluation markdown tables, and small path helpers centralize the paroutes release/script locations.

## risk
this is mostly read-only audit/reporting code. the operational boundary is the script output: it writes `route-embedding-audit.md` and `route-embedding-ledger.jsonl.gz` under the selected release directory. the library path does not mutate release artifacts by itself.

the main correctness risk is undercounting or misclassifying embeddings. coverage focuses on the new audit summaries, root-shifted matches, leaf-extended matches, internal-subroute matches, markdown rendering, and path/table helpers.

## verification
- `uv run pytest tests/curation/test_training_embedding_audit.py tests/test_markdown.py tests/test_paths.py -q`
- `uv run pytest -q`
- `uv run ruff check`
- `uv run ty check .`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782910991&installation_id=125602297&pr_number=119&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F119&signature=ea54e1df81314baf46ff7bece74374c58a26f361f2e6a9e87b57ef74169e59f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route embedding audit reports and a CLI tool to generate them, including detailed coverage, overlap, and ledger outputs.
  * Added path helpers for Paroutes assets and training-release artifacts.
  * Added a renderer to produce human-readable Markdown audit reports.
  * Minor performance improvement via memoization in route path accessors.

* **Refactor**
  * Unified Markdown table generation using a shared utility across report code.

* **Tests**
  * Added tests for embedding audits, Markdown table behavior, and path helpers.

* **Documentation**
  * Added a route embedding audit Markdown report for a Paroutes training release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a route-embedding audit layer for paroutes training releases. It detects when benchmark or holdout query routes are embedded inside training routes (via root-shifted, leaf-extended, or internal-subroute matches), emits a typed JSONL ledger, and renders a readable markdown report. It also refactors existing markdown table generation in `audit.py` and `report.py` to use the new shared `markdown_table` utility.

- **`embedding_audit.py`**: builds a `TrainingEmbeddingIndex` and runs `full_route` and `internal_subroute` matching per query set, accumulating typed `RouteEmbeddingLedgerRow` records and coverage statistics.
- **`embedding_report.py`**: renders the audit as markdown with prefix-depth tables, best-match coverage histograms, and per-query-set overlap summaries.
- **`markdown.py`** / **`paths.py`**: new shared utilities for table rendering (with `|` escaping) and centralized paroutes release path construction with `validate_filename` guards.

<h3>Confidence Score: 5/5</h3>

This is read-only audit and reporting code; it writes two output files and does not touch any release artifacts.

All changed paths are audit/reporting code with no mutations to training data. The embedding index, coverage statistics, and markdown rendering logic are correct. Path helpers apply proper filename validation. The refactored markdown table calls in `audit.py` and `report.py` are equivalent to the originals. Test coverage is solid across the new audit summaries, root-shifted/leaf-extended matches, internal-subroute detection, and the markdown utility.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/curation/training/embedding_audit.py | Core audit logic: index building, full-route and internal-subroute embedding detection, coverage statistics, and histogram computation. Logic is correct and well-structured with proper edge-case handling (empty sequences, zero denominators). |
| src/retrocast/curation/training/embedding_report.py | Markdown rendering for the embedding audit. Clean delegation to `markdown_table`; all format helpers correctly handle edge cases (zero denominators, singular/plural). |
| scripts/paroutes/training-set-prep/05-audit-route-embeddings.py | Audit script that loads training records and query routes, runs the audit, and writes output files. Minor: `ledger_rows` is reused as the int count returned by `save_jsonl_gz`, shadowing the original collection reference, but logging is correct. |
| src/retrocast/markdown.py | New shared `markdown_table` utility with pipe escaping, line-break collapsing, and alignment validation. Well-tested. |
| src/retrocast/paths.py | New `paroutes_training_release_file` path helper with `validate_filename` / `validate_directory_name` guards on all three path segments. Security controls are correct and tested. |
| src/retrocast/curation/training/audit.py | Refactored existing markdown table rendering to use the new shared `markdown_table` utility. The convergence table alignment is now explicit and correct. |
| src/retrocast/models/route.py | Added `@cache` to `RoutePath.target()` and `RoutePath.root_reaction()` classmethods. Correct and beneficial for the hot paths in audit loops. |
| tests/curation/test_training_embedding_audit.py | Good coverage of root-shifted, leaf-extended, and internal-subroute embedding scenarios. Assertions cover both the audit summary fields and the ledger rows. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[training records] --> B[build_training_embedding_index]
    B --> C{by_reaction_root\nroot_prefix_sigs\nsubtree_prefix_sigs}
    D[queries_by_source] --> E[_audit_query_set per source]
    C --> E
    E --> F[_full_route_ledger_rows]
    E --> G{include_partial?}
    G -- yes --> H[_internal_subroute_audit]
    G -- no --> I[internal_summary = None]
    F --> J[RouteEmbeddingLedgerRow tuples]
    H --> J
    J --> K[_summarize_full_embeddings]
    J --> L[_summarize_coverage]
    K --> M[QuerySetAudit]
    L --> M
    M --> N[RouteEmbeddingAudit]
    N --> O[render_route_embedding_audit_markdown]
    N --> P[save_jsonl_gz → ledger.jsonl.gz]
    O --> Q[route-embedding-audit.md]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/paroutes/training-set-prep/05-audit-route-embeddings.py:71-74
The name `ledger_rows` is reused to hold the integer count returned by `save_jsonl_gz`, silently shadowing the original `audit.ledger_rows` reference. The log call is correct (it prints the count), but the variable name implies a collection. Using a distinct name avoids any future confusion if someone tries to iterate `ledger_rows` after this assignment.

```suggestion
    ledger_row_count = save_jsonl_gz(audit.ledger_rows, LEDGER_OUTPUT_PATH)
    logger.info(
        "wrote route embedding audit to %s and %s (%s ledger rows)", OUTPUT_PATH, LEDGER_OUTPUT_PATH, ledger_row_count
    )
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address route embedding audit revie..."](https://github.com/ischemist/project-procrustes/commit/483161c4d45fe9e03ab3c11c90843809f8b0c168) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34908310)</sub>

<!-- /greptile_comment -->