### PR TITLE
fix: report tier validity in analyze

### DIFF
--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -10,6 +10,8 @@ from retrocast.models.analysis import AnalysisReport, MetricSummary
 
 _SOLV_RATE = re.compile(r"^solv_(\d+)\[(.+)]_rate$")
 _MRR_SOLV = re.compile(r"^mrr_solv_(\d+)\[(.+)]$")
+_TIER_VALIDITY = re.compile(r"^tier_(\d+)_validity_rate$")
+_MRR_TIER = re.compile(r"^mrr_tier_(\d+)$")
 _TOP_K = re.compile(r"^acceptable_reconstruction_top_(\d+)\[(.+)]$")
 
 
@@ -22,25 +24,12 @@ def create_analysis_table(report: AnalysisReport, *, title: str = "Analysis Resu
     table.add_column("N", justify="right")
     table.add_column("Reliability", justify="center")
 
-    solv_metrics = _matching_metrics(report.metrics, _SOLV_RATE)
-    if solv_metrics:
-        table.add_row("[dim]Solv-N hierarchy[/]", "", "", "", "")
-        for name, metric, match in solv_metrics:
+    hierarchy_metrics = _hierarchy_metrics(report.metrics)
+    if hierarchy_metrics:
+        table.add_row("[dim]Solv-N evaluation[/]", "", "", "", "")
+        for name, metric, match in hierarchy_metrics:
             table.add_row(
-                _solv_label(match),
-                _format_value(name, metric),
-                _format_ci(name, metric),
-                str(metric.count),
-                _format_reliability(metric),
-            )
-
-    mrr_metrics = _matching_metrics(report.metrics, _MRR_SOLV)
-    if mrr_metrics:
-        table.add_section()
-        table.add_row("[dim]Rank within Solv-N hierarchy[/]", "", "", "", "")
-        for name, metric, match in mrr_metrics:
-            table.add_row(
-                _mrr_label(match),
+                escape(_display_metric_name(name, match)),
                 _format_value(name, metric),
                 _format_ci(name, metric),
                 str(metric.count),
@@ -145,10 +134,28 @@ def _format_reliability(metric: MetricSummary, *, rich: bool = True) -> str:
 
 
 def _ordered_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, MetricSummary, re.Match[str]]]:
-    ordered = []
-    for pattern in (_SOLV_RATE, _MRR_SOLV, _TOP_K):
+    ordered = _hierarchy_metrics(metrics)
+    for pattern in (_TOP_K,):
         ordered.extend(_matching_metrics(metrics, pattern))
     return ordered
+
+
+def _hierarchy_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, MetricSummary, re.Match[str]]]:
+    matches: list[tuple[str, MetricSummary, re.Match[str]]] = []
+    for pattern in (_TIER_VALIDITY, _SOLV_RATE, _MRR_TIER, _MRR_SOLV):
+        matches.extend(_matching_metrics(metrics, pattern))
+    return sorted(matches, key=_hierarchy_sort_key)
+
+
+def _hierarchy_sort_key(item: tuple[str, MetricSummary, re.Match[str]]) -> tuple[int, int, str]:
+    name, _, match = item
+    if _TIER_VALIDITY.match(name):
+        return (int(match.group(1)), 0, "")
+    if _SOLV_RATE.match(name):
+        return (int(match.group(1)), 1, match.group(2))
+    if _MRR_TIER.match(name):
+        return (int(match.group(1)), 2, "")
+    return (int(match.group(1)), 3, match.group(2))
 
 
 def _matching_metrics(
@@ -163,19 +170,15 @@ def _matching_metrics(
 
 
 def _display_metric_name(name: str, match: re.Match[str]) -> str:
+    if _TIER_VALIDITY.match(name):
+        return _plain_tier_validity_label(match)
     if _SOLV_RATE.match(name):
         return _plain_solv_label(match)
+    if _MRR_TIER.match(name):
+        return _plain_mrr_tier_label(match)
     if _MRR_SOLV.match(name):
         return _plain_mrr_label(match)
     return _plain_top_k_label(match)
-
-
-def _solv_label(match: re.Match[str]) -> str:
-    return escape(_plain_solv_label(match))
-
-
-def _mrr_label(match: re.Match[str]) -> str:
-    return escape(_plain_mrr_label(match))
 
 
 def _top_k_label(match: re.Match[str]) -> str:
@@ -184,6 +187,14 @@ def _top_k_label(match: re.Match[str]) -> str:
 
 def _plain_solv_label(match: re.Match[str]) -> str:
     return f"Solv-{match.group(1)}[{match.group(2)}]"
+
+
+def _plain_tier_validity_label(match: re.Match[str]) -> str:
+    return f"Tier-{match.group(1)} Validity"
+
+
+def _plain_mrr_tier_label(match: re.Match[str]) -> str:
+    return f"MRR Tier-{match.group(1)}"
 
 
 def _plain_mrr_label(match: re.Match[str]) -> str:

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -149,13 +149,16 @@ def _hierarchy_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, Met
 
 def _hierarchy_sort_key(item: tuple[str, MetricSummary, re.Match[str]]) -> tuple[int, int, str]:
     name, _, match = item
-    if _TIER_VALIDITY.match(name):
+    pattern = match.re
+    if pattern is _TIER_VALIDITY:
         return (int(match.group(1)), 0, "")
-    if _SOLV_RATE.match(name):
+    if pattern is _SOLV_RATE:
         return (int(match.group(1)), 1, match.group(2))
-    if _MRR_TIER.match(name):
+    if pattern is _MRR_TIER:
         return (int(match.group(1)), 2, "")
-    return (int(match.group(1)), 3, match.group(2))
+    if pattern is _MRR_SOLV:
+        return (int(match.group(1)), 3, match.group(2))
+    raise ValueError(f"unexpected hierarchy metric: {name!r}")
 
 
 def _matching_metrics(
@@ -170,15 +173,18 @@ def _matching_metrics(
 
 
 def _display_metric_name(name: str, match: re.Match[str]) -> str:
-    if _TIER_VALIDITY.match(name):
+    pattern = match.re
+    if pattern is _TIER_VALIDITY:
         return _plain_tier_validity_label(match)
-    if _SOLV_RATE.match(name):
+    if pattern is _SOLV_RATE:
         return _plain_solv_label(match)
-    if _MRR_TIER.match(name):
+    if pattern is _MRR_TIER:
         return _plain_mrr_tier_label(match)
-    if _MRR_SOLV.match(name):
+    if pattern is _MRR_SOLV:
         return _plain_mrr_label(match)
-    return _plain_top_k_label(match)
+    if pattern is _TOP_K:
+        return _plain_top_k_label(match)
+    raise ValueError(f"unexpected report metric: {name!r}")
 
 
 def _top_k_label(match: re.Match[str]) -> str:

--- a/src/retrocast/metrics/analysis.py
+++ b/src/retrocast/metrics/analysis.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import Protocol
 
 from retrocast.metrics.bootstrap import summarize_values
 from retrocast.models.analysis import MetricSummary
-from retrocast.models.evaluation import TargetResult, Tier
+from retrocast.models.evaluation import ScoredCandidate, TargetResult, Tier
+
+CandidatePredicate = Callable[[ScoredCandidate, Tier], bool]
+
+
+class CandidateMetric(Protocol):
+    def __call__(
+        self,
+        targets: Sequence[TargetResult],
+        tier: Tier,
+        predicate: CandidatePredicate,
+        *,
+        n_boot: int,
+        seed: int,
+    ) -> MetricSummary: ...
 
 
 def summarize_targets(
@@ -19,8 +34,14 @@ def summarize_targets(
     metrics: dict[str, MetricSummary] = {}
     for tier in tiers:
         metric_suffix = str(int(tier))
-        metrics[f"solv_{metric_suffix}[{metric_label}]_rate"] = _solv_rate(targets, tier, n_boot=n_boot, seed=seed)
-        metrics[f"mrr_solv_{metric_suffix}[{metric_label}]"] = _mrr_solv(targets, tier, n_boot=n_boot, seed=seed)
+        metric_specs: tuple[tuple[str, CandidateMetric, CandidatePredicate], ...] = (
+            (f"tier_{metric_suffix}_validity_rate", _candidate_rate, ScoredCandidate.satisfies_validity),
+            (f"mrr_tier_{metric_suffix}", _candidate_mrr, ScoredCandidate.satisfies_validity),
+            (f"solv_{metric_suffix}[{metric_label}]_rate", _candidate_rate, ScoredCandidate.satisfies_solv),
+            (f"mrr_solv_{metric_suffix}[{metric_label}]", _candidate_mrr, ScoredCandidate.satisfies_solv),
+        )
+        for name, summarize, predicate in metric_specs:
+            metrics[name] = summarize(targets, tier, predicate, n_boot=n_boot, seed=seed)
 
     reconstruction_targets = [target for target in targets if target.target.acceptable_routes]
     if reconstruction_targets:
@@ -34,20 +55,34 @@ def summarize_targets(
     return metrics
 
 
-def _solv_rate(targets: Sequence[TargetResult], tier: Tier, *, n_boot: int, seed: int) -> MetricSummary:
+def _candidate_rate(
+    targets: Sequence[TargetResult],
+    tier: Tier,
+    predicate: CandidatePredicate,
+    *,
+    n_boot: int,
+    seed: int,
+) -> MetricSummary:
     values = []
     for target in targets:
-        values.append(1.0 if any(candidate.satisfies_solv(tier) for candidate in target.candidates) else 0.0)
+        values.append(1.0 if any(predicate(candidate, tier) for candidate in target.candidates) else 0.0)
     return summarize_values(values, n_boot=n_boot, seed=seed)
 
 
-def _mrr_solv(targets: Sequence[TargetResult], tier: Tier, *, n_boot: int, seed: int) -> MetricSummary:
+def _candidate_mrr(
+    targets: Sequence[TargetResult],
+    tier: Tier,
+    predicate: CandidatePredicate,
+    *,
+    n_boot: int,
+    seed: int,
+) -> MetricSummary:
     values = []
     for target in targets:
         candidates = sorted(target.candidates, key=lambda candidate: candidate.rank)
         reciprocal_rank = 0.0
         for candidate in candidates:
-            if candidate.satisfies_solv(tier):
+            if predicate(candidate, tier):
                 reciprocal_rank = 1.0 / candidate.rank
                 break
         values.append(reciprocal_rank)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -9,7 +9,9 @@ from retrocast.models.analysis import AnalysisReport, MetricSummary, Reliability
 def report_with_all_metric_groups() -> AnalysisReport:
     return AnalysisReport(
         metrics={
+            "tier_0_validity_rate": MetricSummary(value=0.75, count=4, ci_low=0.5, ci_high=1.0),
             "solv_0[test-stock]_rate": MetricSummary(value=1.0, count=4, ci_low=0.8, ci_high=1.0),
+            "mrr_tier_0": MetricSummary(value=0.25, count=4, ci_low=0.0, ci_high=0.5),
             "mrr_solv_0[test-stock]": MetricSummary(value=0.5, count=4, ci_low=0.25, ci_high=0.75),
             "acceptable_reconstruction_top_3[test-stock]": MetricSummary(
                 value=0.75,
@@ -29,7 +31,9 @@ def test_generate_markdown_report_includes_strata_and_metric_groups() -> None:
     markdown = generate_markdown_report(report_with_all_metric_groups(), title="Small Run")
 
     assert "# Small Run" in markdown
+    assert "Tier-0 Validity" in markdown
     assert "Solv-0[test-stock]" in markdown
+    assert "MRR Tier-0" in markdown
     assert "MRR Solv-0[test-stock]" in markdown
     assert "Top-3" in markdown
     assert "## By Stratum" in markdown
@@ -43,6 +47,8 @@ def test_create_analysis_table_renders_top_k_without_ci() -> None:
     console.print(create_analysis_table(report_with_all_metric_groups()))
 
     output = console.export_text()
+    assert "Solv-N evaluation" in output
+    assert "Tier-0 Validity" in output
     assert "Benchmark route reconstruction" in output
     assert "Top-3" in output
     assert "75.0%" in output

--- a/tests/workflow/test_analyze.py
+++ b/tests/workflow/test_analyze.py
@@ -125,6 +125,21 @@ def test_solv_rate_denominator_includes_failed_candidates() -> None:
     assert metric.ci_high is not None
 
 
+def test_tier_validity_is_reported_separately_from_solv() -> None:
+    report = analyze(
+        evaluation(
+            {
+                "ethanol": result(target("ethanol"), [unsolved_candidate(1)]),
+            }
+        )
+    )
+
+    assert report.metrics["tier_0_validity_rate"].value == 1.0
+    assert report.metrics["mrr_tier_0"].value == 1.0
+    assert report.metrics["solv_0[task]_rate"].value == 0.0
+    assert report.metrics["mrr_solv_0[task]"].value == 0.0
+
+
 def test_mrr_uses_first_solv_satisfying_candidate() -> None:
     report = analyze(
         evaluation(


### PR DESCRIPTION
## why
the v2 analyze workflow kept reporting solv-n and mrr@solv-n, but it stopped surfacing tier-n validity directly. that hid the distinction from the solv-n rationale: solv-i is tier-i validity plus task satisfaction, so a route can be valid without solving the configured task.

## what changed
analysis now emits tier-n validity rate and mrr tier-n alongside the existing solv-n metrics for each evaluated tier. the cli and markdown report ordering put tier validity, solv-n, mrr tier, and mrr solv-n together under solv-n evaluation so the relationship stays visible.

## risk
low operational risk: this only adds derived analysis metrics and report rows. it does not change scoring, persisted evaluation inputs, route validity calculation, caches, or external calls. the main compatibility boundary is metric/report shape, where the old solv-n keys remain unchanged and the new tier keys are additive.

## verification
- reviewed branch against .practices/docs/common/pr-review.md: no red or yellow findings remained
- uv run pytest tests/workflow/test_analyze.py tests/cli/test_report.py tests/test_api.py tests/cli/test_cli.py
- uv run pytest
- uv run ruff check
- uv run ruff format --check
- uv run ty check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782921764&installation_id=125602297&pr_number=120&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F120&signature=6eb56ede2df79aae3bd8cf75753d6716745474e7b07bd2c5151a494955316d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores tier-N validity rate and MRR tier-N as explicit analysis metrics alongside the existing solv-N metrics, surfacing the distinction that a route can be tier-valid without satisfying the configured task. The change is additive: no existing metric keys, scoring logic, or persisted data are altered.

- **`analysis.py`**: Generalises `_solv_rate`/`_mrr_solv` into predicate-driven `_candidate_rate`/`_candidate_mrr`, then emits four metrics per tier (tier validity rate, MRR tier, solv rate, MRR solv) using `ScoredCandidate.satisfies_validity` and `ScoredCandidate.satisfies_solv` as the predicates.
- **`report.py`**: Introduces `_TIER_VALIDITY` and `_MRR_TIER` regex patterns, unifies all four metric types under a `_hierarchy_metrics` + `_hierarchy_sort_key` pair that groups and orders them by (tier, metric-type, label), and updates `_display_metric_name` to handle all patterns exhaustively with a `raise` fallback.
- **Tests**: New `test_tier_validity_is_reported_separately_from_solv` verifies the divergence scenario, and report tests confirm the new labels appear in both the Rich CLI table and markdown output.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive metric and display changes with no modifications to scoring, route validity logic, or persisted data.

The change only adds new derived metric keys and corresponding display labels; all existing solv-N keys and their computation are unchanged. The refactored predicate-driven helpers are well-tested, the new _hierarchy_sort_key is exhaustive with an explicit raise, and _display_metric_name now covers all five patterns instead of silently falling through.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/metrics/analysis.py | Adds tier-N validity rate and MRR tier-N metrics alongside existing solv-N metrics by generalizing _solv_rate/_mrr_solv into predicate-driven _candidate_rate/_candidate_mrr; clean refactor with CandidateMetric Protocol. |
| src/retrocast/cli/report.py | Consolidates solv-N and the new tier-N metrics under a single "Solv-N evaluation" section via _hierarchy_metrics/_hierarchy_sort_key; _display_metric_name and _ordered_metrics updated to handle all four pattern types exhaustively. |
| tests/workflow/test_analyze.py | Adds test_tier_validity_is_reported_separately_from_solv confirming that an unsolved-but-valid candidate produces tier_0_validity_rate=1.0 and mrr_tier_0=1.0 while solv metrics remain 0.0. |
| tests/cli/test_report.py | Extends fixture and assertions to cover the new tier_0_validity_rate and mrr_tier_0 entries in both the Rich table and markdown report output. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[summarize_targets] -->|per tier| B{metric_specs}
    B --> C["tier_N_validity_rate\n(_candidate_rate + satisfies_validity)"]
    B --> D["mrr_tier_N\n(_candidate_mrr + satisfies_validity)"]
    B --> E["solv_N[label]_rate\n(_candidate_rate + satisfies_solv)"]
    B --> F["mrr_solv_N[label]\n(_candidate_mrr + satisfies_solv)"]
    C & D & E & F --> G[metrics dict]
    G --> H[_hierarchy_metrics]
    H -->|collect via _matching_metrics| I[_TIER_VALIDITY / _SOLV_RATE / _MRR_TIER / _MRR_SOLV]
    I -->|sort by _hierarchy_sort_key| J["(tier, sub_rank, label)"]
    J --> K[CLI table: Solv-N evaluation section]
    J --> L[Markdown report table]
```

<sub>Reviews (2): Last reviewed commit: ["refactor: make report metric dispatch ex..."](https://github.com/ischemist/project-procrustes/commit/c78073a7fe1be25575f5c2693dfc05e1eb44172f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34940814)</sub>

<!-- /greptile_comment -->