### PR TITLE
feat: add analyze reconstruction diagnostics

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -324,13 +324,14 @@ retrocast analyze \
 
 Useful options:
 
-| Option              | Meaning                                                        |
-| ------------------- | -------------------------------------------------------------- |
-| `--stock`           | Analyze one stock directory under `4-scored`                   |
-| `--top-k 1 5 10 50` | K values for acceptable-route reconstruction                   |
-| `--n-boot 10000`    | Number of bootstrap resamples                                  |
-| `--all-models`      | Analyze all scored models for the selected dataset(s)          |
-| `--all-datasets`    | Analyze the selected model(s) across all benchmark definitions |
+| Option                   | Meaning                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| `--stock`                | Analyze one stock directory under `4-scored`                   |
+| `--top-k 1 5 10 50`      | K values for acceptable-route reconstruction                   |
+| `--prefix-depth 1 2 3`   | Depths for acceptable-route prefix reconstruction diagnostics  |
+| `--n-boot 10000`         | Number of bootstrap resamples                                  |
+| `--all-models`           | Analyze all scored models for the selected dataset(s)          |
+| `--all-datasets`         | Analyze the selected model(s) across all benchmark definitions |
 
 Outputs:
 

--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -615,8 +615,9 @@ analyze(
     evaluation: Evaluation,
     *,
     ks: Sequence[int] = (1, 5, 10, 50),
+    prefix_depths: Sequence[int] = (1, 2, 3),
     stratify_by: Callable[[TargetResult], str | None] | None = None,
 ) -> AnalysisReport
 ```
 
-Top-K reconstruction metrics are emitted only for targets with acceptable_routes; if no target has acceptable_routes, reconstruction metrics are omitted.
+Top-K reconstruction metrics are emitted only for targets with acceptable_routes; if no target has acceptable_routes, reconstruction metrics are omitted. Reconstruction diagnostics use `Evaluation.acceptable_match_level`, so full-route, root-reaction, and prefix comparisons stay on the same molecular identity basis.

--- a/docs/rationale/solv-n-evaluation.md
+++ b/docs/rationale/solv-n-evaluation.md
@@ -66,3 +66,10 @@ As proposed in the original [RetroCast preprint](https://arxiv.org/abs/2512.0707
 While Top-K accuracy fails to reward construction of potentially valid alternative route (a limitation well discussed in the Syntax of Matter preprint), the acceptable-route is one of the valid `Routes` that any planner (even the future Tier-3 compliant ones) should consider, and so it is reasonable to expect its reconstruction for some value of K. The exact value of K is up to debate (how many unique ways are there to make any random molecule?), and we think `K=10` and `K=50` are worth paying attention to.
 
 Notably, this means that `Top-1` accuracy should not be the headline metric.
+
+`analyze` also reports reconstruction diagnostics that preserve the same task-satisfaction filter and top-k window:
+
+- `acceptable_root_reconstruction_top_k[...]`: fraction of targets where a useful top-k candidate has the same root reaction as any acceptable route.
+- `acceptable_reconstruction_given_root_top_k[...]`: full-route reconstruction rate among targets with a root hit. Its denominator is targets, not candidate routes.
+- `acceptable_prefix_reconstruction_depth_d_top_k[...]`: fraction of targets where a useful top-k candidate matches an acceptable route prefix by `Route.signature(depth=d)`.
+- `distinct_root_reactions_top_k[...]`: mean number of distinct root reaction signatures among useful top-k candidates.

--- a/src/retrocast/cli/main.py
+++ b/src/retrocast/cli/main.py
@@ -37,6 +37,7 @@ from retrocast.io import (
 from retrocast.io.blob import load_json_artifact
 from retrocast.io.data import load_stock_file
 from retrocast.metrics.constraints import TaskConstraintChecker
+from retrocast.models.analysis import AnalysisReport
 from retrocast.models.evaluation import Evaluation
 from retrocast.models.provenance import VerificationReport
 from retrocast.models.route import InChIKeyLevel
@@ -172,6 +173,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_model_dataset_args(analyze_parser)
     analyze_parser.add_argument("--stock", help="Specific stock to analyze")
     analyze_parser.add_argument("--top-k", nargs="+", type=int, default=[1, 3, 5, 10, 20, 50, 100])
+    analyze_parser.add_argument("--prefix-depth", nargs="+", type=int, default=[1, 2, 3])
     analyze_parser.add_argument("--n-boot", type=int, default=10000)
 
     verify_parser = subparsers.add_parser("verify", help="Verify artifact manifests and lineage")
@@ -472,60 +474,90 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
 
 def handle_analyze(args: argparse.Namespace, config: dict[str, Any]) -> None:
     paths = get_paths(Path(config.get("data_dir", DEFAULT_DATA_DIR)))
+    jobs: list[tuple[str, str, str]] = []
     for model_name in _resolve_models(args, paths, stage="analyze"):
         for benchmark_name in _resolve_benchmarks(args, paths):
-            _analyze_one(model_name, benchmark_name, paths, args)
-
-
-def _analyze_one(model_name: str, benchmark_name: str, paths: dict[str, Path], args: argparse.Namespace) -> None:
-    scored_base = paths["scored"] / benchmark_name / model_name
-    if not scored_base.exists():
-        logger.warning("Skipping %s/%s: no scored directory", model_name, benchmark_name)
+            scored_base = paths["scored"] / benchmark_name / model_name
+            if not scored_base.exists():
+                logger.warning("Skipping %s/%s: no scored directory", model_name, benchmark_name)
+                continue
+            stock_names = [args.stock] if args.stock else [path.name for path in scored_base.iterdir() if path.is_dir()]
+            jobs.extend((model_name, benchmark_name, stock_name) for stock_name in stock_names)
+    if not jobs:
         return
-    stock_names = [args.stock] if args.stock else [path.name for path in scored_base.iterdir() if path.is_dir()]
-    for stock_name in stock_names:
-        evaluation_path = scored_base / stock_name / "evaluation.json.gz"
-        if not evaluation_path.exists():
-            logger.warning("Skipping missing evaluation %s", evaluation_path)
-            continue
-        evaluation = load_evaluation(evaluation_path)
-        execution_stats_path = _execution_stats_path(paths, model_name, benchmark_name)
-        execution_stats = _load_execution_stats_if_present(execution_stats_path)
-        if execution_stats is not None:
-            evaluation = _evaluation_with_execution_stats(evaluation, execution_stats)
-        report = analyze(evaluation, ks=args.top_k, n_boot=args.n_boot)
-        output_dir = paths["results"] / benchmark_name / model_name / stock_name
-        analysis_path = output_dir / "analysis.json.gz"
-        markdown_path = output_dir / "report.md"
-        save_analysis_report(report, analysis_path)
-        markdown_path.write_text(
-            generate_markdown_report(
-                report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}"
-            ),
-            encoding="utf-8",
-        )
-        sources = [evaluation_path]
-        if execution_stats is not None:
-            sources.append(execution_stats_path)
-        write_manifest(
-            output_dir / "manifest.json",
-            action="analyze:v2",
-            sources=sources,
-            outputs=[analysis_path, markdown_path],
-            root_dir=paths["raw"].parent.resolve(),
-            parameters={
-                "model": model_name,
-                "benchmark": benchmark_name,
-                "stock": stock_name,
-                "top_k": args.top_k,
-                "n_boot": args.n_boot,
-            },
-            statistics={"n_metrics": len(report.metrics), "n_strata": len(report.by_stratum)},
-        )
+
+    rendered_reports: list[tuple[AnalysisReport, str, Path]] = []
+    with create_cli_progress(console=console, unit="jobs", transient=True) as progress, quiet_info_logs("retrocast"):
+        task_id = progress.add_task("Analyzing evaluations", total=len(jobs))
+        for model_name, benchmark_name, stock_name in jobs:
+            progress.update(task_id, description=f"Analyzing {model_name}/{benchmark_name}/{stock_name}")
+            rendered = _analyze_one(model_name, benchmark_name, stock_name, paths, args)
+            if rendered is not None:
+                rendered_reports.append(rendered)
+            progress.advance(task_id)
+
+    for report, subtitle, output_dir in rendered_reports:
         console.print(
-            create_analysis_table(report, title=f"Analysis Results: {model_name} / {benchmark_name} / {stock_name}")
+            create_analysis_table(
+                report,
+                title="analysis results",
+                subtitle=subtitle,
+            )
         )
         console.print(f"\n[dim]Full report saved to: {output_dir}[/]\n")
+
+
+def _analyze_one(
+    model_name: str,
+    benchmark_name: str,
+    stock_name: str,
+    paths: dict[str, Path],
+    args: argparse.Namespace,
+) -> tuple[AnalysisReport, str, Path] | None:
+    evaluation_path = paths["scored"] / benchmark_name / model_name / stock_name / "evaluation.json.gz"
+    if not evaluation_path.exists():
+        logger.warning("Skipping missing evaluation %s", evaluation_path)
+        return None
+
+    evaluation = load_evaluation(evaluation_path)
+    execution_stats_path = _execution_stats_path(paths, model_name, benchmark_name)
+    execution_stats = _load_execution_stats_if_present(execution_stats_path)
+    if execution_stats is not None:
+        evaluation = _evaluation_with_execution_stats(evaluation, execution_stats)
+    report = analyze(
+        evaluation,
+        ks=args.top_k,
+        prefix_depths=args.prefix_depth,
+        n_boot=args.n_boot,
+    )
+    output_dir = paths["results"] / benchmark_name / model_name / stock_name
+    analysis_path = output_dir / "analysis.json.gz"
+    markdown_path = output_dir / "report.md"
+    save_analysis_report(report, analysis_path)
+    markdown_path.write_text(
+        generate_markdown_report(report, title=f"Evaluation Report: {model_name} / {benchmark_name} / {stock_name}"),
+        encoding="utf-8",
+    )
+    sources = [evaluation_path]
+    if execution_stats is not None:
+        sources.append(execution_stats_path)
+    write_manifest(
+        output_dir / "manifest.json",
+        action="analyze:v2",
+        sources=sources,
+        outputs=[analysis_path, markdown_path],
+        root_dir=paths["raw"].parent.resolve(),
+        parameters={
+            "model": model_name,
+            "benchmark": benchmark_name,
+            "stock": stock_name,
+            "top_k": args.top_k,
+            "prefix_depth": args.prefix_depth,
+            "n_boot": args.n_boot,
+        },
+        statistics={"n_metrics": len(report.metrics), "n_strata": len(report.by_stratum)},
+    )
+    return report, f"{model_name} / {benchmark_name} / {stock_name}", output_dir
 
 
 def _execution_stats_path(paths: dict[str, Path], model_name: str, benchmark_name: str) -> Path:

--- a/src/retrocast/cli/progress.py
+++ b/src/retrocast/cli/progress.py
@@ -32,7 +32,12 @@ class RateColumn(ProgressColumn):
         return Text(f"{task.speed:.1f} {self._unit}/s", style="progress.data.speed")
 
 
-def create_cli_progress(*, console: Console, unit: str) -> Progress:
+def create_cli_progress(
+    *,
+    console: Console,
+    unit: str,
+    transient: bool = False,
+) -> Progress:
     return Progress(
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
@@ -43,6 +48,7 @@ def create_cli_progress(*, console: Console, unit: str) -> Progress:
         TimeRemainingColumn(),
         RateColumn(unit),
         console=console,
+        transient=transient,
     )
 
 

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import re
 
+from rich import box
+from rich.console import Group, RenderableType
 from rich.markup import escape
 from rich.table import Table
+from rich.text import Text
 
-from retrocast.markdown import MarkdownRow, markdown_table
+from retrocast.markdown import MarkdownAlign, MarkdownRow, markdown_table
 from retrocast.models.analysis import AnalysisReport, MetricSummary
 
 _SOLV_RATE = re.compile(r"^solv_(\d+)\[(.+)]_rate$")
@@ -13,55 +16,165 @@ _MRR_SOLV = re.compile(r"^mrr_solv_(\d+)\[(.+)]$")
 _TIER_VALIDITY = re.compile(r"^tier_(\d+)_validity_rate$")
 _MRR_TIER = re.compile(r"^mrr_tier_(\d+)$")
 _TOP_K = re.compile(r"^acceptable_reconstruction_top_(\d+)\[(.+)]$")
+_ROOT_TOP_K = re.compile(r"^acceptable_root_reconstruction_top_(\d+)\[(.+)]$")
+_GIVEN_ROOT_TOP_K = re.compile(r"^acceptable_reconstruction_given_root_top_(\d+)\[(.+)]$")
+_PREFIX_TOP_K = re.compile(r"^acceptable_prefix_reconstruction_depth_(\d+)_top_(\d+)\[(.+)]$")
+_DISTINCT_ROOT_TOP_K = re.compile(r"^distinct_root_reactions_top_(\d+)\[(.+)]$")
 
 
-def create_analysis_table(report: AnalysisReport, *, title: str = "Analysis Results") -> Table:
-    """Create the compact CLI table; stratified diagnostics stay in report.md."""
-    table = Table(title=escape(title), header_style="bold magenta", show_lines=False)
-    table.add_column("Metric", style="bold", min_width=32)
-    table.add_column("Value", justify="right")
-    table.add_column("95% CI", justify="center")
-    table.add_column("N", justify="right")
-    table.add_column("Reliability", justify="center")
+def create_analysis_table(
+    report: AnalysisReport,
+    *,
+    title: str = "analysis results",
+    subtitle: str | None = None,
+) -> Group:
+    renderables: list[RenderableType] = [Text.from_markup(f"[bold magenta]{escape(title)}[/]")]
+    if subtitle is not None:
+        renderables.append(Text.from_markup(f"[dim]{escape(subtitle)}[/]"))
+    note = _terminal_report_note(report)
+    if note is not None:
+        renderables.append(Text.from_markup(note))
 
-    hierarchy_metrics = _hierarchy_metrics(report.metrics)
-    if hierarchy_metrics:
-        table.add_row("[dim]Solv-N evaluation[/]", "", "", "", "")
-        for name, metric, match in hierarchy_metrics:
+    solv_table = _create_solv_table(report)
+    if solv_table is not None:
+        renderables.append(solv_table)
+
+    reconstruction_table = _create_reconstruction_table(report.metrics)
+    if reconstruction_table is not None:
+        renderables.append(reconstruction_table)
+
+    runtime_table = _create_runtime_table(report)
+    if runtime_table is not None:
+        renderables.append(runtime_table)
+
+    return Group(*renderables)
+
+
+def _create_solv_table(
+    report: AnalysisReport,
+) -> Table | None:
+    metrics = report.metrics
+    tiers = _solv_tiers(metrics)
+    if not tiers:
+        return None
+
+    table = Table(
+        title="Solv-N Evaluation",
+        title_style="bold magenta",
+        header_style="bold magenta",
+        box=box.SIMPLE_HEAVY,
+        show_lines=False,
+    )
+    table.add_column("Tier", style="bold", justify="right", no_wrap=True)
+    table.add_column("Task", no_wrap=True)
+    table.add_column("Valid", justify="center", no_wrap=True)
+    table.add_column("Solv", justify="center", no_wrap=True)
+    table.add_column("MRR Valid", justify="center", no_wrap=True)
+    table.add_column("MRR Solv", justify="center", no_wrap=True)
+
+    for tier in tiers:
+        labels = _solv_labels(metrics, tier)
+        if not labels:
+            labels = [""]
+        for label in labels:
             table.add_row(
-                escape(_display_metric_name(name, match)),
-                _format_value(name, metric),
-                _format_ci(name, metric),
-                str(metric.count),
-                _format_reliability(metric),
+                str(tier),
+                label,
+                _metric_cell(
+                    f"tier_{tier}_validity_rate",
+                    metrics.get(f"tier_{tier}_validity_rate"),
+                ),
+                _metric_cell(
+                    f"solv_{tier}[{label}]_rate",
+                    metrics.get(f"solv_{tier}[{label}]_rate"),
+                )
+                if label
+                else "",
+                _metric_cell(
+                    f"mrr_tier_{tier}",
+                    metrics.get(f"mrr_tier_{tier}"),
+                ),
+                _metric_cell(
+                    f"mrr_solv_{tier}[{label}]",
+                    metrics.get(f"mrr_solv_{tier}[{label}]"),
+                )
+                if label
+                else "",
             )
+    return table
 
-    top_k_metrics = _matching_metrics(report.metrics, _TOP_K)
-    if top_k_metrics:
-        table.add_section()
-        table.add_row("[dim]Benchmark route reconstruction[/]", "", "", "", "")
-        for name, metric, match in top_k_metrics:
-            table.add_row(
-                _top_k_label(match),
-                _format_value(name, metric),
-                _format_ci(name, metric),
-                str(metric.count),
-                _format_reliability(metric),
-            )
 
+def _create_reconstruction_table(
+    metrics: dict[str, MetricSummary],
+) -> Table | None:
+    ks = _diagnostic_ks(metrics)
+    if not ks:
+        return None
+
+    depths = _diagnostic_prefix_depths(metrics)
+
+    def metric_cell(pattern: re.Pattern[str], k: int) -> str:
+        for name, metric, match in _matching_metrics(metrics, pattern):
+            if int(match.group(1)) == k:
+                return _metric_cell(name, metric, compact_ci=True)
+        return ""
+
+    def prefix_cell(k: int, depth: int) -> str:
+        for name, metric, match in _matching_metrics(metrics, _PREFIX_TOP_K):
+            if int(match.group(1)) == depth and int(match.group(2)) == k:
+                return _metric_cell(name, metric, compact_ci=True)
+        return ""
+
+    table = Table(
+        title="Benchmark Route Reconstruction",
+        title_style="bold magenta",
+        header_style="bold magenta",
+        box=box.SIMPLE_HEAVY,
+        show_lines=False,
+    )
+    table.add_column("Metric", style="bold", min_width=12, no_wrap=True)
+    for k in ks:
+        table.add_column(f"Top-{k}", justify="center", no_wrap=True)
+
+    rows = [
+        ("Full route", [metric_cell(_TOP_K, k) for k in ks]),
+        ("Root reaction", [metric_cell(_ROOT_TOP_K, k) for k in ks]),
+        ("Route | root", [metric_cell(_GIVEN_ROOT_TOP_K, k) for k in ks]),
+        *[(f"Prefix {depth}", [prefix_cell(k, depth) for k in ks]) for depth in depths],
+        ("Unique roots", [metric_cell(_DISTINCT_ROOT_TOP_K, k) for k in ks]),
+    ]
+    for label, cells in rows:
+        table.add_row(label, *cells)
+    return table
+
+
+def _create_runtime_table(report: AnalysisReport) -> Table | None:
     runtime_rows = _runtime_rows(report)
-    if runtime_rows:
-        table.add_section()
-        table.add_row("[dim]Runtime[/]", "", "", "", "")
-        for label, value in runtime_rows:
-            table.add_row(label, value, "", str(report.runtime.timed_target_count), "")
+    if not runtime_rows:
+        return None
 
+    table = Table(
+        title="Runtime",
+        title_style="bold magenta",
+        header_style="bold magenta",
+        box=box.SIMPLE_HEAVY,
+        show_lines=False,
+    )
+    table.add_column("Metric", style="bold")
+    table.add_column("Wall", justify="right")
+    table.add_column("CPU", justify="right")
+    for label, wall_time, cpu_time in runtime_rows:
+        table.add_row(label, wall_time, cpu_time)
     return table
 
 
 def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation Report") -> str:
     lines = [f"# {title}", "", "## Overall", ""]
-    lines.extend(_markdown_metric_table(report.metrics))
+    note = _solv_note(report)
+    if note:
+        lines.extend([note, ""])
+    lines.extend(_markdown_headline_metric_table(report.metrics))
+    lines.extend(_markdown_reconstruction_diagnostics(report.metrics))
     runtime_rows = _runtime_rows(report, rich=False)
     if runtime_rows:
         lines.extend(
@@ -70,8 +183,8 @@ def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation
                 "## Runtime",
                 "",
                 markdown_table(
-                    ["Metric", "Seconds", "Timed Targets"],
-                    [(label, value, report.runtime.timed_target_count) for label, value in runtime_rows],
+                    ["Metric", "Wall", "CPU"],
+                    runtime_rows,
                     align=["left", "right", "right"],
                 ),
             ]
@@ -80,14 +193,64 @@ def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation
         lines.extend(["", "## By Stratum", ""])
         for stratum in sorted(report.by_stratum):
             lines.extend([f"### {stratum}", ""])
-            lines.extend(_markdown_metric_table(report.by_stratum[stratum]))
+            lines.extend(_markdown_headline_metric_table(report.by_stratum[stratum]))
+            lines.extend(_markdown_reconstruction_diagnostics(report.by_stratum[stratum], heading_level=4))
             lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _markdown_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
+def _solv_note(report: AnalysisReport) -> str:
+    parts = []
+    target_count = _target_count(report.metrics)
+    if target_count is not None:
+        parts.append(f"n={target_count} targets")
+
+    if report.bootstrap_resamples is not None:
+        parts.append(f"ci: 95% bootstrap, {report.bootstrap_resamples:,} resamples")
+    else:
+        parts.append("ci: 95% bootstrap")
+
+    legend = _reliability_legend([metric for metric in report.metrics.values()])
+    if legend:
+        parts.append(legend)
+    return " | ".join(parts)
+
+
+def _terminal_report_note(report: AnalysisReport) -> str | None:
+    lines = []
+    lines.extend(f"[dim]{escape(line)}[/]" for line in _terminal_note_lines(report))
+    return "\n".join(lines) if lines else None
+
+
+def _terminal_note_lines(report: AnalysisReport) -> list[str]:
+    parts = []
+    target_count = _target_count(report.metrics)
+    if target_count is not None:
+        parts.append(f"n={target_count} targets")
+
+    if report.bootstrap_resamples is not None:
+        parts.append(f"ci=95% bootstrap, {report.bootstrap_resamples:,} resamples")
+    else:
+        parts.append("ci=95% bootstrap")
+
+    flag_legend = _reliability_legend_parts([metric for metric in report.metrics.values()])
+    if flag_legend:
+        parts.append("flags: " + "; ".join(f"{symbol} {description}" for symbol, description in flag_legend))
+
+    return [" | ".join(parts)]
+
+
+def _plain_reconstruction_note(metrics: dict[str, MetricSummary]) -> str:
+    notes = []
+    legend = _reliability_legend(_reconstruction_metric_values(metrics))
+    if legend:
+        notes.append(legend)
+    return " | ".join(notes)
+
+
+def _markdown_headline_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
     rows: list[MarkdownRow] = []
-    for name, metric, match in _ordered_metrics(metrics):
+    for name, metric, match in _headline_metrics(metrics):
         rows.append(
             (
                 _display_metric_name(name, match),
@@ -104,23 +267,179 @@ def _markdown_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
     ).splitlines()
 
 
-def _runtime_rows(report: AnalysisReport, *, rich: bool = True) -> list[tuple[str, str]]:
+def _markdown_reconstruction_diagnostics(
+    metrics: dict[str, MetricSummary],
+    *,
+    heading_level: int = 2,
+) -> list[str]:
+    ks = _diagnostic_ks(metrics)
+    if not ks:
+        return []
+
+    heading = "#" * heading_level
+    lines = ["", f"{heading} Reconstruction Diagnostics", ""]
+    note = _plain_reconstruction_note(metrics)
+    if note:
+        lines.extend([note, ""])
+
+    def diagnostic_cell(pattern: re.Pattern[str], k: int, *, include_n: bool = False) -> str:
+        for name, metric, match in _matching_metrics(metrics, pattern):
+            if int(match.group(1)) != k:
+                continue
+            value = _format_value(name, metric, rich=False)
+            ci = _format_ci(name, metric, rich=False)
+            cell = f"{value} {ci}" if ci else value
+            return f"{cell} (n={metric.count})" if include_n else cell
+        return ""
+
+    def prefix_cell(k: int, depth: int) -> str:
+        for name, metric, match in _matching_metrics(metrics, _PREFIX_TOP_K):
+            if int(match.group(1)) != depth or int(match.group(2)) != k:
+                continue
+            value = _format_value(name, metric, rich=False)
+            ci = _format_ci(name, metric, rich=False)
+            return f"{value} {ci}" if ci else value
+        return ""
+
+    top_k_rows = []
+    for k in ks:
+        top_k_rows.append(
+            (
+                f"Top-{k}",
+                diagnostic_cell(_TOP_K, k),
+                diagnostic_cell(_ROOT_TOP_K, k),
+                diagnostic_cell(_GIVEN_ROOT_TOP_K, k, include_n=True),
+                diagnostic_cell(_DISTINCT_ROOT_TOP_K, k),
+            )
+        )
+    lines.extend(
+        markdown_table(
+            ["K", "Full route", "Root reaction", "Route given root", "Distinct roots"],
+            top_k_rows,
+            align=["left", "right", "right", "right", "right"],
+        ).splitlines()
+    )
+
+    depths = _diagnostic_prefix_depths(metrics)
+    if depths:
+        prefix_rows = []
+        for k in ks:
+            prefix_rows.append(tuple([f"Top-{k}", *[prefix_cell(k, depth) for depth in depths]]))
+        prefix_align: list[MarkdownAlign] = ["left"]
+        for _ in depths:
+            prefix_align.append("right")
+        lines.extend(["", f"{heading} Prefix Reconstruction", ""])
+        lines.extend(
+            markdown_table(
+                ["K", *[f"Depth {depth}" for depth in depths]],
+                prefix_rows,
+                align=prefix_align,
+            ).splitlines()
+        )
+
+    return lines
+
+
+def _runtime_rows(report: AnalysisReport, *, rich: bool = True) -> list[tuple[str, str, str]]:
     runtime = report.runtime
-    rows = []
-    if runtime.total_wall_time is not None:
-        rows.append(("Total wall time", _format_seconds(runtime.total_wall_time, rich=rich)))
-    if runtime.mean_wall_time is not None:
-        rows.append(("Mean wall time", _format_seconds(runtime.mean_wall_time, rich=rich)))
-    if runtime.total_cpu_time is not None:
-        rows.append(("Total CPU time", _format_seconds(runtime.total_cpu_time, rich=rich)))
-    if runtime.mean_cpu_time is not None:
-        rows.append(("Mean CPU time", _format_seconds(runtime.mean_cpu_time, rich=rich)))
+    rows = [
+        (
+            "Total time",
+            _format_duration(runtime.total_wall_time),
+            _format_duration(runtime.total_cpu_time),
+        ),
+        (
+            "Per target",
+            _format_duration(runtime.mean_wall_time),
+            _format_duration(runtime.mean_cpu_time),
+        ),
+        (
+            "Per 1M targets (projected)",
+            _format_duration(_project_runtime(runtime.mean_wall_time)),
+            _format_duration(_project_runtime(runtime.mean_cpu_time)),
+        ),
+    ]
+    rows = [row for row in rows if row[1] or row[2]]
+    if rich:
+        return [_dim_runtime_projection(row) if "projected" in row[0] else row for row in rows]
     return rows
 
 
-def _format_seconds(value: float, *, rich: bool) -> str:
-    formatted = f"{value:.2f}s"
-    return f"[green]{formatted}[/]" if rich else formatted
+def _project_runtime(seconds_per_target: float | None) -> float | None:
+    if seconds_per_target is None:
+        return None
+    return seconds_per_target * 1_000_000
+
+
+def _dim_runtime_projection(row: tuple[str, str, str]) -> tuple[str, str, str]:
+    label, wall_time, cpu_time = row
+    return (f"[dim]{label}[/]", f"[dim]{wall_time}[/]", f"[dim]{cpu_time}[/]")
+
+
+def _target_count(metrics: dict[str, MetricSummary]) -> int | None:
+    if not metrics:
+        return None
+    return max(metric.count for metric in metrics.values())
+
+
+def _reconstruction_metric_values(metrics: dict[str, MetricSummary]) -> list[MetricSummary]:
+    values = []
+    for pattern in (_TOP_K, _ROOT_TOP_K, _GIVEN_ROOT_TOP_K, _PREFIX_TOP_K, _DISTINCT_ROOT_TOP_K):
+        values.extend(metric for _, metric, _ in _matching_metrics(metrics, pattern))
+    return values
+
+
+def _solv_tiers(metrics: dict[str, MetricSummary]) -> list[int]:
+    tiers: set[int] = set()
+    for name in metrics:
+        for pattern in (_TIER_VALIDITY, _SOLV_RATE, _MRR_TIER, _MRR_SOLV):
+            match = pattern.match(name)
+            if match is not None:
+                tiers.add(int(match.group(1)))
+    return sorted(tiers)
+
+
+def _solv_labels(metrics: dict[str, MetricSummary], tier: int) -> list[str]:
+    labels: set[str] = set()
+    for name in metrics:
+        solv_match = _SOLV_RATE.match(name)
+        if solv_match is not None and int(solv_match.group(1)) == tier:
+            labels.add(solv_match.group(2))
+        mrr_match = _MRR_SOLV.match(name)
+        if mrr_match is not None and int(mrr_match.group(1)) == tier:
+            labels.add(mrr_match.group(2))
+    return sorted(labels)
+
+
+def _metric_cell(
+    name: str,
+    metric: MetricSummary | None,
+    *,
+    compact_ci: bool = False,
+) -> str:
+    if metric is None:
+        return ""
+
+    value = _format_value(name, metric)
+    symbol = _format_reliability_symbol(metric)
+    first_line = f"{value}{symbol}" if symbol else value
+
+    ci = _format_compact_ci(name, metric) if compact_ci else _format_ci(name, metric, rich=False)
+    if not ci:
+        return first_line
+    return f"{first_line}\n[dim]{ci}[/]"
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return ""
+    if seconds > 24 * 60 * 60:
+        return f"{seconds / (24 * 60 * 60):.1f} days"
+    if seconds > 60 * 60:
+        return f"{seconds / (60 * 60):.1f} hr"
+    if seconds > 60:
+        return f"{seconds / 60:.1f} min"
+    return f"{seconds:.2f} s"
 
 
 def _format_reliability(metric: MetricSummary, *, rich: bool = True) -> str:
@@ -133,10 +452,45 @@ def _format_reliability(metric: MetricSummary, *, rich: bool = True) -> str:
     return f"[yellow]{code}[/]" if rich else code
 
 
-def _ordered_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, MetricSummary, re.Match[str]]]:
+def _format_reliability_symbol(metric: MetricSummary) -> str:
+    reliability = metric.reliability
+    if reliability is None or reliability.code == "OK":
+        return ""
+    if reliability.code == "EXTREME_P":
+        return "[yellow]*[/]"
+    return "[yellow]![/]"
+
+
+def _reliability_legend(metrics: list[MetricSummary]) -> str | None:
+    parts = _reliability_legend_parts(metrics)
+    if not parts:
+        return None
+    return "flags: " + "; ".join(f"{symbol} {description}" for symbol, description in parts)
+
+
+def _reliability_legend_parts(metrics: list[MetricSummary]) -> list[tuple[str, str]]:
+    symbols = {_plain_reliability_symbol(metric) for metric in metrics}
+    symbols.discard("")
+    parts = []
+    if "*" in symbols:
+        parts.append(("*", "extreme probability"))
+    if "!" in symbols:
+        parts.append(("!", "low n / unstable ci"))
+    return parts
+
+
+def _plain_reliability_symbol(metric: MetricSummary) -> str:
+    reliability = metric.reliability
+    if reliability is None or reliability.code == "OK":
+        return ""
+    if reliability.code == "EXTREME_P":
+        return "*"
+    return "!"
+
+
+def _headline_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, MetricSummary, re.Match[str]]]:
     ordered = _hierarchy_metrics(metrics)
-    for pattern in (_TOP_K,):
-        ordered.extend(_matching_metrics(metrics, pattern))
+    ordered.extend(_headline_reconstruction_metrics(metrics))
     return ordered
 
 
@@ -145,6 +499,12 @@ def _hierarchy_metrics(metrics: dict[str, MetricSummary]) -> list[tuple[str, Met
     for pattern in (_TIER_VALIDITY, _SOLV_RATE, _MRR_TIER, _MRR_SOLV):
         matches.extend(_matching_metrics(metrics, pattern))
     return sorted(matches, key=_hierarchy_sort_key)
+
+
+def _headline_reconstruction_metrics(
+    metrics: dict[str, MetricSummary],
+) -> list[tuple[str, MetricSummary, re.Match[str]]]:
+    return _matching_metrics(metrics, _TOP_K)
 
 
 def _hierarchy_sort_key(item: tuple[str, MetricSummary, re.Match[str]]) -> tuple[int, int, str]:
@@ -172,6 +532,24 @@ def _matching_metrics(
     return sorted(matches, key=lambda item: int(item[2].group(1)))
 
 
+def _diagnostic_ks(metrics: dict[str, MetricSummary]) -> list[int]:
+    ks: set[int] = set()
+    for name in metrics:
+        for pattern in (_TOP_K, _ROOT_TOP_K, _GIVEN_ROOT_TOP_K, _DISTINCT_ROOT_TOP_K):
+            match = pattern.match(name)
+            if match is not None:
+                ks.add(int(match.group(1)))
+        prefix_match = _PREFIX_TOP_K.match(name)
+        if prefix_match is not None:
+            ks.add(int(prefix_match.group(2)))
+    return sorted(ks)
+
+
+def _diagnostic_prefix_depths(metrics: dict[str, MetricSummary]) -> list[int]:
+    depths = {int(match.group(1)) for name in metrics if (match := _PREFIX_TOP_K.match(name)) is not None}
+    return sorted(depths)
+
+
 def _display_metric_name(name: str, match: re.Match[str]) -> str:
     pattern = match.re
     if pattern is _TIER_VALIDITY:
@@ -184,11 +562,15 @@ def _display_metric_name(name: str, match: re.Match[str]) -> str:
         return _plain_mrr_label(match)
     if pattern is _TOP_K:
         return _plain_top_k_label(match)
+    if pattern is _ROOT_TOP_K:
+        return _plain_root_top_k_label(match)
+    if pattern is _GIVEN_ROOT_TOP_K:
+        return _plain_given_root_top_k_label(match)
+    if pattern is _PREFIX_TOP_K:
+        return _plain_prefix_top_k_label(match)
+    if pattern is _DISTINCT_ROOT_TOP_K:
+        return _plain_distinct_root_top_k_label(match)
     raise ValueError(f"unexpected report metric: {name!r}")
-
-
-def _top_k_label(match: re.Match[str]) -> str:
-    return escape(_plain_top_k_label(match))
 
 
 def _plain_solv_label(match: re.Match[str]) -> str:
@@ -211,16 +593,43 @@ def _plain_top_k_label(match: re.Match[str]) -> str:
     return f"Top-{match.group(1)}"
 
 
+def _plain_root_top_k_label(match: re.Match[str]) -> str:
+    return f"Root Top-{match.group(1)}"
+
+
+def _plain_given_root_top_k_label(match: re.Match[str]) -> str:
+    return f"Route given root Top-{match.group(1)}"
+
+
+def _plain_prefix_top_k_label(match: re.Match[str]) -> str:
+    return f"Prefix depth {match.group(1)} Top-{match.group(2)}"
+
+
+def _plain_distinct_root_top_k_label(match: re.Match[str]) -> str:
+    return f"Distinct roots Top-{match.group(1)}"
+
+
 def _format_value(name: str, metric: MetricSummary, *, rich: bool = True) -> str:
-    value = f"{metric.value:.3f}" if name.startswith("mrr_") else f"{metric.value:.1%}"
-    return f"[green]{value}[/]" if rich else value
+    if name.startswith("mrr_") or name.startswith("distinct_root_reactions_"):
+        value = f"{metric.value:.3f}"
+    else:
+        value = f"{metric.value:.1%}"
+    return value
 
 
 def _format_ci(name: str, metric: MetricSummary, *, rich: bool = True) -> str:
     if metric.ci_low is None or metric.ci_high is None:
         return ""
-    if name.startswith("mrr_"):
+    if name.startswith("mrr_") or name.startswith("distinct_root_reactions_"):
         value = f"[{metric.ci_low:.3f}, {metric.ci_high:.3f}]"
     else:
         value = f"[{metric.ci_low:.1%}, {metric.ci_high:.1%}]"
     return f"[green]{value}[/]" if rich else value
+
+
+def _format_compact_ci(name: str, metric: MetricSummary) -> str:
+    if metric.ci_low is None or metric.ci_high is None:
+        return ""
+    if name.startswith("mrr_") or name.startswith("distinct_root_reactions_"):
+        return f"[{metric.ci_low:.2f}, {metric.ci_high:.2f}]"
+    return f"[{metric.ci_low * 100:.1f}, {metric.ci_high * 100:.1f}]"

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -77,7 +77,7 @@ def _create_solv_table(
     table.add_column("MRR Valid-N", justify="center", no_wrap=True)
     table.add_column("MRR Solv-N", justify="center", no_wrap=True)
 
-    def cell(name: str) -> str:
+    def cell(name: str) -> RenderableType:
         return _metric_cell(name, metrics.get(name))
 
     for tier in tiers:
@@ -109,13 +109,13 @@ def _create_reconstruction_table(
 
     depths = _diagnostic_prefix_depths(metrics)
 
-    def metric_cell(pattern: re.Pattern[str], k: int) -> str:
+    def metric_cell(pattern: re.Pattern[str], k: int) -> RenderableType:
         for name, metric, match in _matching_metrics(metrics, pattern):
             if int(match.group(1)) == k:
                 return _metric_cell(name, metric, compact_ci=True)
         return ""
 
-    def prefix_cell(k: int, depth: int) -> str:
+    def prefix_cell(k: int, depth: int) -> RenderableType:
         for name, metric, match in _matching_metrics(metrics, _PREFIX_TOP_K):
             if int(match.group(1)) == depth and int(match.group(2)) == k:
                 return _metric_cell(name, metric, compact_ci=True)
@@ -137,7 +137,7 @@ def _create_reconstruction_table(
         ("Root reaction", [metric_cell(_ROOT_TOP_K, k) for k in ks]),
         ("Route | root", [metric_cell(_GIVEN_ROOT_TOP_K, k) for k in ks]),
         *[(f"Prefix {depth}", [prefix_cell(k, depth) for k in ks]) for depth in depths],
-        ("Unique roots", [metric_cell(_DISTINCT_ROOT_TOP_K, k) for k in ks]),
+        ("Mean distinct roots", [metric_cell(_DISTINCT_ROOT_TOP_K, k) for k in ks]),
     ]
     for label, cells in rows:
         table.add_row(label, *cells)
@@ -160,7 +160,7 @@ def _create_runtime_table(report: AnalysisReport) -> Table | None:
     table.add_column("Wall", justify="right")
     table.add_column("CPU", justify="right")
     for label, wall_time, cpu_time in runtime_rows:
-        table.add_row(label, wall_time, cpu_time)
+        table.add_row(_markup(label), _markup(wall_time), _markup(cpu_time))
     return table
 
 
@@ -217,7 +217,7 @@ def _markdown_headline_metric_table(metrics: dict[str, MetricSummary]) -> list[s
         rows.append(
             (
                 _display_metric_name(name, match),
-                _format_value(name, metric, rich=False),
+                _format_value(name, metric),
                 _format_ci(name, metric, rich=False),
                 metric.count,
                 _format_reliability(metric, rich=False),
@@ -263,7 +263,7 @@ def _markdown_reconstruction_diagnostics(
         ("Full route", _TOP_K),
         ("Root reaction", _ROOT_TOP_K),
         ("Route given root", _GIVEN_ROOT_TOP_K),
-        ("Distinct roots", _DISTINCT_ROOT_TOP_K),
+        ("Mean distinct roots", _DISTINCT_ROOT_TOP_K),
     ]
     top_k_rows = [tuple([f"Top-{k}", *[diagnostic_cell(pattern, k) for _, pattern in diagnostics]]) for k in ks]
     diagnostic_align: list[MarkdownAlign] = ["left"]
@@ -318,7 +318,8 @@ def _runtime_rows(report: AnalysisReport, *, rich: bool = True) -> list[tuple[st
     ]
     rows = [row for row in rows if row[1] or row[2]]
     if rich:
-        return [_dim_runtime_projection(row) if "projected" in row[0] else row for row in rows]
+        projected_label = "Per 1M targets (projected)"
+        return [_dim_runtime_projection(row) if row[0] == projected_label else row for row in rows]
     return rows
 
 
@@ -373,7 +374,7 @@ def _metric_cell(
     metric: MetricSummary | None,
     *,
     compact_ci: bool = False,
-) -> str:
+) -> RenderableType:
     if metric is None:
         return ""
 
@@ -383,14 +384,20 @@ def _metric_cell(
 
     ci = _format_compact_ci(name, metric) if compact_ci else _format_ci(name, metric, rich=False)
     if not ci:
-        return first_line
-    return f"{first_line}\n[dim]{ci}[/]"
+        return _markup(first_line) if symbol else first_line
+    return _markup(f"{first_line}\n[dim]{ci}[/]")
+
+
+def _markup(value: str) -> Text:
+    return Text.from_markup(value)
 
 
 def _markdown_metric_cell(name: str, metric: MetricSummary) -> str:
-    value = _format_value(name, metric, rich=False)
+    value = _format_value(name, metric)
+    symbol = _plain_reliability_symbol(metric)
     ci = _format_ci(name, metric, rich=False)
-    return f"{value} {ci}" if ci else value
+    first = f"{value}{symbol}" if symbol else value
+    return f"{first} {ci}" if ci else first
 
 
 def _format_duration(seconds: float | None) -> str:
@@ -569,10 +576,10 @@ def _plain_prefix_top_k_label(match: re.Match[str]) -> str:
 
 
 def _plain_distinct_root_top_k_label(match: re.Match[str]) -> str:
-    return f"Distinct roots Top-{match.group(1)}"
+    return f"Mean distinct roots Top-{match.group(1)}"
 
 
-def _format_value(name: str, metric: MetricSummary, *, rich: bool = True) -> str:
+def _format_value(name: str, metric: MetricSummary) -> str:
     if name.startswith("mrr_") or name.startswith("distinct_root_reactions_"):
         value = f"{metric.value:.3f}"
     else:

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -31,9 +31,14 @@ def create_analysis_table(
     renderables: list[RenderableType] = [Text.from_markup(f"[bold magenta]{escape(title)}[/]")]
     if subtitle is not None:
         renderables.append(Text.from_markup(f"[dim]{escape(subtitle)}[/]"))
-    note = _terminal_report_note(report)
-    if note is not None:
-        renderables.append(Text.from_markup(note))
+
+    note_parts = _report_note_parts(report)
+    flag_legend = _reliability_legend_parts([metric for metric in report.metrics.values()])
+    if flag_legend:
+        note_parts.append("flags: " + "; ".join(f"{symbol} {description}" for symbol, description in flag_legend))
+    if note_parts:
+        note = " | ".join(note_parts)
+        renderables.append(Text.from_markup(f"[dim]{escape(note)}[/]"))
 
     solv_table = _create_solv_table(report)
     if solv_table is not None:
@@ -67,39 +72,30 @@ def _create_solv_table(
     )
     table.add_column("Tier", style="bold", justify="right", no_wrap=True)
     table.add_column("Task", no_wrap=True)
-    table.add_column("Valid", justify="center", no_wrap=True)
-    table.add_column("Solv", justify="center", no_wrap=True)
-    table.add_column("MRR Valid", justify="center", no_wrap=True)
-    table.add_column("MRR Solv", justify="center", no_wrap=True)
+    table.add_column("Valid-N", justify="center", no_wrap=True)
+    table.add_column("Solv-N", justify="center", no_wrap=True)
+    table.add_column("MRR Valid-N", justify="center", no_wrap=True)
+    table.add_column("MRR Solv-N", justify="center", no_wrap=True)
+
+    def cell(name: str) -> str:
+        return _metric_cell(name, metrics.get(name))
 
     for tier in tiers:
         labels = _solv_labels(metrics, tier)
         if not labels:
             labels = [""]
         for label in labels:
+            valid_rate = f"tier_{tier}_validity_rate"
+            solv_rate = f"solv_{tier}[{label}]_rate"
+            mrr_valid = f"mrr_tier_{tier}"
+            mrr_solv = f"mrr_solv_{tier}[{label}]"
             table.add_row(
                 str(tier),
                 label,
-                _metric_cell(
-                    f"tier_{tier}_validity_rate",
-                    metrics.get(f"tier_{tier}_validity_rate"),
-                ),
-                _metric_cell(
-                    f"solv_{tier}[{label}]_rate",
-                    metrics.get(f"solv_{tier}[{label}]_rate"),
-                )
-                if label
-                else "",
-                _metric_cell(
-                    f"mrr_tier_{tier}",
-                    metrics.get(f"mrr_tier_{tier}"),
-                ),
-                _metric_cell(
-                    f"mrr_solv_{tier}[{label}]",
-                    metrics.get(f"mrr_solv_{tier}[{label}]"),
-                )
-                if label
-                else "",
+                cell(valid_rate),
+                cell(solv_rate) if label else "",
+                cell(mrr_valid),
+                cell(mrr_solv) if label else "",
             )
     return table
 
@@ -170,9 +166,12 @@ def _create_runtime_table(report: AnalysisReport) -> Table | None:
 
 def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation Report") -> str:
     lines = [f"# {title}", "", "## Overall", ""]
-    note = _solv_note(report)
-    if note:
-        lines.extend([note, ""])
+    note_parts = _report_note_parts(report, ci_separator=": ")
+    legend = _reliability_legend([metric for metric in report.metrics.values()])
+    if legend:
+        note_parts.append(legend)
+    if note_parts:
+        lines.extend([" | ".join(note_parts), ""])
     lines.extend(_markdown_headline_metric_table(report.metrics))
     lines.extend(_markdown_reconstruction_diagnostics(report.metrics))
     runtime_rows = _runtime_rows(report, rich=False)
@@ -199,53 +198,17 @@ def generate_markdown_report(report: AnalysisReport, *, title: str = "Evaluation
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _solv_note(report: AnalysisReport) -> str:
+def _report_note_parts(report: AnalysisReport, *, ci_separator: str = "=") -> list[str]:
     parts = []
     target_count = _target_count(report.metrics)
     if target_count is not None:
         parts.append(f"n={target_count} targets")
 
     if report.bootstrap_resamples is not None:
-        parts.append(f"ci: 95% bootstrap, {report.bootstrap_resamples:,} resamples")
+        parts.append(f"ci{ci_separator}95% bootstrap, {report.bootstrap_resamples:,} resamples")
     else:
-        parts.append("ci: 95% bootstrap")
-
-    legend = _reliability_legend([metric for metric in report.metrics.values()])
-    if legend:
-        parts.append(legend)
-    return " | ".join(parts)
-
-
-def _terminal_report_note(report: AnalysisReport) -> str | None:
-    lines = []
-    lines.extend(f"[dim]{escape(line)}[/]" for line in _terminal_note_lines(report))
-    return "\n".join(lines) if lines else None
-
-
-def _terminal_note_lines(report: AnalysisReport) -> list[str]:
-    parts = []
-    target_count = _target_count(report.metrics)
-    if target_count is not None:
-        parts.append(f"n={target_count} targets")
-
-    if report.bootstrap_resamples is not None:
-        parts.append(f"ci=95% bootstrap, {report.bootstrap_resamples:,} resamples")
-    else:
-        parts.append("ci=95% bootstrap")
-
-    flag_legend = _reliability_legend_parts([metric for metric in report.metrics.values()])
-    if flag_legend:
-        parts.append("flags: " + "; ".join(f"{symbol} {description}" for symbol, description in flag_legend))
-
-    return [" | ".join(parts)]
-
-
-def _plain_reconstruction_note(metrics: dict[str, MetricSummary]) -> str:
-    notes = []
-    legend = _reliability_legend(_reconstruction_metric_values(metrics))
-    if legend:
-        notes.append(legend)
-    return " | ".join(notes)
+        parts.append(f"ci{ci_separator}95% bootstrap")
+    return parts
 
 
 def _markdown_headline_metric_table(metrics: dict[str, MetricSummary]) -> list[str]:
@@ -278,45 +241,39 @@ def _markdown_reconstruction_diagnostics(
 
     heading = "#" * heading_level
     lines = ["", f"{heading} Reconstruction Diagnostics", ""]
-    note = _plain_reconstruction_note(metrics)
-    if note:
-        lines.extend([note, ""])
+    legend = _reliability_legend(_reconstruction_metric_values(metrics))
+    if legend:
+        lines.extend([legend, ""])
 
-    def diagnostic_cell(pattern: re.Pattern[str], k: int, *, include_n: bool = False) -> str:
+    def diagnostic_cell(pattern: re.Pattern[str], k: int) -> str:
         for name, metric, match in _matching_metrics(metrics, pattern):
             if int(match.group(1)) != k:
                 continue
-            value = _format_value(name, metric, rich=False)
-            ci = _format_ci(name, metric, rich=False)
-            cell = f"{value} {ci}" if ci else value
-            return f"{cell} (n={metric.count})" if include_n else cell
+            return _markdown_metric_cell(name, metric)
         return ""
 
     def prefix_cell(k: int, depth: int) -> str:
         for name, metric, match in _matching_metrics(metrics, _PREFIX_TOP_K):
             if int(match.group(1)) != depth or int(match.group(2)) != k:
                 continue
-            value = _format_value(name, metric, rich=False)
-            ci = _format_ci(name, metric, rich=False)
-            return f"{value} {ci}" if ci else value
+            return _markdown_metric_cell(name, metric)
         return ""
 
-    top_k_rows = []
-    for k in ks:
-        top_k_rows.append(
-            (
-                f"Top-{k}",
-                diagnostic_cell(_TOP_K, k),
-                diagnostic_cell(_ROOT_TOP_K, k),
-                diagnostic_cell(_GIVEN_ROOT_TOP_K, k, include_n=True),
-                diagnostic_cell(_DISTINCT_ROOT_TOP_K, k),
-            )
-        )
+    diagnostics: list[tuple[str, re.Pattern[str]]] = [
+        ("Full route", _TOP_K),
+        ("Root reaction", _ROOT_TOP_K),
+        ("Route given root", _GIVEN_ROOT_TOP_K),
+        ("Distinct roots", _DISTINCT_ROOT_TOP_K),
+    ]
+    top_k_rows = [tuple([f"Top-{k}", *[diagnostic_cell(pattern, k) for _, pattern in diagnostics]]) for k in ks]
+    diagnostic_align: list[MarkdownAlign] = ["left"]
+    for _ in diagnostics:
+        diagnostic_align.append("right")
     lines.extend(
         markdown_table(
-            ["K", "Full route", "Root reaction", "Route given root", "Distinct roots"],
+            ["K", *[label for label, _ in diagnostics]],
             top_k_rows,
-            align=["left", "right", "right", "right", "right"],
+            align=diagnostic_align,
         ).splitlines()
     )
 
@@ -428,6 +385,12 @@ def _metric_cell(
     if not ci:
         return first_line
     return f"{first_line}\n[dim]{ci}[/]"
+
+
+def _markdown_metric_cell(name: str, metric: MetricSummary) -> str:
+    value = _format_value(name, metric, rich=False)
+    ci = _format_ci(name, metric, rich=False)
+    return f"{value} {ci}" if ci else value
 
 
 def _format_duration(seconds: float | None) -> str:

--- a/src/retrocast/metrics/analysis.py
+++ b/src/retrocast/metrics/analysis.py
@@ -134,7 +134,8 @@ def _top_k_reconstruction_given_root_values(
     for target in targets:
         if not _target_has_root_hit(target, k, match_level):
             continue
-        values.append(1.0 if _target_has_full_hit(target, k) else 0.0)
+        candidates = _task_satisfying_top_k(target, k)
+        values.append(1.0 if any(candidate.matches_acceptable for candidate in candidates) else 0.0)
     return values
 
 
@@ -161,10 +162,6 @@ def _distinct_root_reaction_values(
         }
         values.append(float(len(root_signatures)))
     return values
-
-
-def _target_has_full_hit(target: TargetResult, k: int) -> bool:
-    return any(candidate.matches_acceptable for candidate in _task_satisfying_top_k(target, k))
 
 
 def _target_has_root_hit(target: TargetResult, k: int, match_level: InChIKeyLevel) -> bool:

--- a/src/retrocast/metrics/analysis.py
+++ b/src/retrocast/metrics/analysis.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from retrocast.metrics.bootstrap import summarize_values
 from retrocast.models.analysis import MetricSummary
 from retrocast.models.evaluation import ScoredCandidate, TargetResult, Tier
+from retrocast.models.route import InChIKeyLevel, Route, RoutePath
 
 CandidatePredicate = Callable[[ScoredCandidate, Tier], bool]
 
@@ -27,7 +28,9 @@ def summarize_targets(
     *,
     tiers: Sequence[Tier],
     ks: Sequence[int],
+    prefix_depths: Sequence[int] = (1, 2, 3),
     metric_label: str = "task",
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
     n_boot: int = 10000,
     seed: int = 42,
 ) -> dict[str, MetricSummary]:
@@ -45,13 +48,30 @@ def summarize_targets(
 
     reconstruction_targets = [target for target in targets if target.target.acceptable_routes]
     if reconstruction_targets:
+
+        def reconstruction_summary(values: Sequence[float], *, reliability: bool = True) -> MetricSummary:
+            return summarize_values(values, n_boot=n_boot, seed=seed, reliability=reliability)
+
         for k in sorted(set(ks)):
-            metrics[f"acceptable_reconstruction_top_{k}[{metric_label}]"] = _top_k_reconstruction(
-                reconstruction_targets,
-                k,
-                n_boot=n_boot,
-                seed=seed,
+            metrics[f"acceptable_reconstruction_top_{k}[{metric_label}]"] = reconstruction_summary(
+                _top_k_reconstruction_values(reconstruction_targets, k)
             )
+            metrics[f"acceptable_root_reconstruction_top_{k}[{metric_label}]"] = reconstruction_summary(
+                _top_k_root_reconstruction_values(reconstruction_targets, k, acceptable_match_level)
+            )
+            metrics[f"acceptable_reconstruction_given_root_top_{k}[{metric_label}]"] = reconstruction_summary(
+                _top_k_reconstruction_given_root_values(reconstruction_targets, k, acceptable_match_level)
+            )
+            metrics[f"distinct_root_reactions_top_{k}[{metric_label}]"] = reconstruction_summary(
+                _distinct_root_reaction_values(reconstruction_targets, k, acceptable_match_level),
+                reliability=False,
+            )
+            for depth in sorted(set(prefix_depths)):
+                metrics[f"acceptable_prefix_reconstruction_depth_{depth}_top_{k}[{metric_label}]"] = (
+                    reconstruction_summary(
+                        _top_k_prefix_reconstruction_values(reconstruction_targets, k, depth, acceptable_match_level)
+                    )
+                )
     return metrics
 
 
@@ -89,10 +109,100 @@ def _candidate_mrr(
     return summarize_values(values, n_boot=n_boot, seed=seed)
 
 
-def _top_k_reconstruction(targets: Sequence[TargetResult], k: int, *, n_boot: int, seed: int) -> MetricSummary:
+def _top_k_reconstruction_values(targets: Sequence[TargetResult], k: int) -> list[float]:
     values = []
     for target in targets:
-        ranked = sorted(target.candidates, key=lambda candidate: candidate.rank)
-        candidates = [candidate for candidate in ranked if candidate.satisfies_task()]
-        values.append(1.0 if any(candidate.matches_acceptable for candidate in candidates[:k]) else 0.0)
-    return summarize_values(values, n_boot=n_boot, seed=seed)
+        candidates = _task_satisfying_top_k(target, k)
+        values.append(1.0 if any(candidate.matches_acceptable for candidate in candidates) else 0.0)
+    return values
+
+
+def _top_k_root_reconstruction_values(
+    targets: Sequence[TargetResult],
+    k: int,
+    match_level: InChIKeyLevel,
+) -> list[float]:
+    return [1.0 if _target_has_root_hit(target, k, match_level) else 0.0 for target in targets]
+
+
+def _top_k_reconstruction_given_root_values(
+    targets: Sequence[TargetResult],
+    k: int,
+    match_level: InChIKeyLevel,
+) -> list[float]:
+    values = []
+    for target in targets:
+        if not _target_has_root_hit(target, k, match_level):
+            continue
+        values.append(1.0 if _target_has_full_hit(target, k) else 0.0)
+    return values
+
+
+def _top_k_prefix_reconstruction_values(
+    targets: Sequence[TargetResult],
+    k: int,
+    depth: int,
+    match_level: InChIKeyLevel,
+) -> list[float]:
+    return [1.0 if _target_has_prefix_hit(target, k, depth, match_level) else 0.0 for target in targets]
+
+
+def _distinct_root_reaction_values(
+    targets: Sequence[TargetResult],
+    k: int,
+    match_level: InChIKeyLevel,
+) -> list[float]:
+    values = []
+    for target in targets:
+        root_signatures = {
+            signature
+            for candidate in _task_satisfying_top_k(target, k)
+            if (signature := _root_reaction_signature(candidate.route, match_level)) is not None
+        }
+        values.append(float(len(root_signatures)))
+    return values
+
+
+def _target_has_full_hit(target: TargetResult, k: int) -> bool:
+    return any(candidate.matches_acceptable for candidate in _task_satisfying_top_k(target, k))
+
+
+def _target_has_root_hit(target: TargetResult, k: int, match_level: InChIKeyLevel) -> bool:
+    acceptable_roots = {
+        signature
+        for route in target.target.acceptable_routes
+        if (signature := _root_reaction_signature(route, match_level)) is not None
+    }
+    if not acceptable_roots:
+        return False
+
+    candidate_roots = {
+        signature
+        for candidate in _task_satisfying_top_k(target, k)
+        if (signature := _root_reaction_signature(candidate.route, match_level)) is not None
+    }
+    return bool(candidate_roots & acceptable_roots)
+
+
+def _target_has_prefix_hit(target: TargetResult, k: int, depth: int, match_level: InChIKeyLevel) -> bool:
+    acceptable_prefixes = {route.signature(match_level, depth=depth) for route in target.target.acceptable_routes}
+    candidate_prefixes = {
+        candidate.route.signature(match_level, depth=depth)
+        for candidate in _task_satisfying_top_k(target, k)
+        if candidate.route is not None
+    }
+    return bool(candidate_prefixes & acceptable_prefixes)
+
+
+def _task_satisfying_top_k(target: TargetResult, k: int) -> list[ScoredCandidate]:
+    ranked = sorted(target.candidates, key=lambda candidate: candidate.rank)
+    return [candidate for candidate in ranked if candidate.satisfies_task()][:k]
+
+
+def _root_reaction_signature(route: Route | None, match_level: InChIKeyLevel) -> str | None:
+    if route is None:
+        return None
+    try:
+        return route.reaction_at(RoutePath.root_reaction()).signature(match_level)
+    except KeyError:
+        return None

--- a/src/retrocast/metrics/analysis.py
+++ b/src/retrocast/metrics/analysis.py
@@ -62,9 +62,8 @@ def summarize_targets(
             metrics[f"acceptable_reconstruction_given_root_top_{k}[{metric_label}]"] = reconstruction_summary(
                 _top_k_reconstruction_given_root_values(reconstruction_targets, k, acceptable_match_level)
             )
-            metrics[f"distinct_root_reactions_top_{k}[{metric_label}]"] = reconstruction_summary(
-                _distinct_root_reaction_values(reconstruction_targets, k, acceptable_match_level),
-                reliability=False,
+            metrics[f"distinct_root_reactions_top_{k}[{metric_label}]"] = _mean_summary(
+                _distinct_root_reaction_values(reconstruction_targets, k, acceptable_match_level)
             )
             for depth in sorted(set(prefix_depths)):
                 metrics[f"acceptable_prefix_reconstruction_depth_{depth}_top_{k}[{metric_label}]"] = (
@@ -73,6 +72,12 @@ def summarize_targets(
                     )
                 )
     return metrics
+
+
+def _mean_summary(values: Sequence[float]) -> MetricSummary:
+    if not values:
+        return MetricSummary(value=0.0, count=0)
+    return MetricSummary(value=sum(values) / len(values), count=len(values))
 
 
 def _candidate_rate(

--- a/src/retrocast/metrics/bootstrap.py
+++ b/src/retrocast/metrics/bootstrap.py
@@ -43,13 +43,14 @@ def summarize_values(
     n_boot: int = 10000,
     seed: int = 42,
     alpha: float = 0.05,
+    reliability: bool = True,
 ) -> MetricSummary:
     data: npt.NDArray[np.float64] = np.array(values, dtype=np.float64)
     if len(data) == 0:
         return MetricSummary(
             value=0.0,
             count=0,
-            reliability=ReliabilityFlag(code="LOW_N", message="No data."),
+            reliability=ReliabilityFlag(code="LOW_N", message="No data.") if reliability else None,
         )
 
     distribution = _bootstrap_mean(data, n_boot=n_boot, seed=seed)
@@ -59,7 +60,7 @@ def summarize_values(
         count=len(data),
         ci_low=float(np.percentile(distribution, 100 * alpha / 2)),
         ci_high=float(np.percentile(distribution, 100 * (1 - alpha / 2))),
-        reliability=check_reliability(len(data), value),
+        reliability=check_reliability(len(data), value) if reliability else None,
     )
 
 

--- a/src/retrocast/models/analysis.py
+++ b/src/retrocast/models/analysis.py
@@ -30,4 +30,5 @@ class AnalysisReport(BaseModel):
     schema_version: Literal["2"] = "2"
     metrics: dict[str, MetricSummary] = Field(default_factory=dict)
     by_stratum: dict[str, dict[str, MetricSummary]] = Field(default_factory=dict)
+    bootstrap_resamples: int | None = None
     runtime: RuntimeSummary = Field(default_factory=RuntimeSummary)

--- a/src/retrocast/models/evaluation.py
+++ b/src/retrocast/models/evaluation.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, model_validator
 
 from retrocast.models.candidates import FailureRecord
-from retrocast.models.route import ReactionId, Route
+from retrocast.models.route import InChIKeyLevel, ReactionId, Route
 from retrocast.models.task import Target, Task, TaskConstraints
 
 
@@ -104,5 +104,6 @@ class Evaluation(BaseModel):
     task: Task
     tiers: list[Tier] = Field(default_factory=list)
     metric_label: str = "task"
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL
     targets: dict[str, TargetResult] = Field(default_factory=dict)
     schema_version: Literal["2"] = "2"

--- a/src/retrocast/workflow/analyze.py
+++ b/src/retrocast/workflow/analyze.py
@@ -11,6 +11,7 @@ def analyze(
     evaluation: Evaluation,
     *,
     ks: Sequence[int] = (1, 5, 10, 50),
+    prefix_depths: Sequence[int] = (1, 2, 3),
     stratify_by: Callable[[TargetResult], str | None] | None = None,
     n_boot: int = 10000,
     seed: int = 42,
@@ -20,7 +21,9 @@ def analyze(
         targets,
         tiers=evaluation.tiers,
         ks=ks,
+        prefix_depths=prefix_depths,
         metric_label=evaluation.metric_label,
+        acceptable_match_level=evaluation.acceptable_match_level,
         n_boot=n_boot,
         seed=seed,
     )
@@ -36,14 +39,21 @@ def analyze(
             stratum_targets,
             tiers=evaluation.tiers,
             ks=ks,
+            prefix_depths=prefix_depths,
             metric_label=evaluation.metric_label,
+            acceptable_match_level=evaluation.acceptable_match_level,
             n_boot=n_boot,
             seed=seed,
         )
         for stratum, stratum_targets in strata.items()
     }
 
-    return AnalysisReport(metrics=metrics, by_stratum=by_stratum, runtime=_runtime_summary(targets))
+    return AnalysisReport(
+        metrics=metrics,
+        by_stratum=by_stratum,
+        bootstrap_resamples=n_boot,
+        runtime=_runtime_summary(targets),
+    )
 
 
 def _runtime_summary(targets: list[TargetResult]) -> RuntimeSummary:

--- a/src/retrocast/workflow/score.py
+++ b/src/retrocast/workflow/score.py
@@ -130,7 +130,13 @@ def score(
             wall_time=execution_stats.wall_time.get(target_id) if execution_stats is not None else None,
             cpu_time=execution_stats.cpu_time.get(target_id) if execution_stats is not None else None,
         )
-    return Evaluation(task=task, tiers=tiers, metric_label=task.derived_metric_label(), targets=target_results)
+    return Evaluation(
+        task=task,
+        tiers=tiers,
+        metric_label=task.derived_metric_label(),
+        acceptable_match_level=acceptable_match_level,
+        targets=target_results,
+    )
 
 
 def _tier_zero_validity(candidate: Candidate) -> RouteValidity:

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -18,6 +18,7 @@ def report_with_all_metric_groups() -> AnalysisReport:
                 count=4,
                 reliability=ReliabilityFlag(code="LOW_N", message="Small sample size."),
             ),
+            "distinct_root_reactions_top_3[test-stock]": MetricSummary(value=2.0, count=4),
         },
         by_stratum={
             "depth=2": {
@@ -36,6 +37,8 @@ def test_generate_markdown_report_includes_strata_and_metric_groups() -> None:
     assert "MRR Tier-0" in markdown
     assert "MRR Solv-0[test-stock]" in markdown
     assert "Top-3" in markdown
+    assert "Mean distinct roots" in markdown
+    assert "| Top-3 | 75.0%! |  |  | 2.000 |" in markdown
     assert "## By Stratum" in markdown
     assert "### depth=2" in markdown
     assert "| Top-1 | 25.0% |  | 2 |  |" in markdown
@@ -52,6 +55,8 @@ def test_create_analysis_table_renders_metric_groups() -> None:
     assert "Benchmark Route" in output
     assert "Top-3" in output
     assert "75.0%" in output
+    assert "Mean distinct roots" in output
+    assert "2.000" in output
     assert "flags: ! low n / unstable ci" in output
 
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -42,18 +42,17 @@ def test_generate_markdown_report_includes_strata_and_metric_groups() -> None:
     assert "| Top-3 | 75.0% |  | 4 | LOW_N |" in markdown
 
 
-def test_create_analysis_table_renders_top_k_without_ci() -> None:
+def test_create_analysis_table_renders_metric_groups() -> None:
     console = Console(record=True, width=120)
     console.print(create_analysis_table(report_with_all_metric_groups()))
 
     output = console.export_text()
-    assert "Solv-N evaluation" in output
-    assert "Tier-0 Validity" in output
-    assert "Benchmark route reconstruction" in output
+    assert "Solv-N Evaluation" in output
+    assert "test-stock" in output
+    assert "Benchmark Route" in output
     assert "Top-3" in output
     assert "75.0%" in output
-    assert "Reliability" in output
-    assert "LOW_N" in output
+    assert "flags: ! low n / unstable ci" in output
 
 
 def test_reports_render_runtime_summary() -> None:
@@ -71,11 +70,12 @@ def test_reports_render_runtime_summary() -> None:
 
     markdown = generate_markdown_report(report, title="Small Run")
     assert "## Runtime" in markdown
-    assert "| Total wall time | 12.00s | 4 |" in markdown
+    assert "| Total time | 12.00 s | 4.00 s |" in markdown
+    assert "| Per target | 3.00 s | 1.00 s |" in markdown
 
     console = Console(record=True, width=120)
     console.print(create_analysis_table(report))
     output = console.export_text()
     assert "Runtime" in output
-    assert "Total wall time" in output
-    assert "12.00s" in output
+    assert "Total time" in output
+    assert "12.00 s" in output

--- a/tests/visualization/test_report.py
+++ b/tests/visualization/test_report.py
@@ -22,9 +22,11 @@ def test_visualization_report_uses_analysis_report() -> None:
 
     markdown = generate_markdown_report(report)
     table = create_analysis_table(report)
+    console = Console(record=True)
+    console.print(table)
 
     assert "Solv-0[buyables]" in markdown
-    assert table.row_count > 0
+    assert "Solv-N Evaluation" in console.export_text()
 
 
 def test_restored_visualization_modules_are_importable() -> None:

--- a/tests/workflow/test_analyze.py
+++ b/tests/workflow/test_analyze.py
@@ -218,7 +218,11 @@ def test_reconstruction_diagnostics_use_useful_top_k_candidates() -> None:
     assert report.metrics["acceptable_root_reconstruction_top_1[task]"].value == 1.0
     assert report.metrics["acceptable_prefix_reconstruction_depth_1_top_1[task]"].value == 1.0
     assert report.metrics["acceptable_reconstruction_given_root_top_1[task]"].value == 0.0
-    assert report.metrics["distinct_root_reactions_top_2[task]"].value == 2.0
+    distinct_roots = report.metrics["distinct_root_reactions_top_2[task]"]
+    assert distinct_roots.value == 2.0
+    assert distinct_roots.ci_low is None
+    assert distinct_roots.ci_high is None
+    assert distinct_roots.reliability is None
 
 
 def test_analyze_stratifies_by_primary_acceptable_route_depth() -> None:

--- a/tests/workflow/test_analyze.py
+++ b/tests/workflow/test_analyze.py
@@ -37,6 +37,12 @@ def route() -> Route:
     return Route(target=molecule("CCO", product_of=Reaction(reactants=[molecule("C"), molecule("CO")])))
 
 
+def route_from_reactants(*reactant_smiles: str) -> Route:
+    return Route(
+        target=molecule("CCO", product_of=Reaction(reactants=[molecule(smiles) for smiles in reactant_smiles]))
+    )
+
+
 def route_with_depth(depth: int) -> Route:
     current = molecule("C")
     for _ in range(depth):
@@ -54,10 +60,15 @@ def target(target_id: str, *, acceptable_routes: list[Route] | None = None) -> T
     )
 
 
-def solved_candidate(rank: int, *, matches_acceptable: bool = False) -> ScoredCandidate:
+def solved_candidate(
+    rank: int,
+    *,
+    candidate_route: Route | None = None,
+    matches_acceptable: bool = False,
+) -> ScoredCandidate:
     return ScoredCandidate(
         rank=rank,
-        route=route(),
+        route=candidate_route or route(),
         validity=RouteValidity(tiers={Tier.ZERO: TierResult(status=CheckStatus.PASS)}),
         constraints=ConstraintResult(status=CheckStatus.PASS),
         matches_acceptable=matches_acceptable,
@@ -181,6 +192,33 @@ def test_top_k_reconstruction_ranks_after_task_satisfaction_filtering() -> None:
 
     assert report.metrics["acceptable_reconstruction_top_1[task]"].value == 0.0
     assert report.metrics["acceptable_reconstruction_top_2[task]"].value == 1.0
+
+
+def test_reconstruction_diagnostics_use_useful_top_k_candidates() -> None:
+    acceptable_route = route_from_reactants("C", "CO")
+    same_root_candidate = route_from_reactants("CO", "C")
+    different_root_candidate = route_from_reactants("CC", "O")
+    report = analyze(
+        evaluation(
+            {
+                "ethanol": result(
+                    target("ethanol", acceptable_routes=[acceptable_route]),
+                    [
+                        solved_candidate(1, candidate_route=same_root_candidate),
+                        solved_candidate(2, candidate_route=different_root_candidate),
+                    ],
+                )
+            }
+        ),
+        ks=(1, 2),
+        prefix_depths=(1,),
+    )
+
+    assert report.metrics["acceptable_reconstruction_top_1[task]"].value == 0.0
+    assert report.metrics["acceptable_root_reconstruction_top_1[task]"].value == 1.0
+    assert report.metrics["acceptable_prefix_reconstruction_depth_1_top_1[task]"].value == 1.0
+    assert report.metrics["acceptable_reconstruction_given_root_top_1[task]"].value == 0.0
+    assert report.metrics["distinct_root_reactions_top_2[task]"].value == 2.0
 
 
 def test_analyze_stratifies_by_primary_acceptable_route_depth() -> None:


### PR DESCRIPTION
## why

analyze had one blunt acceptable-route reconstruction number, which made it hard to tell whether a planner was missing the whole route, missing the root disconnection, or finding plausible partial structure without full reconstruction.

## what changed

adds reconstruction diagnostics for root-reaction hits, full-route reconstruction conditioned on root hits, route prefix hits at configurable depths, and distinct useful root reactions in the top-k window. the analyze workflow carries the evaluation match level into those comparisons, records bootstrap resample count in reports, and renders the new diagnostics in the cli and markdown report outputs.

the cli now batches analyze jobs behind a transient progress display and exposes `--prefix-depth` for the new prefix diagnostics.

## risk

risk is mostly metric semantics and report shape. the metric code keeps the existing task-satisfaction filter and top-k window before computing diagnostics, and `score` now preserves the acceptable-match level in the serialized evaluation so analyze compares roots/prefixes on the same identity basis as acceptable-route scoring.

no data writes, cache invalidation, external calls, or migrations are changed.

## verification

- `uv run pytest tests/workflow/test_analyze.py tests/cli/test_report.py tests/visualization/test_report.py`
- `uv run pytest`
- `uv run ruff check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933637&installation_id=125602297&pr_number=121&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F121&signature=3cd71b9f0b66df53c079efb45e4745fa323504e9d9df40c4fe030879de89575f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--prefix-depth` CLI flag for customizing prefix-depth reconstruction diagnostics in the `analyze` command
  * Enhanced analysis reports with detailed route reconstruction metrics, including prefix-depth breakdowns, root-reaction analysis, and distinct root counts
  * Improved analysis table output with structured reconstruction diagnostics and reliability indicators

* **Documentation**
  * Updated CLI guides and API documentation to describe new prefix-depth reconstruction parameters and metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four reconstruction diagnostics to the `analyze` workflow \u2014 root-reaction hit rate, full-route reconstruction conditioned on a root hit, prefix reconstruction at configurable depths, and mean distinct root reactions \u2014 and wires `acceptable_match_level` from `Evaluation` into all comparisons so root/prefix checks use the same molecular identity basis as acceptable-route scoring.

- **Metrics**: `summarize_targets` now emits `acceptable_root_reconstruction_top_k`, `acceptable_reconstruction_given_root_top_k`, `acceptable_prefix_reconstruction_depth_d_top_k`, and `distinct_root_reactions_top_k` for every k/depth combination; the route-given-root denominator intentionally varies per k.
- **CLI**: `handle_analyze` collects all jobs, runs them behind a transient progress bar, then prints results; `--prefix-depth` is added; the single table is split into Solv-N, Route Reconstruction, and Runtime sub-tables.
- **Models**: `Evaluation.acceptable_match_level` and `AnalysisReport.bootstrap_resamples` are new serialized fields, both backward-compatible via their defaults.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no data writes, migrations, or external calls are touched; the new fields on Evaluation and AnalysisReport default back to existing behaviour for old serialized files.

The core metric logic is well-structured: reaction signatures sort reactants before hashing (making root-hit comparisons order-invariant), Route.signature() is safe to call at any depth without exception guards, and the route-given-root denominator shift is intentional and consistent with the documented semantics. The two observations flagged are minor display and API-surface nits that do not affect correctness.

No files require special attention. src/retrocast/cli/report.py has the compact-CI display issue but it is cosmetic only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/metrics/analysis.py | Adds four new reconstruction diagnostic computations (root hit, route-given-root, prefix reconstruction, distinct roots). Logic is correct: `_task_satisfying_top_k` filters properly before comparisons, reaction signatures are order-invariant (via sorted reactants in `ReactionView.key`), and the route-given-root metric's variable denominator is consistent with its documented semantics. |
| src/retrocast/cli/report.py | Major refactor splitting the single analysis table into separate solv/reconstruction/runtime tables rendered as a Rich Group. Compact CI format drops the `%` sign for rate metrics, producing cells like "75.0%\n[50.0, 75.0]" where the interval could be misread as decimal bounds. |
| src/retrocast/metrics/bootstrap.py | Adds `reliability: bool = True` parameter to `summarize_values`. Parameter is correct but never invoked with `reliability=False` — the one metric that skips reliability (`distinct_root_reactions`) uses `_mean_summary` instead. |
| src/retrocast/workflow/analyze.py | Threads `prefix_depths` and `acceptable_match_level` through to `summarize_targets`, and stores `n_boot` in `bootstrap_resamples` on the returned report. Clean and straightforward. |
| src/retrocast/cli/main.py | Refactors `handle_analyze` to collect all jobs first, run them behind a transient progress bar, then print results. Adds `--prefix-depth` CLI argument wired through to `analyze()`. Manifest now records `prefix_depth` parameter. |
| src/retrocast/models/evaluation.py | Adds `acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL` to `Evaluation`. Default preserves backward compatibility with existing serialized evaluations. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[analyze workflow] --> B[summarize_targets]
    B --> C{reconstruction_targets?}
    C -- yes --> D[for each k in ks]
    D --> E[acceptable_reconstruction_top_k]
    D --> F[acceptable_root_reconstruction_top_k]
    D --> G[acceptable_reconstruction_given_root_top_k]
    D --> H[distinct_root_reactions_top_k - no CI]
    D --> I[for each depth in prefix_depths]
    I --> J[acceptable_prefix_reconstruction_depth_d_top_k]
    C -- no --> K[skip reconstruction metrics]
    B --> L[AnalysisReport]
    L --> M[CLI: create_analysis_table - Group]
    M --> N[Solv-N Table]
    M --> O[Reconstruction Table]
    M --> P[Runtime Table]
    L --> Q[generate_markdown_report]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/retrocast/cli/report.py:600-605
**Compact CI drops `%` units for rate metrics**

`_format_compact_ci` multiplies the raw CI bounds by 100 but omits the `%` sign, so a rate metric cell renders as `"75.0%\n[50.0, 75.0]"` — the value is a percentage but the interval looks like a plain number. Readers expecting `[50.0%, 75.0%]` may misread the CI bounds as absolute or decimal values. The full `_format_ci` path preserves the `%` sign; keeping parity here (`f"[{metric.ci_low * 100:.1f}%, {metric.ci_high * 100:.1f}%]"`) would avoid the mismatch.

### Issue 2 of 2
src/retrocast/metrics/bootstrap.py:48-56
**`reliability=False` path is unreachable from current callers**

The new `reliability` parameter was added to `summarize_values`, and `reconstruction_summary` exposes it as well, but every call site in `summarize_targets` invokes `reconstruction_summary(values)` with the default `reliability=True`. The only metric that intentionally suppresses reliability — `distinct_root_reactions` — bypasses `summarize_values` entirely via `_mean_summary`. As-is, `reliability=False` is dead code. If the plan is to wire it up later, a brief comment would clarify the intent; if not, the parameter adds noise to the API surface.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: tighten analyze diagnostic reportin..."](https://github.com/ischemist/project-procrustes/commit/3e163cbf86a92fb159b936e6b066c3cb5e9e8cd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34981025)</sub>

<!-- /greptile_comment -->