### PR TITLE
feat: support prefix route reconstruction scoring

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -161,8 +161,10 @@ Options:
 | `--stock-name` | Stock label to write into task constraints; defaults to the stock filename stem |
 | `--model-name` | Optional model label for manifest metadata |
 | `--ignore-stereo` | Use stereo-agnostic stock and acceptable-route matching |
+| `--acceptable-route-match prefix\|exact` | Match acceptable routes by target-rooted prefix (default) or exact full-route identity |
 
 `score-file` writes an `Evaluation` artifact. Tier-0 validity comes from adaptation success or failure; task satisfaction comes from the configured constraints.
+`--acceptable-route-match` is applied when this artifact is scored; rerunning `analyze` on an existing `Evaluation` does not retroactively change its stored acceptable-route matches.
 
 ### `compare pareto-frontier` - Compare Reports
 
@@ -295,8 +297,11 @@ Useful options:
 | Option            | Meaning                                                      |
 | ----------------- | ------------------------------------------------------------ |
 | `--ignore-stereo` | Use stereo-agnostic stock and acceptable-route matching      |
+| `--acceptable-route-match prefix\|exact` | Match acceptable routes by target-rooted prefix (default) or exact full-route identity |
 | `--all-models`    | Score all processed models for the selected dataset(s)       |
 | `--all-datasets`  | Score the selected model(s) across all benchmark definitions |
+
+`--acceptable-route-match` is applied when the `Evaluation` is scored; rerun `score` before `analyze` to apply different matching semantics to existing processed candidates.
 
 Input:
 

--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -525,6 +525,8 @@ class TargetResult(BaseModel):
 class Evaluation(BaseModel):
     task: Task
     tiers: list[Tier] = Field(default_factory=list)
+    acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.EXACT
     targets: dict[str, TargetResult] = Field(default_factory=dict)
     schema_version: str = "2"
 ```
@@ -569,6 +571,7 @@ def score_candidate(
     tier_checkers: Sequence[TierChecker],
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
 ) -> ScoredCandidate: ...
 
 
@@ -580,6 +583,7 @@ def score_target(
     tier_checkers: Sequence[TierChecker],
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
 ) -> TargetResult: ...
 
 
@@ -590,6 +594,7 @@ def score(
     tier_checkers: Sequence[TierChecker],
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
 ) -> Evaluation: ...
 ```
 
@@ -620,4 +625,4 @@ analyze(
 ) -> AnalysisReport
 ```
 
-Top-K reconstruction metrics are emitted only for targets with acceptable_routes; if no target has acceptable_routes, reconstruction metrics are omitted. Reconstruction diagnostics use `Evaluation.acceptable_match_level`, so full-route, root-reaction, and prefix comparisons stay on the same molecular identity basis.
+Top-K reconstruction metrics are emitted only for targets with acceptable_routes; if no target has acceptable_routes, reconstruction metrics are omitted. Reconstruction diagnostics use `Evaluation.acceptable_match_level`, so route, root-reaction, and prefix comparisons stay on the same molecular identity basis. `Evaluation.acceptable_route_match` records whether headline acceptable-route reconstruction used target-rooted prefix matching or exact full-route identity. Its model default is `EXACT` so legacy artifacts without the field are interpreted according to their original scoring semantics; new scoring writes the selected mode explicitly.

--- a/docs/rationale/solv-n-evaluation.md
+++ b/docs/rationale/solv-n-evaluation.md
@@ -59,7 +59,9 @@ This is measured by mean-reverse rank (MRR@Solv-N) metric.
 
 In the absence of automated Tier-2 validity checks, as a temporary proxy of full chemical validity we test whether a model can reconstruct an existing, experimentally-verified route for a novel target.
 
-Top-K accuracy measures if an experimentally verified `Route` is present within first `k` `Routes` returned by the model.
+Top-K accuracy measures if an experimentally verified `Route` is reconstructed within first `k` `Routes` returned by the model. A candidate reconstructs an acceptable route when the acceptable route is a target-rooted prefix of the candidate route: `candidate.signature(depth=acceptable.depth()) == acceptable.signature()`, with the candidate at least as deep as the acceptable route. This avoids penalizing a planner that recovers the reference route and then continues expanding below a reference leaf.
+
+Exact full-route identity remains available at scoring time through `acceptable_route_match="exact"` / `--acceptable-route-match exact`, but prefix matching is the default reported reconstruction semantics.
 
 As proposed in the original [RetroCast preprint](https://arxiv.org/abs/2512.07079), we utilize a user-centric evaluation approach. As such, the ranking is performed **after** Routes are filtered for satisfaction of the problem scope (because Routes that do not satisfy them are of no interest to the user).
 
@@ -70,6 +72,6 @@ Notably, this means that `Top-1` accuracy should not be the headline metric.
 `analyze` also reports reconstruction diagnostics that preserve the same task-satisfaction filter and top-k window:
 
 - `acceptable_root_reconstruction_top_k[...]`: fraction of targets where a useful top-k candidate has the same root reaction as any acceptable route.
-- `acceptable_reconstruction_given_root_top_k[...]`: full-route reconstruction rate among targets with a root hit. Its denominator is targets, not candidate routes.
+- `acceptable_reconstruction_given_root_top_k[...]`: acceptable-route reconstruction rate among targets with a root hit. Its denominator is targets, not candidate routes.
 - `acceptable_prefix_reconstruction_depth_d_top_k[...]`: fraction of targets where a useful top-k candidate matches an acceptable route prefix by `Route.signature(depth=d)`.
 - `distinct_root_reactions_top_k[...]`: mean number of distinct root reaction signatures among useful top-k candidates.

--- a/src/retrocast/cli/main.py
+++ b/src/retrocast/cli/main.py
@@ -55,6 +55,7 @@ from retrocast.typing import InChIKeyStr
 from retrocast.utils.logging import configure_script_logging
 from retrocast.utils.timing import ExecutionStats
 from retrocast.workflow import (
+    AcceptableRouteMatch,
     adapt_candidates,
     analyze,
     collect_candidates,
@@ -148,6 +149,7 @@ def _build_parser() -> argparse.ArgumentParser:
     score_file.add_argument("--stock-name", help="Stock label to write into task constraints")
     score_file.add_argument("--model-name", help="Optional model label for manifest metadata")
     score_file.add_argument("--ignore-stereo", action="store_true", help="Use stereo-agnostic stock matching")
+    _add_acceptable_route_match_arg(score_file)
 
     compare_parser = subparsers.add_parser("compare", help="Compare schema v2 analysis reports")
     compare_subparsers = compare_parser.add_subparsers(dest="compare_command", required=True)
@@ -168,6 +170,7 @@ def _build_parser() -> argparse.ArgumentParser:
     score_parser = subparsers.add_parser("score", help="Score v2 processed candidates")
     _add_model_dataset_args(score_parser)
     score_parser.add_argument("--ignore-stereo", action="store_true", help="Use stereo-agnostic stock matching")
+    _add_acceptable_route_match_arg(score_parser)
 
     analyze_parser = subparsers.add_parser("analyze", help="Analyze v2 evaluation artifacts")
     _add_model_dataset_args(analyze_parser)
@@ -191,6 +194,15 @@ def _non_negative_int(value: str) -> int:
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be non-negative")
     return parsed
+
+
+def _add_acceptable_route_match_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--acceptable-route-match",
+        choices=[mode.value for mode in AcceptableRouteMatch],
+        default=AcceptableRouteMatch.PREFIX.value,
+        help="How predicted routes are matched against acceptable routes for reconstruction metrics",
+    )
 
 
 def _add_model_dataset_args(parser: argparse.ArgumentParser) -> None:
@@ -271,6 +283,7 @@ def handle_score_file(args: argparse.Namespace) -> None:
             match_level=match_level,
         ),
         acceptable_match_level=match_level,
+        acceptable_route_match=AcceptableRouteMatch(args.acceptable_route_match),
     )
     save_evaluation(evaluation, args.output)
     write_manifest(
@@ -283,6 +296,7 @@ def handle_score_file(args: argparse.Namespace) -> None:
             "stock": stock_name,
             "model_name": args.model_name,
             "ignore_stereo": args.ignore_stereo,
+            "acceptable_route_match": args.acceptable_route_match,
         },
         statistics=evaluation_statistics(evaluation),
     )
@@ -445,6 +459,7 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
             match_level=match_level,
         ),
         acceptable_match_level=match_level,
+        acceptable_route_match=AcceptableRouteMatch(args.acceptable_route_match),
         execution_stats=_load_execution_stats_if_present(_execution_stats_path(paths, model_name, benchmark_name)),
     )
 
@@ -466,6 +481,7 @@ def _score_one(model_name: str, benchmark_name: str, paths: dict[str, Path], arg
             "benchmark": benchmark_name,
             "stock": output_label,
             "ignore_stereo": args.ignore_stereo,
+            "acceptable_route_match": args.acceptable_route_match,
         },
         statistics=evaluation_statistics(evaluation),
     )

--- a/src/retrocast/cli/report.py
+++ b/src/retrocast/cli/report.py
@@ -133,7 +133,7 @@ def _create_reconstruction_table(
         table.add_column(f"Top-{k}", justify="center", no_wrap=True)
 
     rows = [
-        ("Full route", [metric_cell(_TOP_K, k) for k in ks]),
+        ("Acceptable route", [metric_cell(_TOP_K, k) for k in ks]),
         ("Root reaction", [metric_cell(_ROOT_TOP_K, k) for k in ks]),
         ("Route | root", [metric_cell(_GIVEN_ROOT_TOP_K, k) for k in ks]),
         *[(f"Prefix {depth}", [prefix_cell(k, depth) for k in ks]) for depth in depths],
@@ -260,7 +260,7 @@ def _markdown_reconstruction_diagnostics(
         return ""
 
     diagnostics: list[tuple[str, re.Pattern[str]]] = [
-        ("Full route", _TOP_K),
+        ("Acceptable route", _TOP_K),
         ("Root reaction", _ROOT_TOP_K),
         ("Route given root", _GIVEN_ROOT_TOP_K),
         ("Mean distinct roots", _DISTINCT_ROOT_TOP_K),

--- a/src/retrocast/models/__init__.py
+++ b/src/retrocast/models/__init__.py
@@ -3,6 +3,7 @@
 from retrocast.models.analysis import AnalysisReport, MetricSummary, ReliabilityFlag
 from retrocast.models.candidates import Candidate, FailureRecord
 from retrocast.models.evaluation import (
+    AcceptableRouteMatch,
     CheckResult,
     CheckStatus,
     ConstraintResult,
@@ -31,6 +32,7 @@ from retrocast.models.task import Benchmark, Target, Task, TaskConstraints
 
 __all__ = [
     "AnalysisReport",
+    "AcceptableRouteMatch",
     "Benchmark",
     "Candidate",
     "CheckResult",

--- a/src/retrocast/models/evaluation.py
+++ b/src/retrocast/models/evaluation.py
@@ -23,6 +23,11 @@ class Tier(IntEnum):
     THREE = 3
 
 
+class AcceptableRouteMatch(StrEnum):
+    PREFIX = "prefix"
+    EXACT = "exact"
+
+
 class CheckResult(BaseModel):
     code: str
     status: CheckStatus = CheckStatus.FAIL
@@ -105,5 +110,6 @@ class Evaluation(BaseModel):
     tiers: list[Tier] = Field(default_factory=list)
     metric_label: str = "task"
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.EXACT
     targets: dict[str, TargetResult] = Field(default_factory=dict)
     schema_version: Literal["2"] = "2"

--- a/src/retrocast/workflow/__init__.py
+++ b/src/retrocast/workflow/__init__.py
@@ -1,5 +1,6 @@
 """Schema v2 workflow APIs."""
 
+from retrocast.models.evaluation import AcceptableRouteMatch
 from retrocast.workflow.adapt import adapt_candidates, adapt_route, adapt_routes
 from retrocast.workflow.analyze import analyze
 from retrocast.workflow.collect import (
@@ -23,6 +24,7 @@ __all__ = [
     "CollectedRoutes",
     "ConstraintChecker",
     "CandidateRunStatistics",
+    "AcceptableRouteMatch",
     "TierChecker",
     "adapt_candidates",
     "adapt_route",

--- a/src/retrocast/workflow/score.py
+++ b/src/retrocast/workflow/score.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Protocol, cast
 
 from retrocast.exceptions import UnsupportedValidityTierError
 from retrocast.models.candidates import Candidate
 from retrocast.models.evaluation import (
+    AcceptableRouteMatch,
     CheckResult,
     CheckStatus,
     ConstraintResult,
@@ -34,6 +36,13 @@ class ConstraintChecker(Protocol):
     def check_route(self, route: Route, constraints: TaskConstraints) -> ConstraintResult: ...
 
 
+@dataclass(frozen=True, slots=True)
+class AcceptableRouteIdentity:
+    index: int
+    depth: int
+    signature: str
+
+
 def score_candidate(
     candidate: Candidate,
     *,
@@ -42,7 +51,8 @@ def score_candidate(
     tier_checkers: Sequence[TierChecker],
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
-    _acceptable_signatures: Sequence[str] | None = None,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
+    _acceptable_identities: Sequence[AcceptableRouteIdentity] | None = None,
 ) -> ScoredCandidate:
     """Score one candidate while preserving failed adaptation slots."""
     validity = _tier_zero_validity(candidate)
@@ -57,12 +67,14 @@ def score_candidate(
     route = cast(Route, candidate.route)
     _check_route_validity(route, tier_checkers, validity)
     constraints_result = constraint_checker.check_route(route, constraints)
-    acceptable_signatures = (
-        _acceptable_signatures
-        if _acceptable_signatures is not None
-        else _acceptable_route_signatures(target.acceptable_routes, acceptable_match_level)
+    acceptable_identities = (
+        _acceptable_identities
+        if _acceptable_identities is not None
+        else _acceptable_route_identities(target.acceptable_routes, acceptable_match_level)
     )
-    matched_index = _acceptable_match_index(route, acceptable_signatures, acceptable_match_level)
+    matched_index = _acceptable_match_index(
+        route, acceptable_identities, acceptable_match_level, acceptable_route_match
+    )
     return ScoredCandidate(
         rank=candidate.rank,
         route=route,
@@ -81,11 +93,12 @@ def score_target(
     tier_checkers: Sequence[TierChecker],
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
     wall_time: float | None = None,
     cpu_time: float | None = None,
 ) -> TargetResult:
     scored_candidates = []
-    acceptable_signatures = _acceptable_route_signatures(target.acceptable_routes, acceptable_match_level)
+    acceptable_identities = _acceptable_route_identities(target.acceptable_routes, acceptable_match_level)
     for candidate in candidates:
         scored_candidate = score_candidate(
             candidate,
@@ -94,7 +107,8 @@ def score_target(
             tier_checkers=tier_checkers,
             constraint_checker=constraint_checker,
             acceptable_match_level=acceptable_match_level,
-            _acceptable_signatures=acceptable_signatures,
+            acceptable_route_match=acceptable_route_match,
+            _acceptable_identities=acceptable_identities,
         )
         scored_candidates.append(scored_candidate)
 
@@ -114,6 +128,7 @@ def score(
     tier_checkers: Sequence[TierChecker] = (),
     constraint_checker: ConstraintChecker,
     acceptable_match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+    acceptable_route_match: AcceptableRouteMatch = AcceptableRouteMatch.PREFIX,
     execution_stats: ExecutionStats | None = None,
 ) -> Evaluation:
     tiers = [Tier.ZERO, *sorted({checker.tier for checker in tier_checkers})]
@@ -127,6 +142,7 @@ def score(
             tier_checkers=tier_checkers,
             constraint_checker=constraint_checker,
             acceptable_match_level=acceptable_match_level,
+            acceptable_route_match=acceptable_route_match,
             wall_time=execution_stats.wall_time.get(target_id) if execution_stats is not None else None,
             cpu_time=execution_stats.cpu_time.get(target_id) if execution_stats is not None else None,
         )
@@ -135,6 +151,7 @@ def score(
         tiers=tiers,
         metric_label=task.derived_metric_label(),
         acceptable_match_level=acceptable_match_level,
+        acceptable_route_match=acceptable_route_match,
         targets=target_results,
     )
 
@@ -181,15 +198,39 @@ def _check_route_validity(route: Route, tier_checkers: Sequence[TierChecker], va
 
 def _acceptable_match_index(
     route: Route,
-    acceptable_signatures: Sequence[str],
+    acceptable_identities: Sequence[AcceptableRouteIdentity],
     match_level: InChIKeyLevel,
+    route_match: AcceptableRouteMatch,
 ) -> int | None:
-    route_signature = route.signature(match_level)
-    for index, acceptable_signature in enumerate(acceptable_signatures):
-        if route_signature == acceptable_signature:
-            return index
-    return None
+    if route_match == AcceptableRouteMatch.EXACT:
+        route_signature = route.signature(match_level)
+        for identity in acceptable_identities:
+            if route_signature == identity.signature:
+                return identity.index
+        return None
+
+    if route_match == AcceptableRouteMatch.PREFIX:
+        route_depth = route.depth()
+        route_signatures_by_depth: dict[int, str] = {}
+        best: AcceptableRouteIdentity | None = None
+        for identity in acceptable_identities:
+            if route_depth < identity.depth:
+                continue
+            if identity.depth not in route_signatures_by_depth:
+                route_signatures_by_depth[identity.depth] = route.signature(match_level, depth=identity.depth)
+            route_signature = route_signatures_by_depth[identity.depth]
+            if route_signature == identity.signature and (best is None or identity.depth >= best.depth):
+                best = identity
+        return best.index if best is not None else None
+
+    raise ValueError(f"unsupported acceptable route match mode: {route_match}")
 
 
-def _acceptable_route_signatures(acceptable_routes: Sequence[Route], match_level: InChIKeyLevel) -> list[str]:
-    return [route.signature(match_level) for route in acceptable_routes]
+def _acceptable_route_identities(
+    acceptable_routes: Sequence[Route],
+    match_level: InChIKeyLevel,
+) -> tuple[AcceptableRouteIdentity, ...]:
+    return tuple(
+        AcceptableRouteIdentity(index=index, depth=route.depth(), signature=route.signature(match_level))
+        for index, route in enumerate(acceptable_routes)
+    )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -258,14 +258,20 @@ def test_v2_project_cli_ingest_score_analyze(tmp_path, monkeypatch) -> None:
         str(score_file_path),
         "--model-name",
         "test-model",
+        "--acceptable-route-match",
+        "exact",
     )
-    assert load_evaluation(score_file_path).targets["ethanol"].candidates[0].satisfies_task()
-    assert (tmp_path / "score-file-evaluation.manifest.json").exists()
+    score_file_evaluation = load_evaluation(score_file_path)
+    assert score_file_evaluation.acceptable_route_match == "exact"
+    assert score_file_evaluation.targets["ethanol"].candidates[0].satisfies_task()
+    score_file_manifest = json.loads((tmp_path / "score-file-evaluation.manifest.json").read_text(encoding="utf-8"))
+    assert score_file_manifest["parameters"]["acceptable_route_match"] == "exact"
 
     run_cli(monkeypatch, "--data-dir", str(data_dir), "score", "--model", "test-model", "--dataset", "small")
     evaluation_path = data_dir / "4-scored" / "small" / "test-model" / "test-stock" / "evaluation.json.gz"
     evaluation = load_evaluation(evaluation_path)
     assert evaluation.schema_version == "2"
+    assert evaluation.acceptable_route_match == "prefix"
     assert evaluation.targets["ethanol"].candidates[0].satisfies_task()
     assert evaluation.targets["ethanol"].wall_time == 12.5
     assert evaluation.targets["ethanol"].cpu_time == 3.25

--- a/tests/workflow/test_score.py
+++ b/tests/workflow/test_score.py
@@ -8,6 +8,7 @@ from retrocast.models import (
     Candidate,
     CheckStatus,
     ConstraintResult,
+    Evaluation,
     FailureRecord,
     Molecule,
     Reaction,
@@ -22,7 +23,7 @@ from retrocast.models import (
 )
 from retrocast.typing import ErrorCode, InChIKeyStr, SmilesStr
 from retrocast.utils.timing import ExecutionStats
-from retrocast.workflow.score import score, score_candidate
+from retrocast.workflow.score import AcceptableRouteMatch, score, score_candidate
 
 
 class FixedTierChecker:
@@ -223,9 +224,129 @@ def test_score_preserves_candidate_rank_and_records_acceptable_match() -> None:
 
     scored = evaluation.targets["ethanol"].candidates[0]
     assert evaluation.tiers == [Tier.ZERO, Tier.ONE]
+    assert evaluation.acceptable_route_match == AcceptableRouteMatch.PREFIX
     assert scored.rank == 7
     assert scored.matches_acceptable
     assert scored.matched_acceptable_index == 1
+
+
+def test_score_records_acceptable_match_when_reference_is_prediction_prefix() -> None:
+    acceptable_route = route(reactant_smiles=("C", "CO"))
+    predicted_route = Route(
+        target=molecule(
+            "CCO",
+            product_of=Reaction(
+                reactants=[
+                    molecule("C", product_of=Reaction(reactants=[molecule("N")])),
+                    molecule("CO"),
+                ]
+            ),
+        )
+    )
+    benchmark_target = target(acceptable_routes=[acceptable_route])
+
+    scored = score_candidate(
+        Candidate(rank=1, route=predicted_route),
+        target=benchmark_target,
+        constraints=TaskConstraints(),
+        tier_checkers=[],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert predicted_route.signature() != acceptable_route.signature()
+    assert scored.matches_acceptable
+    assert scored.matched_acceptable_index == 0
+
+
+def test_score_prefers_deepest_acceptable_prefix_match() -> None:
+    shallow_route = route(reactant_smiles=("C", "CO"))
+    deep_route = Route(
+        target=molecule(
+            "CCO",
+            product_of=Reaction(
+                reactants=[
+                    molecule("C", product_of=Reaction(reactants=[molecule("N")])),
+                    molecule("CO"),
+                ]
+            ),
+        )
+    )
+    benchmark_target = target(acceptable_routes=[shallow_route, deep_route])
+
+    scored = score_candidate(
+        Candidate(rank=1, route=deep_route),
+        target=benchmark_target,
+        constraints=TaskConstraints(),
+        tier_checkers=[],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert scored.matches_acceptable
+    assert scored.matched_acceptable_index == 1
+
+
+def test_score_can_require_exact_acceptable_route_match() -> None:
+    acceptable_route = route(reactant_smiles=("C", "CO"))
+    predicted_route = Route(
+        target=molecule(
+            "CCO",
+            product_of=Reaction(
+                reactants=[
+                    molecule("C", product_of=Reaction(reactants=[molecule("N")])),
+                    molecule("CO"),
+                ]
+            ),
+        )
+    )
+    benchmark_target = target(acceptable_routes=[acceptable_route])
+
+    scored = score_candidate(
+        Candidate(rank=1, route=predicted_route),
+        target=benchmark_target,
+        constraints=TaskConstraints(),
+        tier_checkers=[],
+        constraint_checker=FixedConstraintChecker(),
+        acceptable_route_match=AcceptableRouteMatch.EXACT,
+    )
+
+    assert not scored.matches_acceptable
+    assert scored.matched_acceptable_index is None
+
+
+def test_legacy_evaluation_defaults_to_exact_acceptable_route_match() -> None:
+    benchmark_target = target()
+
+    evaluation = Evaluation(task=task(benchmark_target))
+
+    assert evaluation.acceptable_route_match == AcceptableRouteMatch.EXACT
+
+
+def test_score_does_not_match_candidate_shorter_than_reference_route() -> None:
+    acceptable_route = Route(
+        target=molecule(
+            "CCO",
+            product_of=Reaction(
+                reactants=[
+                    molecule("C", product_of=Reaction(reactants=[molecule("N")])),
+                    molecule("CO"),
+                ]
+            ),
+        )
+    )
+    predicted_route = route(reactant_smiles=("C", "CO"))
+    benchmark_target = target(acceptable_routes=[acceptable_route])
+
+    scored = score_candidate(
+        Candidate(rank=1, route=predicted_route),
+        target=benchmark_target,
+        constraints=TaskConstraints(),
+        tier_checkers=[],
+        constraint_checker=FixedConstraintChecker(),
+    )
+
+    assert predicted_route.signature(depth=predicted_route.depth()) != acceptable_route.signature()
+    assert not scored.matches_acceptable
+    assert scored.matched_acceptable_index is None
 
 
 def test_score_records_metric_label_from_task() -> None:


### PR DESCRIPTION
## why

Top-K acceptable-route reconstruction was using exact full-route identity. That undercounts planners that recover the reference route from the target downward but keep expanding below a reference leaf, which is a termination-choice artifact rather than a failure to reconstruct the reference route.

## what changed

Scoring now treats the default acceptable-route match as target-rooted prefix identity: the predicted route must be at least as deep as the acceptable route, and its `Route.signature(depth=acceptable.depth())` must match the acceptable route signature.

Exact full-route identity remains available through `--acceptable-route-match exact` and the library-level `AcceptableRouteMatch.EXACT`. The selected mode is persisted on `Evaluation` artifacts and score manifests so downstream analyses can distinguish prefix-scored and exact-scored runs. Reports use mode-neutral acceptable-route labeling, while the fixed-depth prefix diagnostics remain separate.

## risk

The main behavior change is metric semantics for newly scored evaluations. Existing evaluation artifacts are not rewritten. `analyze` still reads `matches_acceptable` from the stored evaluation, so users must rescore to get prefix semantics. The exact opt-in keeps the old behavior available for audits or comparisons.

## verification

- `uv run ruff check src tests docs scripts`
- `uv run --extra viz ty check src/retrocast`
- `uv run --extra viz pytest` (`709 passed`)

## follow-ups

Existing benchmark result artifacts should be regenerated where comparisons need the new default reconstruction semantics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782940338&installation_id=125602297&pr_number=122&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F122&signature=d197ee0e60e5a5d9ec8082ba63912adb704e3cb72cd9fb6bcabef442ce43965c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--acceptable-route-match` CLI option to `score-file` and `score` commands, allowing selection between "prefix" (default) and "exact" route matching modes for evaluation.

* **Documentation**
  * Updated CLI guide, schema design, and evaluation documentation to describe route matching configuration and its effects on scoring results.

* **Tests**
  * Added test coverage for prefix and exact route matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the default Top-K acceptable-route reconstruction metric from exact full-route identity to target-rooted prefix matching: a candidate now counts as reconstructing an acceptable route when its `Route.signature(depth=acceptable.depth())` matches the acceptable route's signature and the candidate is at least as deep. Exact matching is preserved via `--acceptable-route-match exact` / `AcceptableRouteMatch.EXACT`. The selected mode is written to `Evaluation` artifacts and score manifests; the Pydantic model default remains `EXACT` so legacy artifacts (which lack the field) deserialize with the historically correct semantics.

- **`_acceptable_route_identities`** pre-computes depth and full signature per acceptable route once per target; `_acceptable_match_index` caches the candidate's prefix signatures by depth per call, keeping complexity proportional to the number of unique acceptable-route depths rather than O(candidates × acceptable_routes).
- **`AcceptableRouteMatch`** is a `StrEnum` added to `Evaluation`, exported from both `retrocast.models` and `retrocast.workflow`, and wired into both `score-file` and `score` CLI commands with `prefix` as the CLI default.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the behaviour change is opt-in for existing artifacts (legacy JSON lacking the field deserialises to EXACT), and the new prefix logic is well-tested end-to-end.

The backward-compatibility story is solid: the Evaluation model default is EXACT, so no pre-existing artifact is silently re-labelled. New scorings write the mode explicitly. The only open question is tie-breaking in PREFIX mode (last vs. first match at equal depth), which affects only matched_acceptable_index, not matches_acceptable.

src/retrocast/workflow/score.py — specifically the >= comparison in _acceptable_match_index for the PREFIX branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/workflow/score.py | Core scoring logic refactored to support prefix vs. exact acceptable-route matching; AcceptableRouteIdentity dataclass introduced, identities pre-computed per target, and per-candidate depth caching added. One subtle tie-breaking edge case with >= in PREFIX mode. |
| src/retrocast/models/evaluation.py | Added AcceptableRouteMatch StrEnum and acceptable_route_match field to Evaluation, correctly defaulting to EXACT for backward compatibility with legacy artifacts. |
| src/retrocast/cli/main.py | Adds --acceptable-route-match CLI argument to score-file and score commands via a shared helper; argument is wired through to score() and persisted to manifests. |
| tests/workflow/test_score.py | Good new coverage for prefix matching, exact opt-in, deeper-match preference, candidate-shorter-than-reference guard, and legacy-default assertion. |
| tests/cli/test_cli.py | CLI integration tests verify that --acceptable-route-match is round-tripped into the evaluation and the score manifest, and that the default (prefix) is applied when the flag is omitted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[score / score_target] -->|acceptable_route_match param| B[_acceptable_route_identities\nprecomputed once per target]
    B --> C[score_candidate loop]
    C --> D[_acceptable_match_index]
    D --> E{route_match mode}
    E -->|EXACT| F[compare full route signature\nreturn first match]
    E -->|PREFIX| G[check candidate depth >= acceptable depth\ncache candidate signatures by depth\nreturn deepest match]
    F --> H[ScoredCandidate\nmatches_acceptable\nmatched_acceptable_index]
    G --> H
    H --> I[Evaluation\nacceptable_route_match persisted\nfor downstream analysis]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/retrocast/workflow/score.py:222
When multiple acceptable routes match at the same depth, the `>=` condition causes the last one (by iteration order) to win rather than the first. EXACT mode returns the first match; using `>` here would align the tie-breaking behaviour and make `matched_acceptable_index` predictable when a benchmark defines acceptable routes in priority order.

```suggestion
            if route_signature == identity.signature and (best is None or identity.depth > best.depth):
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: support prefix route reconstructio..."](https://github.com/ischemist/project-procrustes/commit/6c888cac2653e56cb0ce4d88583af812475af1af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35007057)</sub>

<!-- /greptile_comment -->