### PR TITLE
feat: add route content signatures

### DIFF
--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -240,6 +240,21 @@ class Route(BaseModel):
         return stable_hash(self.key(match_level, depth=depth))
 ```
 
+### Content Signatures
+
+The structural `key` / `signature` methods deliberately ignore reaction metadata. This keeps route identity usable across planners and datasets where mapped reaction SMILES, templates, reagents, solvents, or condition labels may be missing or untrustworthy.
+
+Sometimes we want a stricter comparison: same route structure, plus selected first-class reaction content. For that, routes and route-bound views expose `content_key` / `content_signature` methods. The caller must choose which reaction fields matter:
+
+```python
+route.content_signature(fields=("mapped_reaction_smiles",))
+route.content_signature(fields=("template", "reagents", "solvents"))
+```
+
+Content signatures follow the same Merkle shape as structural signatures: molecule identity, reaction identity, selected reaction content, and unordered child signatures. They also support `match_level` and route-prefix `depth` just like structural signatures.
+
+`annotations` are not part of the generic content signature API. They are arbitrary source metadata; dataset-specific identities such as PaRoutes condition slots should stay in the workflow that owns that dataset unless they graduate into first-class `Reaction` fields.
+
 ### Route Embedding
 
 Route embedding asks whether one route occurs inside another route.

--- a/docs/rationale/schema-design.md
+++ b/docs/rationale/schema-design.md
@@ -242,18 +242,16 @@ class Route(BaseModel):
 
 ### Content Signatures
 
-The structural `key` / `signature` methods deliberately ignore reaction metadata. This keeps route identity usable across planners and datasets where mapped reaction SMILES, templates, reagents, solvents, or condition labels may be missing or untrustworthy.
+The structural `key` / `signature` methods answer the basic route question: same molecules, same reaction graph. They do not read mapped reaction SMILES, templates, reagents, solvents, condition labels, or annotations.
 
-Sometimes we want a stricter comparison: same route structure, plus selected first-class reaction content. For that, routes and route-bound views expose `content_key` / `content_signature` methods. The caller must choose which reaction fields matter:
+Sometimes we want a stricter comparison: same structure, plus selected reaction content. For that, routes and route-bound views expose `content_key` / `content_signature` methods. The caller chooses which reaction fields matter:
 
 ```python
 route.content_signature(fields=("mapped_reaction_smiles",))
 route.content_signature(fields=("template", "reagents", "solvents"))
 ```
 
-Content signatures follow the same Merkle shape as structural signatures: molecule identity, reaction identity, selected reaction content, and unordered child signatures. They also support `match_level` and route-prefix `depth` just like structural signatures.
-
-`annotations` are not part of the generic content signature API. They are arbitrary source metadata; dataset-specific identities such as PaRoutes condition slots should stay in the workflow that owns that dataset unless they graduate into first-class `Reaction` fields.
+Content signatures follow the same Merkle shape as structural signatures: molecule identity, reaction identity, selected reaction content, and unordered child signatures. They also support `match_level` and route-prefix `depth`.
 
 ### Route Embedding
 

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -179,13 +179,9 @@ class Molecule(BaseModel):
 
 def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
     """
-    route paths are assigned from sibling positions, so reactants need one
-    canonical order at validation time.
+    RoutePaths depend on the order of reactants, so to ensure that for a chemically unique Route a path is prescriptive, we need to normalize the positions of sibling nodes.
 
-    structural subtree keys usually decide the order by themselves. when two
-    reactants have the same structural key, first-class molecule and reaction
-    fields break the tie. annotations stay out of this because they are carried
-    metadata, not route identity.
+    Sorting uses subtree keys. The tiebreaker compares all route fields we can confidently serialize.
     """
     groups: dict[tuple[Any, ...], list[Molecule]] = {}
     for reactant in reactants:

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -179,12 +179,13 @@ class Molecule(BaseModel):
 
 def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
     """
-    route paths depend on reactant order, so validation canonicalizes the list.
+    route paths are assigned from sibling positions, so reactants need one
+    canonical order at validation time.
 
-    most reactants already have distinct structural subtree keys. for those, the
-    tiebreaker would be dead work. only structurally identical reactants need the
-    first-class payload fallback to get deterministic path assignment; arbitrary
-    annotations are intentionally excluded because they are not route identity.
+    structural subtree keys usually decide the order by themselves. when two
+    reactants have the same structural key, first-class molecule and reaction
+    fields break the tie. annotations stay out of this because they are carried
+    metadata, not route identity.
     """
     groups: dict[tuple[Any, ...], list[Molecule]] = {}
     for reactant in reactants:

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from functools import cache
 from typing import Annotated, Any, Literal
@@ -12,7 +12,19 @@ from retrocast.chem import InChIKeyLevel, reduce_inchikey
 from retrocast.hashing import hash_json
 from retrocast.typing import InChIKeyStr, ReactionSmilesStr, SmilesStr
 
+# section: public route types
+
 RouteNodeKind = Literal["m", "r"]
+ReactionContentField = Literal["mapped_reaction_smiles", "template", "reagents", "solvents"]
+REACTION_CONTENT_FIELDS: tuple[ReactionContentField, ...] = (
+    "mapped_reaction_smiles",
+    "template",
+    "reagents",
+    "solvents",
+)
+
+
+# section: shared validation and hashing
 
 
 def _stable_hash(value: Any) -> str:
@@ -22,6 +34,9 @@ def _stable_hash(value: Any) -> str:
 def _validate_depth(depth: int | None) -> None:
     if depth is not None and depth < 0:
         raise ValueError("depth must be non-negative")
+
+
+# section: route paths
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,6 +144,9 @@ ReactionId = Annotated[str, AfterValidator(validate_reaction_id)]
 MoleculeId = Annotated[str, AfterValidator(validate_molecule_id)]
 
 
+# section: core schema
+
+
 class Reaction(BaseModel):
     reactants: list[Molecule]
     mapped_reaction_smiles: ReactionSmilesStr | None = None
@@ -154,6 +172,9 @@ class Molecule(BaseModel):
 
     def signature(self, match_level: InChIKeyLevel = InChIKeyLevel.FULL) -> str:
         return _stable_hash(self.key(match_level))
+
+
+# section: structural and content identity
 
 
 def _reactant_order_key(molecule: Molecule) -> tuple[tuple[Any, ...], str]:
@@ -201,6 +222,68 @@ def _reaction_key(
         product.key(match_level),
         tuple(sorted(reactant.key(match_level) for reactant in reaction.reactants)),
     )
+
+
+def _normalize_content_fields(fields: Iterable[ReactionContentField]) -> tuple[ReactionContentField, ...]:
+    requested = {fields} if isinstance(fields, str) else set(fields)
+    unknown = sorted(requested - set(REACTION_CONTENT_FIELDS))
+    if unknown:
+        raise ValueError(f"unknown reaction content fields: {', '.join(unknown)}")
+    return tuple(field for field in REACTION_CONTENT_FIELDS if field in requested)
+
+
+def _reaction_content_key(
+    product: Molecule,
+    reaction: Reaction,
+    match_level: InChIKeyLevel,
+    *,
+    fields: tuple[ReactionContentField, ...],
+) -> tuple[Any, ...]:
+    return (
+        "rxn-content",
+        _reaction_key(product, reaction, match_level),
+        tuple((field, _reaction_content_field_value(reaction, field)) for field in fields),
+    )
+
+
+def _reaction_content_field_value(reaction: Reaction, field: ReactionContentField) -> Any:
+    match field:
+        case "mapped_reaction_smiles":
+            return reaction.mapped_reaction_smiles
+        case "template":
+            return reaction.template
+        case "reagents":
+            return None if reaction.reagents is None else tuple(sorted(str(reagent) for reagent in reaction.reagents))
+        case "solvents":
+            return None if reaction.solvents is None else tuple(sorted(str(solvent) for solvent in reaction.solvents))
+
+
+def _molecule_content_subtree_key(
+    molecule: Molecule,
+    match_level: InChIKeyLevel,
+    *,
+    fields: tuple[ReactionContentField, ...],
+    depth: int | None = None,
+) -> tuple[Any, ...]:
+    _validate_depth(depth)
+    reaction = molecule.product_of
+    if reaction is None or depth == 0:
+        return ("mol-content", molecule.key(match_level))
+
+    next_depth = None if depth is None else depth - 1
+    child_signatures = sorted(
+        _stable_hash(_molecule_content_subtree_key(reactant, match_level, fields=fields, depth=next_depth))
+        for reactant in reaction.reactants
+    )
+    return (
+        "mol-content",
+        molecule.key(match_level),
+        _reaction_content_key(molecule, reaction, match_level, fields=fields),
+        tuple(child_signatures),
+    )
+
+
+# section: route model
 
 
 class Route(BaseModel):
@@ -300,6 +383,34 @@ class Route(BaseModel):
     def reaction_signatures(self, match_level: InChIKeyLevel = InChIKeyLevel.FULL) -> set[str]:
         return {reaction.signature(match_level) for reaction in self.iter_reactions()}
 
+    def content_key(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+        depth: int | None = None,
+    ) -> tuple[Any, ...]:
+        content_fields = _normalize_content_fields(fields)
+        return self.molecule_at(RoutePath.target()).content_subtree_key(match_level, fields=content_fields, depth=depth)
+
+    def content_signature(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+        depth: int | None = None,
+    ) -> str:
+        return _stable_hash(self.content_key(match_level, fields=fields, depth=depth))
+
+    def reaction_content_signatures(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+    ) -> set[str]:
+        content_fields = _normalize_content_fields(fields)
+        return {reaction.content_signature(match_level, fields=content_fields) for reaction in self.iter_reactions()}
+
     def depth(self) -> int:
         return self.molecule_at(RoutePath.target()).depth()
 
@@ -316,6 +427,9 @@ class Route(BaseModel):
                 return True
             stack.extend(reaction.reactants)
         return False
+
+
+# section: route-bound views
 
 
 class ReactionView(BaseModel):
@@ -340,6 +454,23 @@ class ReactionView(BaseModel):
 
     def signature(self, match_level: InChIKeyLevel = InChIKeyLevel.FULL) -> str:
         return _stable_hash(self.key(match_level))
+
+    def content_key(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+    ) -> tuple[Any, ...]:
+        content_fields = _normalize_content_fields(fields)
+        return _reaction_content_key(self.product().value, self.value, match_level, fields=content_fields)
+
+    def content_signature(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+    ) -> str:
+        return _stable_hash(self.content_key(match_level, fields=fields))
 
 
 class MoleculeView(BaseModel):
@@ -409,3 +540,22 @@ class MoleculeView(BaseModel):
         depth: int | None = None,
     ) -> str:
         return _stable_hash(self.subtree_key(match_level, depth=depth))
+
+    def content_subtree_key(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+        depth: int | None = None,
+    ) -> tuple[Any, ...]:
+        content_fields = _normalize_content_fields(fields)
+        return _molecule_content_subtree_key(self.value, match_level, fields=content_fields, depth=depth)
+
+    def content_subtree_signature(
+        self,
+        match_level: InChIKeyLevel = InChIKeyLevel.FULL,
+        *,
+        fields: Iterable[ReactionContentField],
+        depth: int | None = None,
+    ) -> str:
+        return _stable_hash(self.content_subtree_key(match_level, fields=fields, depth=depth))

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -179,9 +179,12 @@ class Molecule(BaseModel):
 
 def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
     """
-    RoutePaths depend on reactant order, so pydantic validation should normalize it.
+    route paths depend on reactant order, so validation canonicalizes the list.
 
-    Order is determined by structural signatures of subtrees, and ties are broken by full serialization (which would include annotations, mapped smiles, etc)
+    most reactants already have distinct structural subtree keys. for those, the
+    json tiebreaker would be dead work and can trip over arbitrary annotations.
+    only structurally identical reactants need the full serialization fallback to
+    get deterministic path assignment.
     """
     groups: dict[tuple[Any, ...], list[Molecule]] = {}
     for reactant in reactants:

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -182,9 +182,9 @@ def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
     route paths depend on reactant order, so validation canonicalizes the list.
 
     most reactants already have distinct structural subtree keys. for those, the
-    json tiebreaker would be dead work and can trip over arbitrary annotations.
-    only structurally identical reactants need the full serialization fallback to
-    get deterministic path assignment.
+    tiebreaker would be dead work. only structurally identical reactants need the
+    first-class payload fallback to get deterministic path assignment; arbitrary
+    annotations are intentionally excluded because they are not route identity.
     """
     groups: dict[tuple[Any, ...], list[Molecule]] = {}
     for reactant in reactants:
@@ -198,7 +198,26 @@ def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
 
 
 def _reactant_order_tiebreaker(molecule: Molecule) -> str:
-    return json.dumps(molecule.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    return json.dumps(_molecule_order_payload(molecule), sort_keys=True, separators=(",", ":"))
+
+
+def _molecule_order_payload(molecule: Molecule) -> tuple[Any, ...]:
+    reaction = molecule.product_of
+    return (
+        molecule.smiles,
+        molecule.inchikey,
+        None if reaction is None else _reaction_order_payload(reaction),
+    )
+
+
+def _reaction_order_payload(reaction: Reaction) -> tuple[Any, ...]:
+    return (
+        reaction.mapped_reaction_smiles,
+        reaction.template,
+        _ordered_optional_smiles(reaction.reagents),
+        _ordered_optional_smiles(reaction.solvents),
+        tuple(_molecule_order_payload(reactant) for reactant in reaction.reactants),
+    )
 
 
 def _molecule_subtree_key(
@@ -238,6 +257,7 @@ def _reaction_key(
 
 
 def _normalize_content_fields(fields: Iterable[ReactionContentField]) -> tuple[ReactionContentField, ...]:
+    # str is iterable, but a field name should be treated as one requested field.
     requested = {fields} if isinstance(fields, str) else set(fields)
     unknown = sorted(requested - set(REACTION_CONTENT_FIELDS))
     if unknown:
@@ -252,6 +272,8 @@ def _reaction_content_key(
     *,
     fields: tuple[ReactionContentField, ...],
 ) -> tuple[Any, ...]:
+    if not fields:
+        return _reaction_key(product, reaction, match_level)
     return (
         "rxn-content",
         _reaction_key(product, reaction, match_level),
@@ -266,9 +288,17 @@ def _reaction_content_field_value(reaction: Reaction, field: ReactionContentFiel
         case "template":
             return reaction.template
         case "reagents":
-            return None if reaction.reagents is None else tuple(sorted(str(reagent) for reagent in reaction.reagents))
+            return _ordered_optional_smiles(reaction.reagents)
         case "solvents":
-            return None if reaction.solvents is None else tuple(sorted(str(solvent) for solvent in reaction.solvents))
+            return _ordered_optional_smiles(reaction.solvents)
+        case _ as unreachable:
+            raise AssertionError(f"unhandled reaction content field: {unreachable!r}")
+
+
+def _ordered_optional_smiles(values: list[SmilesStr] | None) -> tuple[str, ...] | None:
+    if not values:
+        return None
+    return tuple(sorted(str(value) for value in values))
 
 
 def _molecule_content_subtree_key(
@@ -278,6 +308,8 @@ def _molecule_content_subtree_key(
     fields: tuple[ReactionContentField, ...],
     depth: int | None = None,
 ) -> tuple[Any, ...]:
+    if not fields:
+        return _molecule_subtree_key(molecule, match_level, depth=depth)
     _validate_depth(depth)
     reaction = molecule.product_of
     if reaction is None or depth == 0:

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -157,7 +157,7 @@ class Reaction(BaseModel):
 
     @model_validator(mode="after")
     def normalize_reactant_order(self) -> Reaction:
-        self.reactants = sorted(self.reactants, key=_reactant_order_key)
+        self.reactants = _normalize_reactants(self.reactants)
         return self
 
 
@@ -177,11 +177,21 @@ class Molecule(BaseModel):
 # section: structural and content identity
 
 
-def _reactant_order_key(molecule: Molecule) -> tuple[tuple[Any, ...], str]:
-    return (
-        _molecule_subtree_key(molecule),
-        _reactant_order_tiebreaker(molecule),
-    )
+def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
+    """
+    RoutePaths depend on reactant order, so pydantic validation should normalize it.
+
+    Order is determined by structural signatures of subtrees, and ties are broken by full serialization (which would include annotations, mapped smiles, etc)
+    """
+    groups: dict[tuple[Any, ...], list[Molecule]] = {}
+    for reactant in reactants:
+        groups.setdefault(_molecule_subtree_key(reactant), []).append(reactant)
+
+    ordered: list[Molecule] = []
+    for key in sorted(groups):
+        group = groups[key]
+        ordered.extend(group if len(group) == 1 else sorted(group, key=_reactant_order_tiebreaker))
+    return ordered
 
 
 def _reactant_order_tiebreaker(molecule: Molecule) -> str:

--- a/src/retrocast/models/route.py
+++ b/src/retrocast/models/route.py
@@ -198,26 +198,20 @@ def _normalize_reactants(reactants: list[Molecule]) -> list[Molecule]:
 
 
 def _reactant_order_tiebreaker(molecule: Molecule) -> str:
-    return json.dumps(_molecule_order_payload(molecule), sort_keys=True, separators=(",", ":"))
+    def payload(value: Molecule) -> tuple[Any, ...]:
+        reaction = value.product_of
+        reaction_payload = None
+        if reaction is not None:
+            reaction_payload = (
+                reaction.mapped_reaction_smiles,
+                reaction.template,
+                _ordered_optional_smiles(reaction.reagents),
+                _ordered_optional_smiles(reaction.solvents),
+                tuple(payload(reactant) for reactant in reaction.reactants),
+            )
+        return (value.smiles, value.inchikey, reaction_payload)
 
-
-def _molecule_order_payload(molecule: Molecule) -> tuple[Any, ...]:
-    reaction = molecule.product_of
-    return (
-        molecule.smiles,
-        molecule.inchikey,
-        None if reaction is None else _reaction_order_payload(reaction),
-    )
-
-
-def _reaction_order_payload(reaction: Reaction) -> tuple[Any, ...]:
-    return (
-        reaction.mapped_reaction_smiles,
-        reaction.template,
-        _ordered_optional_smiles(reaction.reagents),
-        _ordered_optional_smiles(reaction.solvents),
-        tuple(_molecule_order_payload(reactant) for reactant in reaction.reactants),
-    )
+    return json.dumps(payload(molecule), sort_keys=True, separators=(",", ":"))
 
 
 def _molecule_subtree_key(

--- a/tests/models/test_route_signatures.py
+++ b/tests/models/test_route_signatures.py
@@ -263,6 +263,18 @@ def test_duplicate_identity_reactants_use_stable_tiebreaker_for_paths() -> None:
 
 
 @pytest.mark.unit
+def test_reactant_order_tiebreaker_runs_only_for_structural_collisions() -> None:
+    route = one_step_route(
+        [
+            molecule("C", KEY_A).model_copy(update={"annotations": {"opaque": object()}}),
+            molecule("O", KEY_B),
+        ]
+    )
+
+    assert [reactant.value.inchikey for reactant in route.reaction_at("rc:r:/").reactants()] == [KEY_A, KEY_B]
+
+
+@pytest.mark.unit
 @given(tree_shapes)
 def test_generated_recursive_reactant_permutations_normalize_to_same_route(shape: TreeShape) -> None:
     route = route_from_shape(shape)
@@ -357,6 +369,31 @@ def test_content_signature_is_reactant_order_invariant() -> None:
     route_b = Route(target=molecule("CC", KEY_C, product_of=reaction_b))
 
     assert route_a.content_signature(fields=("template",)) == route_b.content_signature(fields=("template",))
+
+
+@pytest.mark.unit
+def test_content_signature_uses_requested_match_level() -> None:
+    route_a = Route(
+        target=molecule(
+            "CC",
+            KEY_C,
+            product_of=Reaction(reactants=[molecule("C", KEY_A_STEREO_1)], template="same"),
+        )
+    )
+    route_b = Route(
+        target=molecule(
+            "CC",
+            KEY_C,
+            product_of=Reaction(reactants=[molecule("C", KEY_A_STEREO_2)], template="same"),
+        )
+    )
+
+    assert route_a.content_signature(InChIKeyLevel.FULL, fields=("template",)) != route_b.content_signature(
+        InChIKeyLevel.FULL, fields=("template",)
+    )
+    assert route_a.content_signature(InChIKeyLevel.NO_STEREO, fields=("template",)) == route_b.content_signature(
+        InChIKeyLevel.NO_STEREO, fields=("template",)
+    )
 
 
 @pytest.mark.unit

--- a/tests/models/test_route_signatures.py
+++ b/tests/models/test_route_signatures.py
@@ -275,6 +275,34 @@ def test_reactant_order_tiebreaker_runs_only_for_structural_collisions() -> None
 
 
 @pytest.mark.unit
+def test_reactant_order_tiebreaker_ignores_annotations() -> None:
+    first = molecule(
+        "C",
+        KEY_A,
+        product_of=Reaction(
+            reactants=[molecule("N", KEY_D)],
+            template="template-a",
+            annotations={"opaque": object()},
+        ),
+    ).model_copy(update={"annotations": {"opaque": object()}})
+    second = molecule(
+        "C",
+        KEY_A,
+        product_of=Reaction(
+            reactants=[molecule("N", KEY_D)],
+            template="template-b",
+            annotations={"opaque": object()},
+        ),
+    ).model_copy(update={"annotations": {"opaque": object()}})
+
+    route = one_step_route([second, first])
+    first_reactant_reaction = route.molecule_at("rc:m:/0").value.product_of
+
+    assert first_reactant_reaction is not None
+    assert first_reactant_reaction.template == "template-a"
+
+
+@pytest.mark.unit
 @given(tree_shapes)
 def test_generated_recursive_reactant_permutations_normalize_to_same_route(shape: TreeShape) -> None:
     route = route_from_shape(shape)
@@ -359,6 +387,29 @@ def test_content_signature_treats_reagents_and_solvents_as_unordered() -> None:
     assert route_a.content_signature(fields=("reagents", "solvents")) == route_b.content_signature(
         fields=("solvents", "reagents")
     )
+
+
+@pytest.mark.unit
+def test_content_signature_treats_empty_reagents_and_solvents_as_absent() -> None:
+    route_a = content_route(reagents=[], solvents=[])
+    route_b = content_route(reagents=None, solvents=None)
+
+    assert route_a.content_signature(fields=("reagents", "solvents")) == route_b.content_signature(
+        fields=("reagents", "solvents")
+    )
+
+
+@pytest.mark.unit
+def test_empty_content_fields_use_structural_identity() -> None:
+    route = content_route(mapped_reaction_smiles="C.O>>CC", template="template-a")
+    target = route.molecule_at("rc:m:/")
+    reaction = route.reaction_at("rc:r:/")
+
+    assert route.content_signature(fields=()) == route.signature()
+    assert route.content_signature(fields=(), depth=1) == route.signature(depth=1)
+    assert target.content_subtree_signature(fields=()) == target.subtree_signature()
+    assert reaction.content_signature(fields=()) == reaction.signature()
+    assert route.reaction_content_signatures(fields=()) == route.reaction_signatures()
 
 
 @pytest.mark.unit

--- a/tests/models/test_route_signatures.py
+++ b/tests/models/test_route_signatures.py
@@ -7,7 +7,7 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from retrocast.models.route import InChIKeyLevel, Molecule, Reaction, Route
-from retrocast.typing import InChIKeyStr, SmilesStr
+from retrocast.typing import InChIKeyStr, ReactionSmilesStr, SmilesStr
 
 KEY_A = "AAAAAAAAAAAAAA-UHFFFAOYSA-N"
 KEY_B = "BBBBBBBBBBBBBB-UHFFFAOYSA-N"
@@ -34,6 +34,25 @@ def molecule(smiles: str, inchikey: str, product_of: Reaction | None = None) -> 
 def one_step_route(reactants: list[Molecule], *, target_key: str = KEY_C) -> Route:
     target = molecule("CC", target_key, product_of=Reaction(reactants=reactants))
     return Route(target=target)
+
+
+def content_route(
+    *,
+    mapped_reaction_smiles: str | None = None,
+    template: str | None = None,
+    reagents: list[str] | None = None,
+    solvents: list[str] | None = None,
+) -> Route:
+    reaction = Reaction(
+        reactants=[molecule("C", KEY_A), molecule("O", KEY_B)],
+        mapped_reaction_smiles=ReactionSmilesStr(mapped_reaction_smiles)
+        if mapped_reaction_smiles is not None
+        else None,
+        template=template,
+        reagents=[SmilesStr(reagent) for reagent in reagents] if reagents is not None else None,
+        solvents=[SmilesStr(solvent) for solvent in solvents] if solvents is not None else None,
+    )
+    return Route(target=molecule("CC", KEY_C, product_of=reaction))
 
 
 def two_step_route() -> Route:
@@ -290,6 +309,87 @@ def test_prefix_depth_changes_signatures_as_expected() -> None:
     assert shallow_route.signature(depth=0) == deep_route.signature(depth=0)
     assert shallow_route.signature(depth=1) == deep_route.signature(depth=1)
     assert shallow_route.signature() != deep_route.signature()
+
+
+@pytest.mark.unit
+def test_structural_signature_ignores_reaction_content() -> None:
+    route_a = content_route(mapped_reaction_smiles="C.O>>CC", template="template-a", reagents=["N"], solvents=["O"])
+    route_b = content_route(mapped_reaction_smiles="C.N>>CC", template="template-b", reagents=["C"], solvents=["CO"])
+
+    assert route_a.signature() == route_b.signature()
+    assert route_a.reaction_at("rc:r:/").signature() == route_b.reaction_at("rc:r:/").signature()
+
+
+@pytest.mark.unit
+def test_content_signature_uses_only_selected_reaction_fields() -> None:
+    route_a = content_route(mapped_reaction_smiles="C.O>>CC", template="same")
+    route_b = content_route(mapped_reaction_smiles="C.N>>CC", template="same")
+
+    assert route_a.content_signature(fields=("mapped_reaction_smiles",)) != route_b.content_signature(
+        fields=("mapped_reaction_smiles",)
+    )
+    assert route_a.content_signature(fields=("template",)) == route_b.content_signature(fields=("template",))
+
+
+@pytest.mark.unit
+def test_content_signature_distinguishes_absent_selected_fields() -> None:
+    route_a = content_route(template="template-a")
+    route_b = content_route(template=None)
+
+    assert route_a.content_signature(fields=("template",)) != route_b.content_signature(fields=("template",))
+
+
+@pytest.mark.unit
+def test_content_signature_treats_reagents_and_solvents_as_unordered() -> None:
+    route_a = content_route(reagents=["N", "O"], solvents=["C", "CO"])
+    route_b = content_route(reagents=["O", "N"], solvents=["CO", "C"])
+
+    assert route_a.content_signature(fields=("reagents", "solvents")) == route_b.content_signature(
+        fields=("solvents", "reagents")
+    )
+
+
+@pytest.mark.unit
+def test_content_signature_is_reactant_order_invariant() -> None:
+    reaction_a = Reaction(reactants=[molecule("C", KEY_A), molecule("O", KEY_B)], template="same")
+    reaction_b = Reaction(reactants=[molecule("O", KEY_B), molecule("C", KEY_A)], template="same")
+    route_a = Route(target=molecule("CC", KEY_C, product_of=reaction_a))
+    route_b = Route(target=molecule("CC", KEY_C, product_of=reaction_b))
+
+    assert route_a.content_signature(fields=("template",)) == route_b.content_signature(fields=("template",))
+
+
+@pytest.mark.unit
+def test_content_signature_depth_limits_nested_reaction_content() -> None:
+    child_a = molecule("CO", KEY_B, product_of=Reaction(reactants=[molecule("C", KEY_A)], template="child-a"))
+    child_b = molecule("CO", KEY_B, product_of=Reaction(reactants=[molecule("C", KEY_A)], template="child-b"))
+    route_a = one_step_route([child_a, molecule("N", KEY_D)])
+    route_b = one_step_route([child_b, molecule("N", KEY_D)])
+
+    assert route_a.content_signature(fields=("template",), depth=1) == route_b.content_signature(
+        fields=("template",), depth=1
+    )
+    assert route_a.content_signature(fields=("template",)) != route_b.content_signature(fields=("template",))
+
+
+@pytest.mark.unit
+def test_reaction_and_subtree_content_signatures_use_route_context() -> None:
+    route = content_route(mapped_reaction_smiles="C.O>>CC")
+
+    assert route.reaction_content_signatures(fields=("mapped_reaction_smiles",)) == {
+        route.reaction_at("rc:r:/").content_signature(fields=("mapped_reaction_smiles",))
+    }
+    assert route.molecule_at("rc:m:/").content_subtree_signature(fields=("mapped_reaction_smiles",)) == (
+        route.content_signature(fields=("mapped_reaction_smiles",))
+    )
+
+
+@pytest.mark.unit
+def test_content_signature_rejects_unknown_reaction_fields() -> None:
+    route = content_route()
+
+    with pytest.raises(ValueError, match="unknown reaction content fields"):
+        route.content_signature(fields=("condition_slot",))  # type: ignore[arg-type]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## why

structural route signatures intentionally ignore reaction metadata so scoring, holdouts, prefix matching, and embedding keep using the smallest trustworthy route identity. we also need an opt-in way to compare routes by first-class reaction content when mapped smiles, templates, reagents, or solvents matter.

this also addresses the prior review concern around reactant normalization doing full json serialization for every reactant. route paths still need deterministic ordering, but the expensive tiebreaker is only needed when structural subtree keys collide.

## what changed

added content key/signature methods on route, reactionview, and moleculeview that mirror the existing merkle-style structural identity surface while requiring callers to choose which reaction fields matter.

reactant normalization now groups by structural subtree key first and only runs the full serialization tiebreaker inside structural collision groups.

added a short schema-design section explaining the split between structural signatures and content signatures, and section markers in route.py to keep the core schema file navigable.

## risk

this touches the core route model, but existing structural signature behavior remains the default and existing scoring/embedding callers continue to use `signature()` / `subtree_signature()`. content signatures are a new opt-in comparison surface. annotations remain excluded from the generic content signature api because they are source-specific metadata.

## verification

- `uv run pytest tests/models/test_route_signatures.py`
- `uv run ruff check src/retrocast/models/route.py tests/models/test_route_signatures.py`
- `uv run ruff format --check src/retrocast/models/route.py tests/models/test_route_signatures.py`
- `uv run ty check .`
- `uv run pytest`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782998699&installation_id=125602297&pr_number=124&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F124&signature=b046ff821fd7ded9f2a6d73fe0dd168c8d204e11d45ba478fa97592a83f148c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content-based signature and key computation for routes, reactions, and molecules, enabling identity comparison beyond structural equivalence.
  * Content signatures support selective inclusion of reaction fields (e.g., mapped SMILES, template, reagents, solvents) with configurable match levels and depth limits.

* **Documentation**
  * Added schema design rationale documenting content signature behavior and specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in content signature API (content_key / content_signature) to `Route`, `ReactionView`, and `MoleculeView` that mirrors the existing Merkle-style structural identity surface while letting callers select which reaction fields (mapped SMILES, template, reagents, solvents) participate in the hash. It also replaces the previous O(N · full_serialize) reactant normalization with a group-then-tiebreak strategy that only runs the expensive JSON serialization inside structural collision groups.

- **Content signatures** follow the same Merkle shape and depth/match_level semantics as structural signatures. Empty fields short-circuit cleanly to the structural path, making `content_signature(fields=())` exactly equal to `signature()`.
- **Reactant normalization** now groups reactants by `_molecule_subtree_key` first and calls `_reactant_order_tiebreaker` only for molecules in the same structural group. The tiebreaker explicitly excludes `annotations` (which may be non-JSON-serializable) and handles empty vs. `None` reagent/solvent lists uniformly via `_ordered_optional_smiles`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change adds a new opt-in API surface without touching any existing structural signature paths, and the reactant normalization refactor preserves the old sort order for non-colliding molecules while fixing the annotation-serialization crash.

All existing structural signature callers are unaffected — the content methods are purely additive. The group-then-tiebreak normalization is a strict improvement over the previous full-serialization approach: it is cheaper for the common case and correctly excludes non-JSON-serializable annotations that would have caused runtime errors. Empty-field short-circuit, depth semantics, and match-level behaviour are all covered by the new tests, and the exhaustive match now raises an AssertionError for unhandled fields rather than silently returning None.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/models/route.py | Adds content-signature helpers and refactors reactant normalization; new logic is well-guarded, short-circuits correctly when fields=(), and the exhaustive match now has an explicit AssertionError fallback. No pre-existing structural behaviour is altered. |
| tests/models/test_route_signatures.py | Comprehensive test coverage for content signatures: field selection, empty/None reagent equivalence, depth limits, match-level sensitivity, reactant-order invariance, field-order canonicalization, and the new tiebreaker behaviour. All edge cases in the PR description are exercised. |
| docs/rationale/schema-design.md | Adds a short prose section documenting the split between structural and content signatures with a usage example. Accurate and consistent with the implementation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["DEV: address comments and cleanup"](https://github.com/ischemist/project-procrustes/commit/59d130e78f505bb64730e3c40b8af3327ca529fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35136797)</sub>

<!-- /greptile_comment -->