### PR TITLE
feat: add benchmark route embedding audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,6 @@ data/retrocast/3-processed/
 data/retrocast/4-scored/
 data/retrocast/5-results/
 data/retrocast/6-comparisons/
+data/retrocast/audits/
 .private
 .codex

--- a/scripts/06-audit-benchmark-route-embeddings.py
+++ b/scripts/06-audit-benchmark-route-embeddings.py
@@ -14,8 +14,8 @@ from typing import Literal
 from retrocast.chem import InChIKeyLevel
 from retrocast.curation.training.embedding_audit import (
     RouteEmbeddingAudit,
+    build_container_embedding_index,
     build_route_embedding_audit,
-    build_training_embedding_index,
 )
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
 from retrocast.curation.training.records import TrainingRouteRecord
@@ -39,7 +39,7 @@ def main() -> None:
         audits.append(
             build_route_embedding_audit(
                 release_name=benchmark_name,
-                training_records=records,
+                container_records=records,
                 queries_by_source={benchmark_name: {record.id: record.route for record in records}},
                 match_level=match_level,
                 allow_leaf_extension=args.allow_leaf_extension,
@@ -50,7 +50,7 @@ def main() -> None:
         )
         logger.info("loaded %s acceptable routes from %s", len(records), benchmark_name)
 
-    index = build_training_embedding_index(all_records, match_level)
+    index = build_container_embedding_index(all_records, match_level)
     audit = merge_audits(
         "benchmark-route-embeddings",
         audits,
@@ -115,9 +115,9 @@ def merge_audits(
         match_level=first.match_level,
         allow_leaf_extension=first.allow_leaf_extension,
         partial_min_reactions=first.partial_min_reactions,
-        training_routes=total_routes,
-        training_route_signatures=route_signatures,
-        training_reaction_signatures=reaction_signatures,
+        container_routes=total_routes,
+        container_route_signatures=route_signatures,
+        container_reaction_signatures=reaction_signatures,
         query_sets=tuple(query_set for audit in audits for query_set in audit.query_sets),
         ledger_rows=tuple(row for audit in audits for row in audit.ledger_rows),
     )

--- a/scripts/06-audit-benchmark-route-embeddings.py
+++ b/scripts/06-audit-benchmark-route-embeddings.py
@@ -1,0 +1,107 @@
+"""
+audit route-pattern embeddings within benchmark acceptable routes.
+
+usage:
+    uv run scripts/06-audit-benchmark-route-embeddings.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Literal
+
+from retrocast.chem import InChIKeyLevel
+from retrocast.curation.training.embedding_audit import RouteEmbeddingAudit, build_route_embedding_audit
+from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
+from retrocast.curation.training.records import TrainingRouteRecord
+from retrocast.io import load_benchmark, save_jsonl_gz
+from retrocast.paths import benchmark_definitions_dir
+from retrocast.utils.logging import configure_script_logging, logger
+
+DEFAULT_BENCHMARKS = ("mkt-cnv-160", "mkt-lin-500", "ref-lng-84", "uspto-190")
+
+
+def main() -> None:
+    configure_script_logging()
+    args = parse_args()
+    match_level = InChIKeyLevel(args.match_level)
+    audits: list[RouteEmbeddingAudit] = []
+    all_records: list[TrainingRouteRecord] = []
+
+    for benchmark_name in args.benchmarks:
+        records = load_benchmark_records(benchmark_name, route_selection=args.route_selection)
+        all_records.extend(records)
+        audits.append(
+            build_route_embedding_audit(
+                release_name=benchmark_name,
+                training_records=records,
+                queries_by_source={benchmark_name: {record.id: record.route for record in records}},
+                match_level=match_level,
+                allow_leaf_extension=args.allow_leaf_extension,
+                include_partial=True,
+                partial_min_reactions=args.partial_min_reactions,
+                exclude_query_containers=True,
+            )
+        )
+        logger.info("loaded %s acceptable routes from %s", len(records), benchmark_name)
+
+    audit = merge_audits("benchmark-route-embeddings", audits, total_routes=len(all_records))
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "benchmark-route-embedding-audit.md"
+    ledger_path = output_dir / "benchmark-route-embedding-ledger.jsonl.gz"
+    report_path.write_text(
+        render_route_embedding_audit_markdown(audit, container_label="benchmark"),
+        encoding="utf-8",
+    )
+    n_rows = save_jsonl_gz(audit.ledger_rows, ledger_path)
+    logger.info("wrote %s and %s (%s ledger rows)", report_path, ledger_path, n_rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="audit route embeddings among acceptable routes inside benchmarks")
+    parser.add_argument("--benchmarks", nargs="+", default=list(DEFAULT_BENCHMARKS))
+    parser.add_argument("--route-selection", choices=("primary", "all"), default="primary")
+    parser.add_argument(
+        "--match-level", choices=[level.value for level in InChIKeyLevel], default=InChIKeyLevel.FULL.value
+    )
+    parser.add_argument("--partial-min-reactions", type=int, default=2)
+    parser.add_argument("--output-dir", type=Path, default=Path("data/retrocast/audits"))
+    parser.add_argument("--no-leaf-extension", dest="allow_leaf_extension", action="store_false")
+    parser.set_defaults(allow_leaf_extension=True)
+    return parser.parse_args()
+
+
+def load_benchmark_records(
+    benchmark_name: str,
+    *,
+    route_selection: Literal["primary", "all"],
+) -> list[TrainingRouteRecord]:
+    benchmark = load_benchmark(benchmark_definitions_dir() / f"{benchmark_name}.json.gz")
+    records: list[TrainingRouteRecord] = []
+    for target in benchmark.targets.values():
+        routes = target.acceptable_routes[:1] if route_selection == "primary" else target.acceptable_routes
+        for index, route in enumerate(routes, start=1):
+            route_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
+            records.append(TrainingRouteRecord(id=route_id, split="training", route=route))
+    return records
+
+
+def merge_audits(release_name: str, audits: list[RouteEmbeddingAudit], *, total_routes: int) -> RouteEmbeddingAudit:
+    first = audits[0]
+    return RouteEmbeddingAudit(
+        release_name=release_name,
+        match_level=first.match_level,
+        allow_leaf_extension=first.allow_leaf_extension,
+        partial_min_reactions=first.partial_min_reactions,
+        training_routes=total_routes,
+        training_route_signatures=sum(audit.training_route_signatures for audit in audits),
+        training_reaction_signatures=sum(audit.training_reaction_signatures for audit in audits),
+        query_sets=tuple(query_set for audit in audits for query_set in audit.query_sets),
+        ledger_rows=tuple(row for audit in audits for row in audit.ledger_rows),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/06-audit-benchmark-route-embeddings.py
+++ b/scripts/06-audit-benchmark-route-embeddings.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from typing import Literal
 
 from retrocast.chem import InChIKeyLevel
-from retrocast.curation.training.embedding_audit import RouteEmbeddingAudit, build_route_embedding_audit
+from retrocast.curation.training.embedding_audit import (
+    RouteEmbeddingAudit,
+    build_route_embedding_audit,
+    build_training_embedding_index,
+)
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
 from retrocast.curation.training.records import TrainingRouteRecord
 from retrocast.io import load_benchmark, save_jsonl_gz
@@ -46,7 +50,14 @@ def main() -> None:
         )
         logger.info("loaded %s acceptable routes from %s", len(records), benchmark_name)
 
-    audit = merge_audits("benchmark-route-embeddings", audits, total_routes=len(all_records))
+    index = build_training_embedding_index(all_records, match_level)
+    audit = merge_audits(
+        "benchmark-route-embeddings",
+        audits,
+        total_routes=len(all_records),
+        route_signatures=len(index.route_signatures),
+        reaction_signatures=len(index.reaction_signatures),
+    )
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     report_path = output_dir / "benchmark-route-embedding-audit.md"
@@ -88,7 +99,16 @@ def load_benchmark_records(
     return records
 
 
-def merge_audits(release_name: str, audits: list[RouteEmbeddingAudit], *, total_routes: int) -> RouteEmbeddingAudit:
+def merge_audits(
+    release_name: str,
+    audits: list[RouteEmbeddingAudit],
+    *,
+    total_routes: int,
+    route_signatures: int,
+    reaction_signatures: int,
+) -> RouteEmbeddingAudit:
+    if not audits:
+        raise ValueError("merge_audits requires at least one audit")
     first = audits[0]
     return RouteEmbeddingAudit(
         release_name=release_name,
@@ -96,8 +116,8 @@ def merge_audits(release_name: str, audits: list[RouteEmbeddingAudit], *, total_
         allow_leaf_extension=first.allow_leaf_extension,
         partial_min_reactions=first.partial_min_reactions,
         training_routes=total_routes,
-        training_route_signatures=sum(audit.training_route_signatures for audit in audits),
-        training_reaction_signatures=sum(audit.training_reaction_signatures for audit in audits),
+        training_route_signatures=route_signatures,
+        training_reaction_signatures=reaction_signatures,
         query_sets=tuple(query_set for audit in audits for query_set in audit.query_sets),
         ledger_rows=tuple(row for audit in audits for row in audit.ledger_rows),
     )

--- a/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+++ b/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
@@ -54,10 +54,10 @@ def main() -> None:
         }
         logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
 
-    training_records = load_training_route_records(RELEASE_PATH)
+    container_records = load_training_route_records(RELEASE_PATH)
     audit = build_route_embedding_audit(
         release_name=RELEASE_NAME,
-        training_records=training_records,
+        container_records=container_records,
         queries_by_source=queries,
         match_level=MATCH_LEVEL,
         allow_leaf_extension=ALLOW_LEAF_EXTENSION,
@@ -67,7 +67,7 @@ def main() -> None:
 
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     LEDGER_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(render_route_embedding_audit_markdown(audit), encoding="utf-8")
+    OUTPUT_PATH.write_text(render_route_embedding_audit_markdown(audit, container_label="training"), encoding="utf-8")
     ledger_rows = save_jsonl_gz(audit.ledger_rows, LEDGER_OUTPUT_PATH)
     logger.info(
         "wrote route embedding audit to %s and %s (%s ledger rows)", OUTPUT_PATH, LEDGER_OUTPUT_PATH, ledger_rows

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -17,13 +17,13 @@ EmbeddingMatchKind = Literal["full_route", "internal_subroute"]
 
 
 @dataclass(slots=True)
-class TrainingRouteOccurrence:
+class ContainerRouteOccurrence:
     record: TrainingRouteRecord
     molecule: MoleculeView
 
 
 @dataclass(slots=True)
-class TrainingEmbeddingIndex:
+class ContainerEmbeddingIndex:
     route_signatures: set[str]
     reaction_signatures: set[str]
     route_signature_counts: Mapping[str, int]
@@ -32,7 +32,7 @@ class TrainingEmbeddingIndex:
     subtree_prefix_signatures_by_depth: Mapping[int, set[str]]
     root_prefix_signature_counts_by_depth: Mapping[int, Mapping[str, int]]
     subtree_prefix_signature_counts_by_depth: Mapping[int, Mapping[str, int]]
-    by_reaction_root: Mapping[str, tuple[TrainingRouteOccurrence, ...]]
+    by_reaction_root: Mapping[str, tuple[ContainerRouteOccurrence, ...]]
 
 
 class RouteEmbeddingLedgerRow(BaseModel):
@@ -89,7 +89,7 @@ class CoverageSummary:
     embedded_query_fraction_stats: tuple[float, float, float]
     all_container_fraction_stats: tuple[float, float, float]
     embedded_container_fraction_stats: tuple[float, float, float]
-    embedded_mean_training_routes_per_query: float
+    embedded_mean_container_routes_per_query: float
     embedded_mean_occurrences_per_query: float
     matched_fraction_histogram: tuple[tuple[str, int], ...]
 
@@ -113,9 +113,9 @@ class RouteEmbeddingAudit:
     match_level: str
     allow_leaf_extension: bool
     partial_min_reactions: int | None
-    training_routes: int
-    training_route_signatures: int
-    training_reaction_signatures: int
+    container_routes: int
+    container_route_signatures: int
+    container_reaction_signatures: int
     query_sets: tuple[QuerySetAudit, ...]
     ledger_rows: tuple[RouteEmbeddingLedgerRow, ...]
 
@@ -124,14 +124,14 @@ class RouteEmbeddingAudit:
 class _QueryCoverageRow:
     matched_fraction_of_query_route: float
     matched_fraction_of_container_route: float
-    training_routes: int
+    container_routes: int
     occurrences: int
 
 
 def build_route_embedding_audit(
     *,
     release_name: str,
-    training_records: Sequence[TrainingRouteRecord],
+    container_records: Sequence[TrainingRouteRecord],
     queries_by_source: Mapping[str, Mapping[str, Route]],
     match_level: InChIKeyLevel = InChIKeyLevel.FULL,
     allow_leaf_extension: bool = True,
@@ -140,8 +140,22 @@ def build_route_embedding_audit(
     exclude_query_containers: bool = False,
 ) -> RouteEmbeddingAudit:
     if exclude_query_containers:
-        _validate_query_container_exclusion(training_records, queries_by_source)
-    index = build_training_embedding_index(training_records, match_level)
+        container_ids = [record.id for record in container_records]
+        duplicate_ids = {container_id for container_id, count in Counter(container_ids).items() if count > 1}
+        if duplicate_ids:
+            raise ValueError(
+                f"exclude_query_containers requires unique container record ids; duplicate ids: {sorted(duplicate_ids)}"
+            )
+
+        container_id_set = set(container_ids)
+        query_ids = {query_id for queries in queries_by_source.values() for query_id in queries}
+        missing_query_ids = sorted(query_ids - container_id_set)
+        if missing_query_ids:
+            raise ValueError(
+                "exclude_query_containers requires query ids to match container record ids; "
+                f"missing ids: {missing_query_ids}"
+            )
+    index = build_container_embedding_index(container_records, match_level)
     query_sets: list[QuerySetAudit] = []
     ledger_rows: list[RouteEmbeddingLedgerRow] = []
     for source, queries in sorted(queries_by_source.items()):
@@ -163,18 +177,18 @@ def build_route_embedding_audit(
         match_level=match_level.value,
         allow_leaf_extension=allow_leaf_extension,
         partial_min_reactions=partial_min_reactions if include_partial else None,
-        training_routes=len(training_records),
-        training_route_signatures=len(index.route_signatures),
-        training_reaction_signatures=len(index.reaction_signatures),
+        container_routes=len(container_records),
+        container_route_signatures=len(index.route_signatures),
+        container_reaction_signatures=len(index.reaction_signatures),
         query_sets=tuple(query_sets),
         ledger_rows=tuple(ledger_rows),
     )
 
 
-def build_training_embedding_index(
+def build_container_embedding_index(
     records: Sequence[TrainingRouteRecord],
     match_level: InChIKeyLevel = InChIKeyLevel.FULL,
-) -> TrainingEmbeddingIndex:
+) -> ContainerEmbeddingIndex:
     route_signatures: set[str] = set()
     reaction_signatures: set[str] = set()
     route_signature_counts: Counter[str] = Counter()
@@ -183,7 +197,7 @@ def build_training_embedding_index(
     subtree_prefix_signatures_by_depth: dict[int, set[str]] = defaultdict(set)
     root_prefix_signature_counts_by_depth: dict[int, Counter[str]] = defaultdict(Counter)
     subtree_prefix_signature_counts_by_depth: dict[int, Counter[str]] = defaultdict(Counter)
-    by_reaction_root: dict[str, list[TrainingRouteOccurrence]] = defaultdict(list)
+    by_reaction_root: dict[str, list[ContainerRouteOccurrence]] = defaultdict(list)
 
     for record in records:
         route_signature = record.route.signature(match_level)
@@ -202,14 +216,14 @@ def build_training_embedding_index(
                 subtree_prefix = molecule.subtree_signature(match_level, depth=depth)
                 subtree_prefix_signatures_by_depth[depth].add(subtree_prefix)
                 subtree_prefixes_by_depth[depth].add(subtree_prefix)
-            occurrence = TrainingRouteOccurrence(record=record, molecule=molecule)
+            occurrence = ContainerRouteOccurrence(record=record, molecule=molecule)
             reaction = molecule.produced_by()
             if reaction is not None:
                 by_reaction_root[reaction.signature(match_level)].append(occurrence)
         for depth, signatures in subtree_prefixes_by_depth.items():
             subtree_prefix_signature_counts_by_depth[depth].update(signatures)
 
-    return TrainingEmbeddingIndex(
+    return ContainerEmbeddingIndex(
         route_signatures=route_signatures,
         reaction_signatures=reaction_signatures,
         route_signature_counts=dict(route_signature_counts),
@@ -226,34 +240,11 @@ def build_training_embedding_index(
     )
 
 
-def _validate_query_container_exclusion(
-    training_records: Sequence[TrainingRouteRecord],
-    queries_by_source: Mapping[str, Mapping[str, Route]],
-) -> None:
-    container_ids = [record.id for record in training_records]
-    duplicate_ids = {container_id for container_id, count in Counter(container_ids).items() if count > 1}
-    if duplicate_ids:
-        raise ValueError(
-            "exclude_query_containers requires unique TrainingRouteRecord.id values; "
-            f"duplicate ids: {sorted(duplicate_ids)}"
-        )
-
-    container_id_set = set(container_ids)
-    missing_query_ids = sorted(
-        query_id for queries in queries_by_source.values() for query_id in queries if query_id not in container_id_set
-    )
-    if missing_query_ids:
-        raise ValueError(
-            "exclude_query_containers requires query ids to match TrainingRouteRecord.id values; "
-            f"missing ids: {missing_query_ids}"
-        )
-
-
 def _audit_query_set(
     *,
     source: str,
     queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
     include_partial: bool,
@@ -286,14 +277,28 @@ def _audit_query_set(
     query_reaction_signatures = {
         signature for route in queries.values() for signature in route.reaction_signatures(match_level)
     }
+    if exclude_query_containers:
+        exact_route_signature_overlap = sum(
+            index.route_signature_counts.get(route.signature(match_level), 0) > 1 for route in queries.values()
+        )
+        reaction_signature_overlap = len(
+            {
+                signature
+                for signature in query_reaction_signatures
+                if index.reaction_signature_route_counts.get(signature, 0) > 1
+            }
+        )
+    else:
+        exact_route_signature_overlap = sum(
+            route.signature(match_level) in index.route_signatures for route in queries.values()
+        )
+        reaction_signature_overlap = len(query_reaction_signatures & index.reaction_signatures)
     query_set = QuerySetAudit(
         source=source,
         query_routes=len(queries),
         query_reaction_signatures=len(query_reaction_signatures),
-        exact_route_signature_overlap=_exact_route_signature_overlap(
-            queries, index, match_level, exclude_query_containers
-        ),
-        reaction_signature_overlap=_reaction_signature_overlap(queries, index, match_level, exclude_query_containers),
+        exact_route_signature_overlap=exact_route_signature_overlap,
+        reaction_signature_overlap=reaction_signature_overlap,
         prefix_depths=_summarize_prefix_depths(
             queries=queries,
             index=index,
@@ -318,7 +323,7 @@ def _audit_query_set(
 def _summarize_prefix_depths(
     *,
     queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
     exclude_query_containers: bool,
 ) -> tuple[PrefixDepthSummary, ...]:
@@ -330,73 +335,29 @@ def _summarize_prefix_depths(
         subtree_prefixes = index.subtree_prefix_signatures_by_depth.get(depth, set())
         root_counts = index.root_prefix_signature_counts_by_depth.get(depth, {})
         subtree_counts = index.subtree_prefix_signature_counts_by_depth.get(depth, {})
-        root_overlaps = _signature_overlap_check(root_prefixes, root_counts, exclude_query_containers)
-        subtree_overlaps = _signature_overlap_check(subtree_prefixes, subtree_counts, exclude_query_containers)
+        signatures = [route.signature(match_level, depth=depth) for route in eligible]
+        if exclude_query_containers:
+            root_overlap = sum(root_counts.get(signature, 0) > 1 for signature in signatures)
+            subtree_overlap = sum(subtree_counts.get(signature, 0) > 1 for signature in signatures)
+        else:
+            root_overlap = sum(signature in root_prefixes for signature in signatures)
+            subtree_overlap = sum(signature in subtree_prefixes for signature in signatures)
         summaries.append(
             PrefixDepthSummary(
                 depth=depth,
                 query_routes=len(eligible),
-                root_prefix_signature_overlap=sum(
-                    root_overlaps(route.signature(match_level, depth=depth)) for route in eligible
-                ),
-                subtree_prefix_signature_overlap=sum(
-                    subtree_overlaps(route.signature(match_level, depth=depth)) for route in eligible
-                ),
+                root_prefix_signature_overlap=root_overlap,
+                subtree_prefix_signature_overlap=subtree_overlap,
             )
         )
     return tuple(summaries)
-
-
-def _exact_route_signature_overlap(
-    queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
-    match_level: InChIKeyLevel,
-    exclude_query_containers: bool,
-) -> int:
-    overlaps = _signature_overlap_check(
-        index.route_signatures,
-        index.route_signature_counts,
-        exclude_query_containers,
-    )
-    return sum(overlaps(route.signature(match_level)) for route in queries.values())
-
-
-def _reaction_signature_overlap(
-    queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
-    match_level: InChIKeyLevel,
-    exclude_query_containers: bool,
-) -> int:
-    overlaps = _signature_overlap_check(
-        index.reaction_signatures,
-        index.reaction_signature_route_counts,
-        exclude_query_containers,
-    )
-    return len(
-        {
-            signature
-            for route in queries.values()
-            for signature in route.reaction_signatures(match_level)
-            if overlaps(signature)
-        }
-    )
-
-
-def _signature_overlap_check(
-    signatures: set[str],
-    counts: Mapping[str, int],
-    exclude_query_container: bool,
-):
-    if exclude_query_container:
-        return lambda signature: counts.get(signature, 0) > 1
-    return lambda signature: signature in signatures
 
 
 def _full_route_ledger_rows(
     *,
     source: str,
     queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
     exclude_query_containers: bool,
@@ -423,7 +384,7 @@ def _internal_subroute_audit(
     *,
     source: str,
     queries: Mapping[str, Route],
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
     partial_min_reactions: int,
@@ -472,7 +433,7 @@ def _embedding_rows(
     query_route: Route,
     query_molecule: MoleculeView,
     match_kind: EmbeddingMatchKind,
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
     exclude_query_container: bool,
@@ -519,9 +480,9 @@ def _embedding_rows(
 
 def _candidate_occurrences(
     query_root: MoleculeView,
-    index: TrainingEmbeddingIndex,
+    index: ContainerEmbeddingIndex,
     match_level: InChIKeyLevel,
-) -> Sequence[TrainingRouteOccurrence]:
+) -> Sequence[ContainerRouteOccurrence]:
     reaction = query_root.produced_by()
     if reaction is None:
         return ()
@@ -570,7 +531,7 @@ def _summarize_coverage(
         embedded_container_fraction_stats=_fraction_stats(
             [row.matched_fraction_of_container_route for row in embedded_rows]
         ),
-        embedded_mean_training_routes_per_query=_mean([row.training_routes for row in embedded_rows]),
+        embedded_mean_container_routes_per_query=_mean([row.container_routes for row in embedded_rows]),
         embedded_mean_occurrences_per_query=_mean([row.occurrences for row in embedded_rows]),
         matched_fraction_histogram=_coverage_histogram(coverage_rows),
     )
@@ -581,7 +542,7 @@ def _query_coverage_row(rows: Sequence[RouteEmbeddingLedgerRow]) -> _QueryCovera
         return _QueryCoverageRow(
             matched_fraction_of_query_route=0.0,
             matched_fraction_of_container_route=0.0,
-            training_routes=0,
+            container_routes=0,
             occurrences=0,
         )
 
@@ -597,7 +558,7 @@ def _query_coverage_row(rows: Sequence[RouteEmbeddingLedgerRow]) -> _QueryCovera
     return _QueryCoverageRow(
         matched_fraction_of_query_route=_ratio(best.matched_reactions, best.query_route_reactions),
         matched_fraction_of_container_route=_ratio(best.matched_reactions, best.container_route_reactions),
-        training_routes=len({row.container_route_id for row in rows}),
+        container_routes=len({row.container_route_id for row in rows}),
         occurrences=len(rows),
     )
 

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -139,6 +139,8 @@ def build_route_embedding_audit(
     partial_min_reactions: int = 2,
     exclude_query_containers: bool = False,
 ) -> RouteEmbeddingAudit:
+    if exclude_query_containers:
+        _validate_query_container_exclusion(training_records, queries_by_source)
     index = build_training_embedding_index(training_records, match_level)
     query_sets: list[QuerySetAudit] = []
     ledger_rows: list[RouteEmbeddingLedgerRow] = []
@@ -224,6 +226,29 @@ def build_training_embedding_index(
     )
 
 
+def _validate_query_container_exclusion(
+    training_records: Sequence[TrainingRouteRecord],
+    queries_by_source: Mapping[str, Mapping[str, Route]],
+) -> None:
+    container_ids = [record.id for record in training_records]
+    duplicate_ids = {container_id for container_id, count in Counter(container_ids).items() if count > 1}
+    if duplicate_ids:
+        raise ValueError(
+            "exclude_query_containers requires unique TrainingRouteRecord.id values; "
+            f"duplicate ids: {sorted(duplicate_ids)}"
+        )
+
+    container_id_set = set(container_ids)
+    missing_query_ids = sorted(
+        query_id for queries in queries_by_source.values() for query_id in queries if query_id not in container_id_set
+    )
+    if missing_query_ids:
+        raise ValueError(
+            "exclude_query_containers requires query ids to match TrainingRouteRecord.id values; "
+            f"missing ids: {missing_query_ids}"
+        )
+
+
 def _audit_query_set(
     *,
     source: str,
@@ -305,27 +330,17 @@ def _summarize_prefix_depths(
         subtree_prefixes = index.subtree_prefix_signatures_by_depth.get(depth, set())
         root_counts = index.root_prefix_signature_counts_by_depth.get(depth, {})
         subtree_counts = index.subtree_prefix_signature_counts_by_depth.get(depth, {})
+        root_overlaps = _signature_overlap_check(root_prefixes, root_counts, exclude_query_containers)
+        subtree_overlaps = _signature_overlap_check(subtree_prefixes, subtree_counts, exclude_query_containers)
         summaries.append(
             PrefixDepthSummary(
                 depth=depth,
                 query_routes=len(eligible),
                 root_prefix_signature_overlap=sum(
-                    _signature_overlaps(
-                        route.signature(match_level, depth=depth),
-                        root_prefixes,
-                        root_counts,
-                        exclude_self=exclude_query_containers,
-                    )
-                    for route in eligible
+                    root_overlaps(route.signature(match_level, depth=depth)) for route in eligible
                 ),
                 subtree_prefix_signature_overlap=sum(
-                    _signature_overlaps(
-                        route.signature(match_level, depth=depth),
-                        subtree_prefixes,
-                        subtree_counts,
-                        exclude_self=exclude_query_containers,
-                    )
-                    for route in eligible
+                    subtree_overlaps(route.signature(match_level, depth=depth)) for route in eligible
                 ),
             )
         )
@@ -338,15 +353,12 @@ def _exact_route_signature_overlap(
     match_level: InChIKeyLevel,
     exclude_query_containers: bool,
 ) -> int:
-    return sum(
-        _signature_overlaps(
-            route.signature(match_level),
-            index.route_signatures,
-            index.route_signature_counts,
-            exclude_self=exclude_query_containers,
-        )
-        for route in queries.values()
+    overlaps = _signature_overlap_check(
+        index.route_signatures,
+        index.route_signature_counts,
+        exclude_query_containers,
     )
+    return sum(overlaps(route.signature(match_level)) for route in queries.values())
 
 
 def _reaction_signature_overlap(
@@ -355,31 +367,29 @@ def _reaction_signature_overlap(
     match_level: InChIKeyLevel,
     exclude_query_containers: bool,
 ) -> int:
+    overlaps = _signature_overlap_check(
+        index.reaction_signatures,
+        index.reaction_signature_route_counts,
+        exclude_query_containers,
+    )
     return len(
         {
             signature
             for route in queries.values()
             for signature in route.reaction_signatures(match_level)
-            if _signature_overlaps(
-                signature,
-                index.reaction_signatures,
-                index.reaction_signature_route_counts,
-                exclude_self=exclude_query_containers,
-            )
+            if overlaps(signature)
         }
     )
 
 
-def _signature_overlaps(
-    signature: str,
+def _signature_overlap_check(
     signatures: set[str],
     counts: Mapping[str, int],
-    *,
-    exclude_self: bool,
-) -> bool:
-    if not exclude_self:
-        return signature in signatures
-    return counts.get(signature, 0) > 1
+    exclude_query_container: bool,
+):
+    if exclude_query_container:
+        return lambda signature: counts.get(signature, 0) > 1
+    return lambda signature: signature in signatures
 
 
 def _full_route_ledger_rows(

--- a/src/retrocast/curation/training/embedding_audit.py
+++ b/src/retrocast/curation/training/embedding_audit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import ceil
@@ -26,8 +26,12 @@ class TrainingRouteOccurrence:
 class TrainingEmbeddingIndex:
     route_signatures: set[str]
     reaction_signatures: set[str]
+    route_signature_counts: Mapping[str, int]
+    reaction_signature_route_counts: Mapping[str, int]
     root_prefix_signatures_by_depth: Mapping[int, set[str]]
     subtree_prefix_signatures_by_depth: Mapping[int, set[str]]
+    root_prefix_signature_counts_by_depth: Mapping[int, Mapping[str, int]]
+    subtree_prefix_signature_counts_by_depth: Mapping[int, Mapping[str, int]]
     by_reaction_root: Mapping[str, tuple[TrainingRouteOccurrence, ...]]
 
 
@@ -133,6 +137,7 @@ def build_route_embedding_audit(
     allow_leaf_extension: bool = True,
     include_partial: bool = False,
     partial_min_reactions: int = 2,
+    exclude_query_containers: bool = False,
 ) -> RouteEmbeddingAudit:
     index = build_training_embedding_index(training_records, match_level)
     query_sets: list[QuerySetAudit] = []
@@ -146,6 +151,7 @@ def build_route_embedding_audit(
             allow_leaf_extension=allow_leaf_extension,
             include_partial=include_partial,
             partial_min_reactions=partial_min_reactions,
+            exclude_query_containers=exclude_query_containers,
         )
         query_sets.append(query_set)
         ledger_rows.extend(rows)
@@ -169,28 +175,51 @@ def build_training_embedding_index(
 ) -> TrainingEmbeddingIndex:
     route_signatures: set[str] = set()
     reaction_signatures: set[str] = set()
+    route_signature_counts: Counter[str] = Counter()
+    reaction_signature_route_counts: Counter[str] = Counter()
     root_prefix_signatures_by_depth: dict[int, set[str]] = defaultdict(set)
     subtree_prefix_signatures_by_depth: dict[int, set[str]] = defaultdict(set)
+    root_prefix_signature_counts_by_depth: dict[int, Counter[str]] = defaultdict(Counter)
+    subtree_prefix_signature_counts_by_depth: dict[int, Counter[str]] = defaultdict(Counter)
     by_reaction_root: dict[str, list[TrainingRouteOccurrence]] = defaultdict(list)
 
     for record in records:
-        route_signatures.add(record.route.signature(match_level))
-        reaction_signatures.update(record.route.reaction_signatures(match_level))
+        route_signature = record.route.signature(match_level)
+        route_signatures.add(route_signature)
+        route_signature_counts[route_signature] += 1
+        record_reaction_signatures = set(record.route.reaction_signatures(match_level))
+        reaction_signatures.update(record_reaction_signatures)
+        reaction_signature_route_counts.update(record_reaction_signatures)
         for depth in range(1, record.route.depth() + 1):
-            root_prefix_signatures_by_depth[depth].add(record.route.signature(match_level, depth=depth))
+            root_prefix_signature = record.route.signature(match_level, depth=depth)
+            root_prefix_signatures_by_depth[depth].add(root_prefix_signature)
+            root_prefix_signature_counts_by_depth[depth][root_prefix_signature] += 1
+        subtree_prefixes_by_depth: dict[int, set[str]] = defaultdict(set)
         for molecule in record.route.iter_molecules():
             for depth in range(1, molecule.depth() + 1):
-                subtree_prefix_signatures_by_depth[depth].add(molecule.subtree_signature(match_level, depth=depth))
+                subtree_prefix = molecule.subtree_signature(match_level, depth=depth)
+                subtree_prefix_signatures_by_depth[depth].add(subtree_prefix)
+                subtree_prefixes_by_depth[depth].add(subtree_prefix)
             occurrence = TrainingRouteOccurrence(record=record, molecule=molecule)
             reaction = molecule.produced_by()
             if reaction is not None:
                 by_reaction_root[reaction.signature(match_level)].append(occurrence)
+        for depth, signatures in subtree_prefixes_by_depth.items():
+            subtree_prefix_signature_counts_by_depth[depth].update(signatures)
 
     return TrainingEmbeddingIndex(
         route_signatures=route_signatures,
         reaction_signatures=reaction_signatures,
+        route_signature_counts=dict(route_signature_counts),
+        reaction_signature_route_counts=dict(reaction_signature_route_counts),
         root_prefix_signatures_by_depth=dict(root_prefix_signatures_by_depth),
         subtree_prefix_signatures_by_depth=dict(subtree_prefix_signatures_by_depth),
+        root_prefix_signature_counts_by_depth={
+            depth: dict(counts) for depth, counts in root_prefix_signature_counts_by_depth.items()
+        },
+        subtree_prefix_signature_counts_by_depth={
+            depth: dict(counts) for depth, counts in subtree_prefix_signature_counts_by_depth.items()
+        },
         by_reaction_root={key: tuple(value) for key, value in by_reaction_root.items()},
     )
 
@@ -204,6 +233,7 @@ def _audit_query_set(
     allow_leaf_extension: bool,
     include_partial: bool,
     partial_min_reactions: int,
+    exclude_query_containers: bool,
 ) -> tuple[QuerySetAudit, tuple[RouteEmbeddingLedgerRow, ...]]:
     full_rows = _full_route_ledger_rows(
         source=source,
@@ -211,6 +241,7 @@ def _audit_query_set(
         index=index,
         match_level=match_level,
         allow_leaf_extension=allow_leaf_extension,
+        exclude_query_containers=exclude_query_containers,
     )
     internal_summary = None
     internal_rows: tuple[RouteEmbeddingLedgerRow, ...] = ()
@@ -222,6 +253,7 @@ def _audit_query_set(
             match_level=match_level,
             allow_leaf_extension=allow_leaf_extension,
             partial_min_reactions=partial_min_reactions,
+            exclude_query_containers=exclude_query_containers,
         )
 
     rows = (*full_rows, *internal_rows)
@@ -233,11 +265,16 @@ def _audit_query_set(
         source=source,
         query_routes=len(queries),
         query_reaction_signatures=len(query_reaction_signatures),
-        exact_route_signature_overlap=sum(
-            route.signature(match_level) in index.route_signatures for route in queries.values()
+        exact_route_signature_overlap=_exact_route_signature_overlap(
+            queries, index, match_level, exclude_query_containers
         ),
-        reaction_signature_overlap=len(query_reaction_signatures & index.reaction_signatures),
-        prefix_depths=_summarize_prefix_depths(queries=queries, index=index, match_level=match_level),
+        reaction_signature_overlap=_reaction_signature_overlap(queries, index, match_level, exclude_query_containers),
+        prefix_depths=_summarize_prefix_depths(
+            queries=queries,
+            index=index,
+            match_level=match_level,
+            exclude_query_containers=exclude_query_containers,
+        ),
         full_embeddings=_summarize_full_embeddings(full_rows),
         internal_subroute_embeddings=internal_summary,
         coverage=_summarize_coverage(
@@ -258,6 +295,7 @@ def _summarize_prefix_depths(
     queries: Mapping[str, Route],
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
+    exclude_query_containers: bool,
 ) -> tuple[PrefixDepthSummary, ...]:
     max_depth = max((route.depth() for route in queries.values()), default=0)
     summaries: list[PrefixDepthSummary] = []
@@ -265,16 +303,83 @@ def _summarize_prefix_depths(
         eligible = [route for route in queries.values() if route.depth() >= depth]
         root_prefixes = index.root_prefix_signatures_by_depth.get(depth, set())
         subtree_prefixes = index.subtree_prefix_signatures_by_depth.get(depth, set())
-        signatures = [route.signature(match_level, depth=depth) for route in eligible]
+        root_counts = index.root_prefix_signature_counts_by_depth.get(depth, {})
+        subtree_counts = index.subtree_prefix_signature_counts_by_depth.get(depth, {})
         summaries.append(
             PrefixDepthSummary(
                 depth=depth,
                 query_routes=len(eligible),
-                root_prefix_signature_overlap=sum(signature in root_prefixes for signature in signatures),
-                subtree_prefix_signature_overlap=sum(signature in subtree_prefixes for signature in signatures),
+                root_prefix_signature_overlap=sum(
+                    _signature_overlaps(
+                        route.signature(match_level, depth=depth),
+                        root_prefixes,
+                        root_counts,
+                        exclude_self=exclude_query_containers,
+                    )
+                    for route in eligible
+                ),
+                subtree_prefix_signature_overlap=sum(
+                    _signature_overlaps(
+                        route.signature(match_level, depth=depth),
+                        subtree_prefixes,
+                        subtree_counts,
+                        exclude_self=exclude_query_containers,
+                    )
+                    for route in eligible
+                ),
             )
         )
     return tuple(summaries)
+
+
+def _exact_route_signature_overlap(
+    queries: Mapping[str, Route],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    exclude_query_containers: bool,
+) -> int:
+    return sum(
+        _signature_overlaps(
+            route.signature(match_level),
+            index.route_signatures,
+            index.route_signature_counts,
+            exclude_self=exclude_query_containers,
+        )
+        for route in queries.values()
+    )
+
+
+def _reaction_signature_overlap(
+    queries: Mapping[str, Route],
+    index: TrainingEmbeddingIndex,
+    match_level: InChIKeyLevel,
+    exclude_query_containers: bool,
+) -> int:
+    return len(
+        {
+            signature
+            for route in queries.values()
+            for signature in route.reaction_signatures(match_level)
+            if _signature_overlaps(
+                signature,
+                index.reaction_signatures,
+                index.reaction_signature_route_counts,
+                exclude_self=exclude_query_containers,
+            )
+        }
+    )
+
+
+def _signature_overlaps(
+    signature: str,
+    signatures: set[str],
+    counts: Mapping[str, int],
+    *,
+    exclude_self: bool,
+) -> bool:
+    if not exclude_self:
+        return signature in signatures
+    return counts.get(signature, 0) > 1
 
 
 def _full_route_ledger_rows(
@@ -284,6 +389,7 @@ def _full_route_ledger_rows(
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
+    exclude_query_containers: bool,
 ) -> tuple[RouteEmbeddingLedgerRow, ...]:
     rows: list[RouteEmbeddingLedgerRow] = []
     for query_id, route in queries.items():
@@ -297,6 +403,7 @@ def _full_route_ledger_rows(
                 index=index,
                 match_level=match_level,
                 allow_leaf_extension=allow_leaf_extension,
+                exclude_query_container=exclude_query_containers,
             )
         )
     return tuple(rows)
@@ -310,6 +417,7 @@ def _internal_subroute_audit(
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
     partial_min_reactions: int,
+    exclude_query_containers: bool,
 ) -> tuple[InternalSubrouteEmbeddingSummary, tuple[RouteEmbeddingLedgerRow, ...]]:
     checked = 0
     rows: list[RouteEmbeddingLedgerRow] = []
@@ -329,6 +437,7 @@ def _internal_subroute_audit(
                 index=index,
                 match_level=match_level,
                 allow_leaf_extension=allow_leaf_extension,
+                exclude_query_container=exclude_query_containers,
             )
             rows.extend(subroute_rows)
             if subroute_rows:
@@ -356,11 +465,14 @@ def _embedding_rows(
     index: TrainingEmbeddingIndex,
     match_level: InChIKeyLevel,
     allow_leaf_extension: bool,
+    exclude_query_container: bool,
 ) -> tuple[RouteEmbeddingLedgerRow, ...]:
     rows: list[RouteEmbeddingLedgerRow] = []
     query_route_reactions = sum(1 for _ in query_route.iter_reactions())
     query_subroute_reactions = subtree_reaction_count(query_molecule)
     for occurrence in _candidate_occurrences(query_molecule, index, match_level):
+        if exclude_query_container and occurrence.record.id == query_id:
+            continue
         match = route_embeds_at(
             query_molecule,
             occurrence.molecule,

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -14,7 +14,7 @@ from retrocast.markdown import MarkdownAlign, MarkdownRow, markdown_table
 def render_route_embedding_audit_markdown(
     audit: RouteEmbeddingAudit,
     *,
-    container_label: str = "training",
+    container_label: str = "container",
 ) -> str:
     container_route_label = f"{container_label} route"
     lines = [
@@ -24,9 +24,9 @@ def render_route_embedding_audit_markdown(
         f"- allow leaf extension: `{str(audit.allow_leaf_extension).lower()}`",
         "- partial minimum reactions: "
         f"{f'{audit.partial_min_reactions} reactions' if audit.partial_min_reactions is not None else 'not run'}",
-        f"- {container_label} routes: {_format_integer(audit.training_routes)}",
-        f"- {container_route_label} signatures: {_format_integer(audit.training_route_signatures)}",
-        f"- {container_label} reaction signatures: {_format_integer(audit.training_reaction_signatures)}",
+        f"- {container_label} routes: {_format_integer(audit.container_routes)}",
+        f"- {container_route_label} signatures: {_format_integer(audit.container_route_signatures)}",
+        f"- {container_label} reaction signatures: {_format_integer(audit.container_reaction_signatures)}",
         "",
         "terms: a query route is the route being searched for. "
         f"a container route is a {container_route_label} where an embedding is found.",
@@ -188,7 +188,7 @@ def _best_match_coverage(
             [
                 "",
                 f"query routes with any embedding match "
-                f"{coverage.embedded_mean_training_routes_per_query:.2f} "
+                f"{coverage.embedded_mean_container_routes_per_query:.2f} "
                 f"unique {container_route_label}s and "
                 f"{coverage.embedded_mean_occurrences_per_query:.2f} "
                 "total occurrences per query route on average.",

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -11,7 +11,12 @@ from retrocast.curation.training.embedding_audit import (
 from retrocast.markdown import MarkdownAlign, MarkdownRow, markdown_table
 
 
-def render_route_embedding_audit_markdown(audit: RouteEmbeddingAudit) -> str:
+def render_route_embedding_audit_markdown(
+    audit: RouteEmbeddingAudit,
+    *,
+    container_label: str = "training",
+) -> str:
+    container_route_label = f"{container_label} route"
     lines = [
         f"# route embedding audit: {audit.release_name}",
         "",
@@ -19,27 +24,27 @@ def render_route_embedding_audit_markdown(audit: RouteEmbeddingAudit) -> str:
         f"- allow leaf extension: `{str(audit.allow_leaf_extension).lower()}`",
         "- partial minimum reactions: "
         f"{f'{audit.partial_min_reactions} reactions' if audit.partial_min_reactions is not None else 'not run'}",
-        f"- training routes: {_format_integer(audit.training_routes)}",
-        f"- training route signatures: {_format_integer(audit.training_route_signatures)}",
-        f"- training reaction signatures: {_format_integer(audit.training_reaction_signatures)}",
+        f"- {container_label} routes: {_format_integer(audit.training_routes)}",
+        f"- {container_route_label} signatures: {_format_integer(audit.training_route_signatures)}",
+        f"- {container_label} reaction signatures: {_format_integer(audit.training_reaction_signatures)}",
         "",
         "terms: a query route is the route being searched for. "
-        "a container route is a training route where an embedding is found.",
+        f"a container route is a {container_route_label} where an embedding is found.",
         "",
-        _summary_table(audit.query_sets),
+        _summary_table(audit.query_sets, container_label=container_label),
     ]
 
     for query_set in audit.query_sets:
         lines.extend(["", f"## {query_set.source}", ""])
-        lines.extend(["### overlap summary", "", _overlap_summary(query_set)])
-        lines.extend(["", _prefix_depth_summary(query_set)])
+        lines.extend(["### overlap summary", "", _overlap_summary(query_set, container_label=container_label)])
+        lines.extend(["", _prefix_depth_summary(query_set, container_label=container_label)])
         if query_set.internal_subroute_embeddings is not None:
             lines.extend(["", _internal_subroute_summary(query_set, query_set.internal_subroute_embeddings)])
-        lines.extend(["", _best_match_coverage(query_set.coverage)])
+        lines.extend(["", _best_match_coverage(query_set.coverage, container_route_label=container_route_label)])
     return "\n".join(lines) + "\n"
 
 
-def _summary_table(query_sets: Sequence[QuerySetAudit]) -> str:
+def _summary_table(query_sets: Sequence[QuerySetAudit], *, container_label: str) -> str:
     align: list[MarkdownAlign] = ["left"]
     for _ in query_sets:
         align.append("right")
@@ -50,7 +55,7 @@ def _summary_table(query_sets: Sequence[QuerySetAudit]) -> str:
     rows = [
         row("query routes", [_format_integer(q.query_routes) for q in query_sets]),
         row(
-            "reaction signatures in training",
+            f"reaction signatures in {container_label}",
             [_format_count_rate(q.reaction_signature_overlap, q.query_reaction_signatures) for q in query_sets],
         ),
         row(
@@ -66,30 +71,30 @@ def _summary_table(query_sets: Sequence[QuerySetAudit]) -> str:
     return markdown_table(["metric", *(query_set.source for query_set in query_sets)], rows, align=align)
 
 
-def _overlap_summary(query_set: QuerySetAudit) -> str:
+def _overlap_summary(query_set: QuerySetAudit, *, container_label: str) -> str:
     full = query_set.full_embeddings
     lines = [
         f"{_format_count_rate(query_set.reaction_signature_overlap, query_set.query_reaction_signatures)} "
-        "reaction signatures are present in training; "
+        f"reaction signatures are present in {container_label}; "
         f"{_format_count_rate(query_set.exact_route_signature_overlap, query_set.query_routes)} "
         "query routes have exact route-signature matches.",
         "",
     ]
     if full.query_routes_with_embedding == 0:
-        lines.append("no query routes are fully embedded in training.")
+        lines.append(f"no query routes are fully embedded in {container_label}.")
         return "\n".join(lines)
 
     distance_counts = dict(full.root_distance_counts)
     lines.append(
         f"{_format_count_rate(full.query_routes_with_embedding, query_set.query_routes)} "
-        "query routes are fully embedded somewhere inside training routes. "
+        f"query routes are fully embedded somewhere inside {container_label} routes. "
         f"these produce {_format_integer(full.embedding_occurrences)} total matching occurrences. "
         f"{_format_plural(full.query_routes_with_root_shifted_embedding, 'query route has', 'query routes have')} "
         "a root-shifted full embedding; "
         f"{_format_plural(full.query_routes_with_leaf_extended_embedding, 'query route has', 'query routes have')} "
         "a leaf-extended full embedding. "
         f"{_format_plural(distance_counts.get(0, 0), 'occurrence shares', 'occurrences share')} "
-        "the training target (distance 0 from the root); "
+        f"the {container_label} target (distance 0 from the root); "
         f"{_format_root_distance_sentence(full.root_distance_counts)}."
     )
     return "\n".join(lines)
@@ -114,15 +119,20 @@ def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrou
     )
 
 
-def _prefix_depth_summary(query_set: QuerySetAudit) -> str:
+def _prefix_depth_summary(query_set: QuerySetAudit, *, container_label: str) -> str:
     return "\n".join(
         [
             "### root-prefix overlap",
             "",
-            "query route prefixes are compared to training route prefixes with `route.signature(depth=k)`.",
+            f"query route prefixes are compared to {container_label} route prefixes with `route.signature(depth=k)`.",
             "",
             markdown_table(
-                ["prefix depth", "query routes with depth", "found at training root", "found anywhere in training"],
+                [
+                    "prefix depth",
+                    "query routes with depth",
+                    f"found at {container_label} root",
+                    f"found anywhere in {container_label}",
+                ],
                 [
                     (
                         row.depth,
@@ -138,7 +148,11 @@ def _prefix_depth_summary(query_set: QuerySetAudit) -> str:
     )
 
 
-def _best_match_coverage(coverage: CoverageSummary) -> str:
+def _best_match_coverage(
+    coverage: CoverageSummary,
+    *,
+    container_route_label: str,
+) -> str:
     lines = [
         "### best-match coverage",
         "",
@@ -158,7 +172,7 @@ def _best_match_coverage(coverage: CoverageSummary) -> str:
             embedded_values=coverage.embedded_query_fraction_stats,
         ),
         "",
-        "#### matched fraction of training route",
+        f"#### matched fraction of {container_route_label}",
         "",
         "matched reactions divided by all reactions in the container route.",
         "",
@@ -175,7 +189,7 @@ def _best_match_coverage(coverage: CoverageSummary) -> str:
                 "",
                 f"query routes with any embedding match "
                 f"{coverage.embedded_mean_training_routes_per_query:.2f} "
-                "unique training routes and "
+                f"unique {container_route_label}s and "
                 f"{coverage.embedded_mean_occurrences_per_query:.2f} "
                 "total occurrences per query route on average.",
             ]

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -92,6 +92,38 @@ def test_route_embedding_audit_can_include_internal_subroutes() -> None:
     ]
 
 
+@pytest.mark.integration
+def test_route_embedding_audit_can_exclude_query_containers() -> None:
+    route = route_c_b_a()
+    record = route_record("self", route)
+
+    audit = build_route_embedding_audit(
+        release_name="benchmark-route-embeddings",
+        training_records=[record],
+        queries_by_source={"bench": {record.id: route}},
+        include_partial=True,
+        partial_min_reactions=1,
+        exclude_query_containers=True,
+    )
+
+    query_set = audit.query_sets[0]
+    internal = query_set.internal_subroute_embeddings
+    assert internal is not None
+    assert query_set.reaction_signature_overlap == 0
+    assert query_set.exact_route_signature_overlap == 0
+    assert [
+        (
+            row.depth,
+            row.root_prefix_signature_overlap,
+            row.subtree_prefix_signature_overlap,
+        )
+        for row in query_set.prefix_depths
+    ] == [(1, 0, 0), (2, 0, 0)]
+    assert query_set.full_embeddings.query_routes_with_embedding == 0
+    assert internal.query_routes_with_embedding == 0
+    assert audit.ledger_rows == ()
+
+
 def sample_full_match_audit() -> RouteEmbeddingAudit:
     training = route_record("container", route_c_b_a())
     queries = {

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -59,11 +59,11 @@ def test_route_embedding_report_renders_audit_summary() -> None:
 
 @pytest.mark.integration
 def test_route_embedding_audit_can_include_internal_subroutes() -> None:
-    training = route_record("container", route_c_b_a())
+    container = route_record("container", route_c_b_a())
 
     audit = build_route_embedding_audit(
         release_name="route-holdout-n1-n5",
-        training_records=[training],
+        container_records=[container],
         queries_by_source={"bench": {"full": route_c_b_a()}},
         include_partial=True,
         partial_min_reactions=1,
@@ -99,7 +99,7 @@ def test_route_embedding_audit_can_exclude_query_containers() -> None:
 
     audit = build_route_embedding_audit(
         release_name="benchmark-route-embeddings",
-        training_records=[record],
+        container_records=[record],
         queries_by_source={"bench": {record.id: route}},
         include_partial=True,
         partial_min_reactions=1,
@@ -126,10 +126,10 @@ def test_route_embedding_audit_can_exclude_query_containers() -> None:
 
 @pytest.mark.integration
 def test_route_embedding_audit_rejects_exclusion_without_matching_query_id() -> None:
-    with pytest.raises(ValueError, match="query ids to match TrainingRouteRecord.id"):
+    with pytest.raises(ValueError, match="query ids to match container record ids"):
         build_route_embedding_audit(
             release_name="benchmark-route-embeddings",
-            training_records=[route_record("container", route_c_b_a())],
+            container_records=[route_record("container", route_c_b_a())],
             queries_by_source={"bench": {"query": route_c_b_a()}},
             exclude_query_containers=True,
         )
@@ -140,17 +140,17 @@ def test_route_embedding_audit_rejects_exclusion_with_duplicate_container_ids() 
     route = route_c_b_a()
     records = [route_record("duplicate", route), route_record("duplicate", route)]
 
-    with pytest.raises(ValueError, match="unique TrainingRouteRecord.id"):
+    with pytest.raises(ValueError, match="unique container record ids"):
         build_route_embedding_audit(
             release_name="benchmark-route-embeddings",
-            training_records=records,
+            container_records=records,
             queries_by_source={"bench": {records[0].id: route}},
             exclude_query_containers=True,
         )
 
 
 def sample_full_match_audit() -> RouteEmbeddingAudit:
-    training = route_record("container", route_c_b_a())
+    container = route_record("container", route_c_b_a())
     queries = {
         "shifted": Route(target=molecule("b", KEY_B, reactants=[molecule("a", KEY_A)])),
         "leaf": Route(target=molecule("c", KEY_C, reactants=[molecule("b", KEY_B)])),
@@ -159,7 +159,7 @@ def sample_full_match_audit() -> RouteEmbeddingAudit:
 
     return build_route_embedding_audit(
         release_name="route-holdout-n1-n5",
-        training_records=[training],
+        container_records=[container],
         queries_by_source={"bench": queries},
     )
 

--- a/tests/curation/test_training_embedding_audit.py
+++ b/tests/curation/test_training_embedding_audit.py
@@ -124,6 +124,31 @@ def test_route_embedding_audit_can_exclude_query_containers() -> None:
     assert audit.ledger_rows == ()
 
 
+@pytest.mark.integration
+def test_route_embedding_audit_rejects_exclusion_without_matching_query_id() -> None:
+    with pytest.raises(ValueError, match="query ids to match TrainingRouteRecord.id"):
+        build_route_embedding_audit(
+            release_name="benchmark-route-embeddings",
+            training_records=[route_record("container", route_c_b_a())],
+            queries_by_source={"bench": {"query": route_c_b_a()}},
+            exclude_query_containers=True,
+        )
+
+
+@pytest.mark.integration
+def test_route_embedding_audit_rejects_exclusion_with_duplicate_container_ids() -> None:
+    route = route_c_b_a()
+    records = [route_record("duplicate", route), route_record("duplicate", route)]
+
+    with pytest.raises(ValueError, match="unique TrainingRouteRecord.id"):
+        build_route_embedding_audit(
+            release_name="benchmark-route-embeddings",
+            training_records=records,
+            queries_by_source={"bench": {records[0].id: route}},
+            exclude_query_containers=True,
+        )
+
+
 def sample_full_match_audit() -> RouteEmbeddingAudit:
     training = route_record("container", route_c_b_a())
     queries = {


### PR DESCRIPTION
## why
benchmark acceptable routes can overlap structurally, but we did not have a small audit that asks the same route-embedding questions as the training-set contamination report. this made it hard to tell whether benchmark targets are genuinely distinct or whether acceptable routes embed inside other targets.

## what changed
added a benchmark route-embedding audit script that loads primary acceptable routes, runs each benchmark as both query and container set, excludes the query route itself from container matches, and renders through the existing route-embedding markdown report shape. the shared audit now has a narrow `exclude_query_containers` mode so benchmark audits can reuse the same summaries without self-match contamination.

## risk
main risk is metric semantics: training-set audits must keep their old behavior, while benchmark audits must not count each route against itself. the new mode defaults off, and the regression test covers the self-exclusion boundary for exact route, reaction, prefix, full-route, and internal-subroute counts.

## verification
- `uv run ruff check scripts/06-audit-benchmark-route-embeddings.py src/retrocast/curation/training/embedding_audit.py src/retrocast/curation/training/embedding_report.py tests/curation/test_training_embedding_audit.py`
- `uv run pytest tests/curation/test_training_embedding_audit.py`
- `uv run scripts/06-audit-benchmark-route-embeddings.py --benchmarks mkt-cnv-160 uspto-190`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023138&installation_id=125602297&pr_number=125&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F125&signature=10406a7cd2084d7229d7d8dc416588210346a8900cc0244c01b4aad64ade26f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new audit script for route-pattern embeddings in benchmarks, supporting flexible route selection with configurable reporting options.

* **Improvements**
  * Enhanced embedding audit system with container-level metrics and optional query container exclusion for more accurate overlap detection in reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a benchmark route-embedding audit script that mirrors the existing training-set contamination report but runs each benchmark as both query and container set, excluding each route from matching against itself. The shared `embedding_audit` module is extended with an `exclude_query_containers` mode (defaulting off) backed by new per-signature count fields added to the container index.

- `build_container_embedding_index` now tracks `route_signature_counts` and `reaction_signature_route_counts` (plus per-depth prefix counts) so self-exclusion can be applied as a `> 1` threshold rather than set membership.
- `build_route_embedding_audit` validates ID uniqueness and full query-ID-to-container-ID coverage before entering the exclude path, and the check is applied uniformly across exact-route, reaction-signature, prefix-depth, full-route, and internal-subroute metrics.
- The new `merge_audits` helper derives header statistics from a freshly built combined index over all benchmark records, correctly deduplicating cross-benchmark signatures rather than summing per-benchmark counts.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new mode defaults off, existing training-set audits are unaffected, and the self-exclusion logic is applied consistently across every metric path.

The self-exclusion threshold (count > 1) is correctly wired at all six metric sites — exact route, reaction signature, prefix-depth root, prefix-depth subtree, full-route ledger rows, and internal-subroute ledger rows. The combined index used for merged header statistics is built from all benchmark records in a single pass, so cross-benchmark signature deduplication is handled correctly rather than summed. Validation guards surface mis-configured callers early with clear error messages, and the new tests exercise all the self-exclusion boundaries.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/06-audit-benchmark-route-embeddings.py | New script that runs per-benchmark embedding audits with exclude_query_containers=True, then merges them into a combined report using a fresh deduplicated index for the header statistics. |
| src/retrocast/curation/training/embedding_audit.py | Core logic extended with exclude_query_containers mode; adds count-based index fields and self-exclusion guards at exact-route, reaction-signature, prefix-depth, full-route, and internal-subroute levels. Renamed Training* classes/fields to Container* throughout. |
| src/retrocast/curation/training/embedding_report.py | Updated to reference renamed CoverageSummary field (embedded_mean_container_routes_per_query); container_label parameter allows "benchmark" vs "training" labeling in rendered output. |
| tests/curation/test_training_embedding_audit.py | New tests cover self-exclusion at all metric boundaries (exact route, reaction, prefix, full-route, internal-subroute), plus validation tests for duplicate container IDs and mismatched query IDs. |
| scripts/paroutes/training-set-prep/05-audit-route-embeddings.py | Updated call sites to use renamed parameter container_records; passes container_label="training" to preserve old report labeling. No behavioral change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[06-audit-benchmark-route-embeddings.py] --> B[load_benchmark_records\nper benchmark]
    B --> C[build_route_embedding_audit\nexclude_query_containers=True]
    C --> D{exclude_query_containers\nvalidation}
    D -->|duplicate IDs| E[raise ValueError]
    D -->|missing query IDs| F[raise ValueError]
    D -->|valid| G[build_container_embedding_index\nwith count fields]
    G --> H[_audit_query_set]
    H --> I[exact-route overlap\ncount > 1]
    H --> J[reaction-signature overlap\ncount > 1]
    H --> K[prefix-depth overlap\ncount > 1]
    H --> L[_full_route_ledger_rows\nskip if record.id == query_id]
    H --> M[_internal_subroute_audit\nskip if record.id == query_id]
    A --> N[build_container_embedding_index\nall_records combined]
    N --> O[merge_audits\ndeduplicated header counts]
    O --> P[render_route_embedding_audit_markdown\ncontainer_label=benchmark]
```

<sub>Reviews (3): Last reviewed commit: ["final clean up"](https://github.com/ischemist/project-procrustes/commit/13a07aed535e244696aa876f6ffa11ced6803b73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35229529)</sub>

<!-- /greptile_comment -->