### PR TITLE
feat: add pre-adapted PaRoutes n1/n5 test sets

### DIFF
--- a/data/retrocast/releases/paroutes-training-sets/v2026-05-12/SHA256SUMS
+++ b/data/retrocast/releases/paroutes-training-sets/v2026-05-12/SHA256SUMS
@@ -1,0 +1,17 @@
+fcf89172cb3a4d8b8649326703572da9d6f7c24c017442ad95707fa48288246e  reaction-holdout-n1-n5/all.jsonl.gz
+5f7de3ce82ef7a39fc50b09a918583ee4956552be33427fea2481f7bf779dd37  reaction-holdout-n1-n5/manifest.json
+f9150f0f13bb4ca7ee3688f18bfb67d2abc7faa3b07ada3b954f9e7466b50584  reaction-holdout-n1-n5/training.jsonl.gz
+0f1e12f3993f6af1bd38e18828cbd1c51996cc9496032cb4bc668536a7a14cda  reaction-holdout-n1-n5/validation.jsonl.gz
+e050b0f395e4bac9e04eb86260374c88336b75404f3239a37347ee3c07ce2a84  route-holdout-n1-n5/all.jsonl.gz
+a72243cdf06b1408c05ad3e03d64858dc8a01a4d4765ac70af9e53b5a085f715  route-holdout-n1-n5/manifest.json
+be933d17fd52a44e226b0efa43b362e20acb1a2ee2aa646a0d125d4d14c06344  route-holdout-n1-n5/route-embedding-audit.md
+c59dee1bb7d0a48fde9d12a95769ff5642ebf51a46876476083dcc6ea71cc818  route-holdout-n1-n5/route-embedding-ledger.jsonl.gz
+9ed1510c1c4b1171f37d7add0e22f73c66fb0ad52ee2a06b987d28226284c11a  route-holdout-n1-n5/training.jsonl.gz
+a4c6c94b988c079f7422160640c09b24c3218ab8f0e0378bb2d41d8e8400afea  route-holdout-n1-n5/validation.jsonl.gz
+fadc97d1403908c3d88dc773238309b3988fb871178e4b0e738f3536c8f5bcce  single-step-reaction-holdout-n1-n5/all.jsonl.gz
+c2126aa5b7f391768f671e7b124defeb63bf165a0c9365da69ed0bc28d0913f3  single-step-reaction-holdout-n1-n5/all.rsmi.txt.gz
+f699598272d661962e98b9dfa71edce87fa94660e776d878b9ab96c9db337411  single-step-reaction-holdout-n1-n5/manifest.json
+b52a1708b6c86c94e2e8ccd9ca068da0289f22a4805ef76f45902fe7bf4b9b2a  single-step-reaction-holdout-n1-n5/training.jsonl.gz
+28585ca060d2682047e6a25c12e96bf16edc5b1a491f82014144b852e6d23620  single-step-reaction-holdout-n1-n5/training.rsmi.txt.gz
+a2973f7fbab61963c50e75054c33f865b4f5e557da8663d735d04b461504a54a  single-step-reaction-holdout-n1-n5/validation.jsonl.gz
+b8cfa5e5b4dbc2cf71223afc997715db87955fb17beed76b7d6fe07ab16dcc13  single-step-reaction-holdout-n1-n5/validation.rsmi.txt.gz

--- a/docs/dev/rationale/training-set-releases.md
+++ b/docs/dev/rationale/training-set-releases.md
@@ -28,13 +28,23 @@ RetroCast is an open-source effort, so we do not release this as an authoritativ
 
 ## Overview
 
-RetroCast produces three PaRoutes-derived artifacts from `all-routes.json.gz`, `n1-routes.json.gz`, and `n5-routes.json.gz`:
+RetroCast produces PaRoutes-derived training and test set artifacts from `all-routes.json.gz`, `n1-routes.json.gz`, and `n5-routes.json.gz`.
+
+Training artifacts:
 
 1. `route-holdout-n1-n5`
 2. `reaction-holdout-n1-n5`
-3. `single-step-reaction-holdout-n1-n5`
+3. `single-step-route-holdout-n1-n5`
+4. `single-step-reaction-holdout-n1-n5`
 
-`all` is the candidate training universe. `n1` and `n5` are the holdout reference sets.
+Test set artifacts:
+
+1. `n1-routes`
+2. `n5-routes`
+3. `n1-single-step-reactions`
+4. `n5-single-step-reactions`
+
+`all` is the candidate training universe. `n1` and `n5` are the holdout test sets.
 
 ## Route Releases
 
@@ -90,15 +100,29 @@ Entrypoint:
 
 Implementation:
 
-- `load_training_route_records()` reads the released `reaction-holdout-n1-n5` route artifact.
-- `TrainingReactionReleaseBuilder` flattens routes into reactions, deduplicates each split, and removes validation reactions that overlap training.
+- `load_training_route_records()` reads released route artifacts.
+- `TrainingReactionReleaseBuilder` flattens routes into reactions, deduplicates each split, and applies holdout-specific split cleanup.
 - `write_training_reaction_release()` writes the final artifact.
 
-The single-step release does not re-adapt raw PaRoutes. It derives from the released `reaction-holdout-n1-n5` route artifact so the single-step predictor and multistep planner train from compatible data.
+The single-step releases do not re-adapt raw PaRoutes. They derive from released route artifacts so the single-step predictor and multistep planner train from compatible data.
+
+`single-step-route-holdout-n1-n5` derives from `route-holdout-n1-n5`. Because route holdout only excludes exact holdout routes, flattened training and validation splits may share reaction identities. RetroCast reports that overlap in the build summary and audit instead of removing it.
+
+`single-step-reaction-holdout-n1-n5` derives from `reaction-holdout-n1-n5`. Because this artifact is intended for one-step reaction training, validation reactions that overlap training are removed after split-level deduplication.
 
 Each flattened reaction keeps reactants, product, mapped smiles, alternative mapped smiles, condition metadata, and route-step provenance. Reaction sources store `route_id`, `step_index`, and optional PaRoutes `source_id`; raw route hashes and patent ids stay in the parent route release.
 
 The structured `jsonl.gz` files are canonical. The `*.rsmi.txt.gz` files are convenience exports.
+
+## Test Set Releases
+
+Entrypoint:
+
+- `scripts/paroutes/training-set-prep/06-create-test-set-release.py`
+
+`n1-routes` and `n5-routes` adapt the original PaRoutes test set routes into RetroCast `Route` records. They publish only `all.jsonl.gz`.
+
+`n1-single-step-reactions` and `n5-single-step-reactions` flatten those adapted test set routes into route-step reaction records. They are occurrence-preserving: if the same reaction appears in multiple test set routes, or multiple times inside one test set route, each occurrence remains in the release with route-step provenance. They publish `all.jsonl.gz` and `all.rsmi.txt.gz`.
 
 ## Audit
 

--- a/docs/guides/training-sets.md
+++ b/docs/guides/training-sets.md
@@ -90,7 +90,7 @@ Pick one of two workflows:
     data/datasets/paroutes/<release>/<artifact>/<file>
     ```
 
-One-step reaction training uses the same flow with `artifact="single-step-reaction-holdout-n1-n5"` or `artifact="single-step-route-holdout-n1-n5"`. By default that downloads the canonical `jsonl` artifact. Pass `format="rsmi"` if you specifically want the plain reaction-smiles text file.
+One-step reaction training uses the same flow with `artifact="single-step-reaction-holdout-n1-n5"` or `artifact="single-step-route-holdout-n1-n5"`. By default, that downloads the canonical `jsonl` artifact. Pass `format="rsmi"` if you specifically want the plain reaction-smiles text file.
 
 The original PaRoutes n1/n5 test sets are also published as all-only artifacts: `n1-routes`, `n5-routes`, `n1-single-step-reactions`, and `n5-single-step-reactions`. Use `split="all"` for those.
 

--- a/docs/guides/training-sets.md
+++ b/docs/guides/training-sets.md
@@ -90,7 +90,9 @@ Pick one of two workflows:
     data/datasets/paroutes/<release>/<artifact>/<file>
     ```
 
-One-step reaction training uses the same flow with `artifact="single-step-reaction-holdout-n1-n5"`. By default that downloads the canonical `jsonl` artifact. Pass `format="rsmi"` if you specifically want the plain reaction-smiles text file.
+One-step reaction training uses the same flow with `artifact="single-step-reaction-holdout-n1-n5"` or `artifact="single-step-route-holdout-n1-n5"`. By default that downloads the canonical `jsonl` artifact. Pass `format="rsmi"` if you specifically want the plain reaction-smiles text file.
+
+The original PaRoutes n1/n5 test sets are also published as all-only artifacts: `n1-routes`, `n5-routes`, `n1-single-step-reactions`, and `n5-single-step-reactions`. Use `split="all"` for those.
 
 When a real download happens in an interactive terminal, RetroCast shows a progress bar automatically. Pass `show_progress=False` to suppress it or `show_progress=True` to force it.
 
@@ -108,8 +110,13 @@ Use `reaction-holdout-n1-n5` unless you specifically need a route-holdout baseli
 
 | artifact | intended training target | holdout rule | valid `format` values | files published per split |
 | --- | --- | --- | --- | --- |
+| `n1-routes` | test set/evaluation routes | original PaRoutes n1 routes adapted to RetroCast `Route` records | `jsonl` | `all.jsonl.gz` |
+| `n5-routes` | test set/evaluation routes | original PaRoutes n5 routes adapted to RetroCast `Route` records | `jsonl` | `all.jsonl.gz` |
 | `route-holdout-n1-n5` | multistep route models | remove exact `n1 ∪ n5` routes | `jsonl` | `all.jsonl.gz`, `training.jsonl.gz`, `validation.jsonl.gz` |
 | `reaction-holdout-n1-n5` | multistep route models | remove exact holdout routes, then excise holdout reactions | `jsonl` | `all.jsonl.gz`, `training.jsonl.gz`, `validation.jsonl.gz` |
+| `n1-single-step-reactions` | test set/evaluation reactions | flatten original n1 routes, preserving route-step occurrences | `jsonl`, `rsmi` | `all.jsonl.gz`, `all.rsmi.txt.gz` |
+| `n5-single-step-reactions` | test set/evaluation reactions | flatten original n5 routes, preserving route-step occurrences | `jsonl`, `rsmi` | `all.jsonl.gz`, `all.rsmi.txt.gz` |
+| `single-step-route-holdout-n1-n5` | one-step reaction models | flatten `route-holdout-n1-n5` routes into deduplicated reactions; cross-split reaction overlap is reported, not removed | `jsonl`, `rsmi` | `all.jsonl.gz`, `training.jsonl.gz`, `validation.jsonl.gz`, `all.rsmi.txt.gz`, `training.rsmi.txt.gz`, `validation.rsmi.txt.gz` |
 | `single-step-reaction-holdout-n1-n5` | one-step reaction models | flatten `reaction-holdout-n1-n5` routes into deduplicated reactions | `jsonl`, `rsmi` | `all.jsonl.gz`, `training.jsonl.gz`, `validation.jsonl.gz`, `all.rsmi.txt.gz`, `training.rsmi.txt.gz`, `validation.rsmi.txt.gz` |
 
 Each artifact directory includes:

--- a/get-training-set.sh
+++ b/get-training-set.sh
@@ -147,6 +147,8 @@ main() {
             ;;
     esac
 
+    validate_omit_parts "$OMIT"
+
     RESOLVED_RELEASE="$RELEASE"
     if [ "$RELEASE" = "latest" ]; then
         RESOLVED_RELEASE="$(resolve_latest_release "$BASE_URL" "$DATASET")"
@@ -168,7 +170,10 @@ main() {
     mkdir -p "$RELEASE_DIR"
     curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS_PATH"
 
-    mapfile -t DOWNLOAD_KEYS < <(resolve_download_keys "$ARTIFACT" "$SPLIT" "$FORMAT" "$OMIT")
+    DOWNLOAD_KEYS=()
+    while IFS= read -r key; do
+        DOWNLOAD_KEYS+=("$key")
+    done < <(resolve_download_keys "$ARTIFACT" "$SPLIT" "$FORMAT" "$OMIT")
     if [ "${#DOWNLOAD_KEYS[@]}" -eq 0 ]; then
         echo -e "${R}error: no published files match request${NC}" >&2
         exit 1
@@ -235,6 +240,28 @@ resolve_latest_release() {
     echo "$latest_release"
 }
 
+validate_omit_parts() {
+    local omit="$1"
+    local part
+
+    [ -z "$omit" ] && return 0
+    while IFS= read -r part; do
+        case "$part" in
+            ""|all|training|validation|jsonl|rsmi) ;;
+            *)
+                echo -e "${R}error: unsupported omit part '$part'${NC}" >&2
+                exit 1
+                ;;
+        esac
+    done < <(printf '%s\n' "$omit" | awk '{
+        count = split($0, parts, ",")
+        for (i = 1; i <= count; i++) {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", parts[i])
+            print parts[i]
+        }
+    }')
+}
+
 resolve_download_keys() {
     local artifact="$1"
     local split="$2"
@@ -243,6 +270,9 @@ resolve_download_keys() {
 
     awk -v artifact="$artifact" -v split_filter="$split" -v format_filter="$format" -v omit="$omit" '
         function has_omitted_part(file, parts, count, i) {
+            if (omit == "") {
+                return 0
+            }
             count = split_csv(omit, parts)
             for (i = 1; i <= count; i++) {
                 if (parts[i] != "" && file_part_matches(file, parts[i])) {
@@ -270,7 +300,7 @@ resolve_download_keys() {
             file = key
             sub(/^.*\//, "", file)
             if (file == "manifest.json") {
-                if (split_filter == "" && format_filter == "") {
+                if (artifact != "" || (split_filter == "" && format_filter == "")) {
                     print key
                 }
                 next

--- a/get-training-set.sh
+++ b/get-training-set.sh
@@ -10,9 +10,11 @@ main() {
     OUTPUT_DIR=""
     DATASET="paroutes"
     ARTIFACT=""
-    SPLIT="training"
-    FORMAT="jsonl"
+    SPLIT=""
+    FORMAT=""
     RELEASE="latest"
+    RELEASE_EXPLICIT=0
+    OMIT=""
     DRY_RUN=0
 
     R='\033[0;31m'
@@ -23,19 +25,25 @@ main() {
         echo ""
         echo -e "${B}usage:${NC}"
         if [ -t 0 ]; then
-            echo "  $0 <artifact> [flags]"
+            echo "  $0 [artifact|release] [flags]"
         else
-            echo "  ... | bash -s -- <artifact> [flags]"
+            echo "  ... | bash -s -- [artifact|release] [flags]"
         fi
         echo ""
         echo -e "${B}artifacts:${NC}"
+        echo "  n1-routes"
+        echo "  n5-routes"
         echo "  route-holdout-n1-n5"
         echo "  reaction-holdout-n1-n5"
+        echo "  n1-single-step-reactions"
+        echo "  n5-single-step-reactions"
+        echo "  single-step-route-holdout-n1-n5"
         echo "  single-step-reaction-holdout-n1-n5"
         echo ""
         echo -e "${B}flags:${NC}"
-        echo "  --split=all|training|validation"
-        echo "  --format=jsonl|rsmi"
+        echo "  --split=all|training|validation  only download one split"
+        echo "  --format=jsonl|rsmi              only download one format"
+        echo "  --omit=PART[,PART...]            omit splits or formats"
         echo "  --release=latest|vYYYY-MM-DD"
         echo "  --dataset=paroutes"
         echo "  --dir=PATH  materialize into an explicit project-owned directory"
@@ -56,7 +64,8 @@ main() {
             -V|--version) show_version ;;
             --split=*) SPLIT="${1#*=}"; shift ;;
             --format=*) FORMAT="${1#*=}"; shift ;;
-            --release=*) RELEASE="${1#*=}"; shift ;;
+            --omit=*) OMIT="${1#*=}"; shift ;;
+            --release=*) RELEASE="${1#*=}"; RELEASE_EXPLICIT=1; shift ;;
             --dataset=*) DATASET="${1#*=}"; shift ;;
             --dir=*) OUTPUT_DIR="${1#*=}"; shift ;;
             --dry-run) DRY_RUN=1; shift ;;
@@ -66,9 +75,17 @@ main() {
                 ;;
             *)
                 if [ -z "$ARTIFACT" ]; then
-                    ARTIFACT="$1"
+                    case "$1" in
+                        v[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+                            RELEASE="$1"
+                            RELEASE_EXPLICIT=1
+                            ;;
+                        *)
+                            ARTIFACT="$1"
+                            ;;
+                    esac
                 else
-                    echo -e "${R}error: multiple artifacts specified${NC}" >&2
+                    echo -e "${R}error: multiple positional arguments specified${NC}" >&2
                     usage
                 fi
                 shift
@@ -76,7 +93,9 @@ main() {
         esac
     done
 
-    [ -n "$ARTIFACT" ] || usage
+    if [ -z "$ARTIFACT" ] && [ "$RELEASE_EXPLICIT" -eq 0 ]; then
+        usage
+    fi
 
     for cmd in curl awk; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -102,23 +121,32 @@ main() {
             ;;
     esac
 
-    case "$ARTIFACT" in
-        route-holdout-n1-n5|reaction-holdout-n1-n5|single-step-reaction-holdout-n1-n5) ;;
-        *)
-            echo -e "${R}error: unsupported artifact '$ARTIFACT'${NC}" >&2
-            exit 1
-            ;;
-    esac
+    if [ -n "$ARTIFACT" ]; then
+        case "$ARTIFACT" in
+            n1-routes|n5-routes|route-holdout-n1-n5|reaction-holdout-n1-n5|n1-single-step-reactions|n5-single-step-reactions|single-step-route-holdout-n1-n5|single-step-reaction-holdout-n1-n5) ;;
+            *)
+                echo -e "${R}error: unsupported artifact '$ARTIFACT'${NC}" >&2
+                exit 1
+                ;;
+        esac
+    fi
 
     case "$SPLIT" in
-        all|training|validation) ;;
+        ""|all|training|validation) ;;
         *)
             echo -e "${R}error: unsupported split '$SPLIT'${NC}" >&2
             exit 1
             ;;
     esac
 
-    FILENAME="$(resolve_filename "$ARTIFACT" "$SPLIT" "$FORMAT")"
+    case "$FORMAT" in
+        ""|jsonl|rsmi) ;;
+        *)
+            echo -e "${R}error: unsupported format '$FORMAT'${NC}" >&2
+            exit 1
+            ;;
+    esac
+
     RESOLVED_RELEASE="$RELEASE"
     if [ "$RELEASE" = "latest" ]; then
         RESOLVED_RELEASE="$(resolve_latest_release "$BASE_URL" "$DATASET")"
@@ -134,26 +162,31 @@ main() {
     else
         RELEASE_DIR="$ROOT_DIR/$DATASET/$RESOLVED_RELEASE"
     fi
-    LOCAL_DIR="$RELEASE_DIR/$ARTIFACT"
-    LOCAL_PATH="$LOCAL_DIR/$FILENAME"
-    MANIFEST_PATH="$LOCAL_DIR/manifest.json"
     CHECKSUMS_PATH="$RELEASE_DIR/SHA256SUMS"
-    FILE_URL="$BASE_URL/$DATASET/$RESOLVED_RELEASE/$ARTIFACT/$FILENAME"
-    MANIFEST_URL="$BASE_URL/$DATASET/$RESOLVED_RELEASE/$ARTIFACT/manifest.json"
     CHECKSUMS_URL="$BASE_URL/$DATASET/$RESOLVED_RELEASE/SHA256SUMS"
-    CHECKSUMS_KEY="$ARTIFACT/$FILENAME"
-    MANIFEST_CHECKSUM_KEY="$ARTIFACT/manifest.json"
 
-    mkdir -p "$LOCAL_DIR"
+    mkdir -p "$RELEASE_DIR"
     curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS_PATH"
+
+    mapfile -t DOWNLOAD_KEYS < <(resolve_download_keys "$ARTIFACT" "$SPLIT" "$FORMAT" "$OMIT")
+    if [ "${#DOWNLOAD_KEYS[@]}" -eq 0 ]; then
+        echo -e "${R}error: no published files match request${NC}" >&2
+        exit 1
+    fi
+
     if [ "$DRY_RUN" -eq 1 ]; then
-        echo "$LOCAL_PATH"
+        for key in "${DOWNLOAD_KEYS[@]}"; do
+            echo "$RELEASE_DIR/$key"
+        done
         exit 0
     fi
 
-    download_and_verify "$FILE_URL" "$LOCAL_PATH" "$CHECKSUMS_KEY"
-    download_and_verify "$MANIFEST_URL" "$MANIFEST_PATH" "$MANIFEST_CHECKSUM_KEY"
-    echo "$LOCAL_PATH"
+    for key in "${DOWNLOAD_KEYS[@]}"; do
+        local_path="$RELEASE_DIR/$key"
+        mkdir -p "$(dirname "$local_path")"
+        download_and_verify "$BASE_URL/$DATASET/$RESOLVED_RELEASE/$key" "$local_path" "$key"
+        echo "$local_path"
+    done
 }
 
 download_and_verify() {
@@ -202,32 +235,61 @@ resolve_latest_release() {
     echo "$latest_release"
 }
 
-resolve_filename() {
+resolve_download_keys() {
     local artifact="$1"
     local split="$2"
     local format="$3"
+    local omit="$4"
 
-    case "$artifact" in
-        route-holdout-n1-n5|reaction-holdout-n1-n5)
-            case "$format" in
-                jsonl) echo "${split}.jsonl.gz" ;;
-                *)
-                    echo "unsupported format '$format' for artifact '$artifact'" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
-        single-step-reaction-holdout-n1-n5)
-            case "$format" in
-                jsonl) echo "${split}.jsonl.gz" ;;
-                rsmi) echo "${split}.rsmi.txt.gz" ;;
-                *)
-                    echo "unsupported format '$format' for artifact '$artifact'" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
-    esac
+    awk -v artifact="$artifact" -v split_filter="$split" -v format_filter="$format" -v omit="$omit" '
+        function has_omitted_part(file, parts, count, i) {
+            count = split_csv(omit, parts)
+            for (i = 1; i <= count; i++) {
+                if (parts[i] != "" && file_part_matches(file, parts[i])) {
+                    return 1
+                }
+            }
+            return 0
+        }
+        function split_csv(value, parts, n, raw, i) {
+            n = split(value, raw, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", raw[i])
+                parts[i] = raw[i]
+            }
+            return n
+        }
+        function file_part_matches(file, part) {
+            return file == part ".jsonl.gz" || file == part ".rsmi.txt.gz" || file ~ ("\\." part "\\.")
+        }
+        $2 != "" {
+            key = $2
+            if (artifact != "" && key !~ ("^" artifact "/")) {
+                next
+            }
+            file = key
+            sub(/^.*\//, "", file)
+            if (file == "manifest.json") {
+                if (split_filter == "" && format_filter == "") {
+                    print key
+                }
+                next
+            }
+            if (split_filter != "" && !file_part_matches(file, split_filter)) {
+                next
+            }
+            if (format_filter == "jsonl" && file !~ /\.jsonl\.gz$/) {
+                next
+            }
+            if (format_filter == "rsmi" && file !~ /\.rsmi\.txt\.gz$/) {
+                next
+            }
+            if (has_omitted_part(file)) {
+                next
+            }
+            print key
+        }
+    ' "$CHECKSUMS_PATH"
 }
 
 main "$@"

--- a/scripts/paroutes/README.md
+++ b/scripts/paroutes/README.md
@@ -20,6 +20,7 @@ uv run scripts/paroutes/training-set-prep/01-create-training-release.py --mode r
 uv run scripts/paroutes/training-set-prep/01-create-training-release.py --mode reaction
 uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py
 uv run scripts/paroutes/training-set-prep/03-audit-release.py
+uv run scripts/paroutes/training-set-prep/06-create-test-set-release.py
 ```
 
 `01-create-training-release.py` writes route releases for `route-holdout-n1-n5` and/or
@@ -32,10 +33,11 @@ Each route release folder contains:
 - `validation.jsonl.gz`
 - `manifest.json`
 
-`02-create-single-step-release.py` writes the flat reaction release by loading the
-released `reaction-holdout-n1-n5` route artifact, flattening and deduplicating
-each split separately, then removing validation reactions whose reaction
-identity also appears in training.
+`02-create-single-step-release.py` writes flat reaction releases by loading released
+route artifacts, flattening and deduplicating each split separately, then applying
+holdout-specific overlap handling. `single-step-route-holdout-n1-n5` reports
+cross-split reaction overlap without removing it. `single-step-reaction-holdout-n1-n5`
+removes validation reactions whose reaction identity also appears in training.
 
 The single-step release folder contains:
 
@@ -46,6 +48,13 @@ The single-step release folder contains:
 - `training.rsmi.txt.gz`
 - `validation.rsmi.txt.gz`
 - `manifest.json`
+
+`06-create-test-set-release.py` writes all-only n1/n5 test set releases:
+
+- `n1-routes`
+- `n5-routes`
+- `n1-single-step-reactions`
+- `n5-single-step-reactions`
 
 `03-audit-release.py` reads the released route artifacts and writes one master
 markdown audit for the whole release version:

--- a/scripts/paroutes/training-set-prep/01-create-training-release.py
+++ b/scripts/paroutes/training-set-prep/01-create-training-release.py
@@ -13,6 +13,9 @@ import argparse
 from pathlib import Path
 from typing import cast
 
+from rich.console import Console
+
+from retrocast.cli.progress import step_progress
 from retrocast.curation.training import (
     TrainingHoldoutMode,
     TrainingRouteReleaseBuilder,
@@ -51,11 +54,6 @@ def main() -> None:
         help="Validation fraction within each stratification bucket. Default: 0.05.",
     )
     parser.add_argument("--seed", type=int, default=20260502, help="Deterministic split seed.")
-    parser.add_argument(
-        "--no-progress",
-        action="store_true",
-        help="Disable progress bars.",
-    )
     args = parser.parse_args()
 
     all_path = RAW_DIR / "all-routes.json.gz"
@@ -63,22 +61,13 @@ def main() -> None:
     n5_path = RAW_DIR / "n5-routes.json.gz"
     source_paths = [all_path, n1_path, n5_path]
 
-    show_progress = not args.no_progress
-    all_adaptation = adapt_training_routes(
-        all_path,
-        dataset="all",
-        show_progress=show_progress,
-    )
-    n1_adaptation = adapt_training_routes(
-        n1_path,
-        dataset="n1",
-        show_progress=show_progress,
-    )
-    n5_adaptation = adapt_training_routes(
-        n5_path,
-        dataset="n5",
-        show_progress=show_progress,
-    )
+    with step_progress(console=Console(), total=3, transient=True) as step:
+        with step("all: adapt routes"):
+            all_adaptation = adapt_training_routes(all_path, dataset="all", show_progress=False)
+        with step("n1: adapt routes"):
+            n1_adaptation = adapt_training_routes(n1_path, dataset="n1", show_progress=False)
+        with step("n5: adapt routes"):
+            n5_adaptation = adapt_training_routes(n5_path, dataset="n5", show_progress=False)
     logger.info("Inputs adapted:")
     logger.info("  %s: %s routes", all_path.relative_to(BASE_DIR), f"{all_adaptation.stats.adapted_routes:,}")
     logger.info("  %s: %s routes", n1_path.relative_to(BASE_DIR), f"{n1_adaptation.stats.adapted_routes:,}")
@@ -92,7 +81,6 @@ def main() -> None:
             holdout_mode=mode,
             val_fraction=args.val_fraction,
             seed=args.seed,
-            show_progress=show_progress,
         )
 
         result = TrainingRouteReleaseBuilder(
@@ -112,34 +100,39 @@ def main() -> None:
         output = result.summary["output"]
         all_records = output["all_records"]
         postprocessing = result.summary["postprocessing"]
+        release_name = result.release_name
         logger.info(
-            "Output: %s records (%s training, %s validation).",
+            "%s output: %s records (%s training, %s validation).",
+            release_name,
             all_records["total"],
             all_records["training"],
             all_records["validation"],
         )
         logger.info(
-            "Postprocessing: %s exact route matches removed; %s duplicates removed.",
+            "%s postprocessing: %s exact route matches removed; %s duplicates removed.",
+            release_name,
             postprocessing["exact_route_matches_removed"],
             postprocessing["duplicate_routes_removed"],
         )
         logger.info(
-            "Dedup breakdown: %s exact-chemistry duplicates removed; %s mapped-smiles variants collapsed.",
+            "%s dedup breakdown: %s exact-chemistry duplicates removed; %s mapped-smiles variants collapsed.",
+            release_name,
             postprocessing["chemical_duplicates_removed"],
             postprocessing["mapped_smiles_variants_collapsed"],
         )
         reaction_overlap = postprocessing.get("reaction_overlap")
         if reaction_overlap is not None:
             logger.info(
-                "Reaction overlap: %s routes had overlapping reactions; %s fragments kept after excision "
+                "%s reaction overlap: %s routes had overlapping reactions; %s fragments kept after excision "
                 "(%s routes fully removed).",
+                release_name,
                 reaction_overlap["routes_with_overlapping_reactions"],
                 reaction_overlap["fragments_kept_after_excision"],
                 reaction_overlap["routes_fully_removed_after_excision"],
             )
         failures_by_code = result.summary["adaptation"]["all_routes"]["failures_by_code"]
         if failures_by_code:
-            logger.info("Adaptation failures by code: %s", failures_by_code)
+            logger.info("%s adaptation failures by code: %s", release_name, failures_by_code)
 
 
 if __name__ == "__main__":

--- a/scripts/paroutes/training-set-prep/02-create-single-step-release.py
+++ b/scripts/paroutes/training-set-prep/02-create-single-step-release.py
@@ -1,10 +1,11 @@
 """
 create public paroutes single-step training-set release files from the released
-reaction-holdout route artifact.
+route artifacts.
 
 usage:
     uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py
     uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py --route-release-dir path/to/reaction-holdout-n1-n5
+    uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py --mode route
 """
 
 from __future__ import annotations
@@ -12,7 +13,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from rich.console import Console
+
+from retrocast.cli.progress import step_progress
 from retrocast.curation.training import (
+    TrainingHoldoutMode,
     TrainingReactionReleaseBuilder,
     TrainingSetBuildConfig,
     write_training_reaction_release,
@@ -24,19 +29,25 @@ BASE_DIR = Path(__file__).resolve().parents[3]
 DATA_DIR = BASE_DIR / "data" / "retrocast"
 RELEASE_VERSION = "v2026-05-29"
 DEFAULT_RELEASE_ROOT = DATA_DIR / "releases" / "paroutes-training-sets" / RELEASE_VERSION
-DEFAULT_ROUTE_RELEASE_DIR = DEFAULT_RELEASE_ROOT / "reaction-holdout-n1-n5"
+DEFAULT_HOLDOUT_MODES: tuple[TrainingHoldoutMode, ...] = ("route", "reaction")
 
 
 def main() -> None:
     configure_script_logging()
     parser = argparse.ArgumentParser(
-        description="create paroutes single-step training-set release files from the reaction-holdout route release."
+        description="create paroutes single-step training-set release files from released route artifacts."
     )
     parser.add_argument(
         "--route-release-dir",
         type=Path,
-        default=DEFAULT_ROUTE_RELEASE_DIR,
-        help=f"reaction-holdout route release directory. default: {DEFAULT_ROUTE_RELEASE_DIR}",
+        default=None,
+        help="explicit route release directory. when omitted, builds from <output-dir>/<mode>-holdout-n1-n5.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=[*DEFAULT_HOLDOUT_MODES, "both"],
+        default="both",
+        help="route holdout mode to flatten. default: both.",
     )
     parser.add_argument(
         "--output-dir",
@@ -46,13 +57,27 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    route_release_dir = args.route_release_dir
+    modes: list[TrainingHoldoutMode] = list(DEFAULT_HOLDOUT_MODES) if args.mode == "both" else [args.mode]
+    if args.route_release_dir is not None and len(modes) != 1:
+        parser.error("--route-release-dir requires --mode route or --mode reaction")
+
+    with step_progress(console=Console(), total=3 * len(modes), transient=True) as step:
+        for mode in modes:
+            route_release_dir = args.route_release_dir or args.output_dir / f"{mode}-holdout-n1-n5"
+            build_single_step_release(
+                route_release_dir=route_release_dir, output_dir=args.output_dir, mode=mode, step=step
+            )
+
+
+def build_single_step_release(*, route_release_dir: Path, output_dir: Path, mode: TrainingHoldoutMode, step) -> None:
     training_path = route_release_dir / "training.jsonl.gz"
     validation_path = route_release_dir / "validation.jsonl.gz"
     route_manifest_path = route_release_dir / "manifest.json"
 
-    training_routes = load_training_route_records(training_path)
-    validation_routes = load_training_route_records(validation_path)
+    release_name = f"single-step-{mode}-holdout-n1-n5"
+    with step(f"{release_name}: load route records"):
+        training_routes = load_training_route_records(training_path)
+        validation_routes = load_training_route_records(validation_path)
     route_records = [*training_routes, *validation_routes]
     display_route_release_dir = (
         route_release_dir.relative_to(BASE_DIR) if route_release_dir.is_relative_to(BASE_DIR) else route_release_dir
@@ -61,19 +86,21 @@ def main() -> None:
     logger.info("  training routes: %s", f"{len(training_routes):,}")
     logger.info("  validation routes: %s", f"{len(validation_routes):,}")
 
-    config = TrainingSetBuildConfig(holdout_mode="reaction", show_progress=False)
-    result = TrainingReactionReleaseBuilder(route_records=route_records, config=config).build()
+    config = TrainingSetBuildConfig(holdout_mode=mode, show_progress=False)
+    with step(f"{release_name}: build reactions"):
+        result = TrainingReactionReleaseBuilder(route_records=route_records, config=config).build()
     source_paths = [training_path, validation_path]
     if route_manifest_path.exists():
         source_paths.append(route_manifest_path)
 
-    write_training_reaction_release(
-        result=result,
-        output_dir=args.output_dir,
-        source_paths=source_paths,
-        source_root=BASE_DIR,
-        config=config,
-    )
+    with step(f"{release_name}: write artifacts"):
+        write_training_reaction_release(
+            result=result,
+            output_dir=output_dir,
+            source_paths=source_paths,
+            source_root=BASE_DIR,
+            config=config,
+        )
 
     output = result.summary["output"]["all_records"]
     reaction_postprocessing = result.summary["reaction_postprocessing"]
@@ -115,6 +142,13 @@ def main() -> None:
         overlap_after_cleanup["shared_reaction_identities"],
         overlap_after_cleanup["shared_exact_reaction_signatures"],
     )
+    if mode == "route" and overlap_after_cleanup["shared_reaction_identities"]:
+        logger.warning(
+            "single-step route-holdout release keeps %s cross-split shared reaction identities "
+            "(%s exact mapped reaction signatures).",
+            overlap_after_cleanup["shared_reaction_identities"],
+            overlap_after_cleanup["shared_exact_reaction_signatures"],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/paroutes/training-set-prep/02-create-single-step-release.py
+++ b/scripts/paroutes/training-set-prep/02-create-single-step-release.py
@@ -4,7 +4,7 @@ route artifacts.
 
 usage:
     uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py
-    uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py --route-release-dir path/to/reaction-holdout-n1-n5
+    uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py --mode reaction --route-release-dir path/to/reaction-holdout-n1-n5
     uv run scripts/paroutes/training-set-prep/02-create-single-step-release.py --mode route
 """
 

--- a/scripts/paroutes/training-set-prep/03-audit-release.py
+++ b/scripts/paroutes/training-set-prep/03-audit-release.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from rich.console import Console
+
+from retrocast.cli.progress import step_progress
 from retrocast.curation.training import build_route_release_split_audit, render_route_release_split_audit_markdown
 from retrocast.curation.training.audit import (
+    RouteReleaseFiles,
     audit_route_release_sanity,
     audit_single_step_release_if_present,
-    load_holdout_reference,
     load_route_release_files,
-    render_sanity_checks_markdown,
-    render_single_step_sanity_markdown,
     required_route_release_files,
 )
 from retrocast.utils.logging import configure_script_logging, logger
@@ -28,6 +29,10 @@ DATA_DIR = BASE_DIR / "data" / "retrocast"
 RELEASE_VERSION = "v2026-05-29"
 DEFAULT_RELEASE_ROOT = DATA_DIR / "releases" / "paroutes-training-sets" / RELEASE_VERSION
 ROUTE_RELEASE_NAMES = ("route-holdout-n1-n5", "reaction-holdout-n1-n5")
+SINGLE_STEP_RELEASE_BY_PARENT = {
+    "route-holdout-n1-n5": "single-step-route-holdout-n1-n5",
+    "reaction-holdout-n1-n5": "single-step-reaction-holdout-n1-n5",
+}
 
 
 def main() -> None:
@@ -56,39 +61,56 @@ def main() -> None:
     if not release_dirs:
         raise FileNotFoundError(f"no route releases found under {args.release_root}")
 
-    sanity_checks = {}
-    audits = []
-    for release_name, release_dir in release_dirs.items():
-        files = load_route_release_files(release_dir)
-        audits.append(
-            build_route_release_split_audit(
-                release_name=release_name, route_records=[*files.training, *files.validation]
-            )
-        )
-        sanity_checks[release_name] = audit_route_release_sanity(
-            release_name=release_name,
-            files=files,
-            holdout=load_holdout_reference(release_dir),
-        )
-
-    report = render_route_release_split_audit_markdown(release_root_name=args.release_root.name, audits=audits)
-    report = f"{report}\n{render_sanity_checks_markdown(sanity_checks)}"
-
-    parent_route_ids = (
-        {record.id for record in load_route_release_files(release_dirs["reaction-holdout-n1-n5"]).all}
-        if "reaction-holdout-n1-n5" in release_dirs
-        else set()
-    )
-    single_step_checks = audit_single_step_release_if_present(
-        release_root=args.release_root,
-        parent_route_ids=parent_route_ids,
-    )
-    if single_step_checks is not None:
-        report = f"{report}\n{render_single_step_sanity_markdown(single_step_checks)}"
+    with step_progress(console=Console(), total=audit_step_count(release_dirs), transient=True) as step:
+        report = build_audit_report(release_root=args.release_root, release_dirs=release_dirs, step=step)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(report, encoding="utf-8")
     logger.info("wrote release audit to %s", output_path)
+
+
+def build_audit_report(*, release_root: Path, release_dirs: dict[str, Path], step) -> str:
+    audits = []
+    summary_rows = []
+    route_files: dict[str, RouteReleaseFiles] = {}
+    for release_name, release_dir in release_dirs.items():
+        with step(f"{release_name}: load route files"):
+            files = load_route_release_files(release_dir)
+        route_files[release_name] = files
+        with step(f"{release_name}: build depth audit"):
+            audit = build_route_release_split_audit(
+                release_name=release_name, route_records=[*files.training, *files.validation]
+            )
+        audits.append(audit)
+        summary_rows.append(audit)
+        with step(f"{release_name}: sanity checks"):
+            audit_route_release_sanity(release_name=release_name, files=files)
+
+    for parent_release_name, single_step_release_name in SINGLE_STEP_RELEASE_BY_PARENT.items():
+        if parent_release_name not in release_dirs:
+            continue
+        parent_route_ids = {record.id for record in route_files[parent_release_name].all}
+        with step(f"{single_step_release_name}: sanity checks"):
+            single_step_checks = audit_single_step_release_if_present(
+                release_root=release_root,
+                parent_route_ids=parent_route_ids,
+                release_name=single_step_release_name,
+            )
+        if single_step_checks is not None:
+            summary_rows.append(single_step_checks)
+    return render_route_release_split_audit_markdown(
+        release_root_name=release_root.name,
+        audits=audits,
+        summary_rows=summary_rows,
+    )
+
+
+def audit_step_count(release_dirs: dict[str, Path]) -> int:
+    route_steps = 3 * len(release_dirs)
+    single_step_steps = sum(
+        parent_release_name in release_dirs for parent_release_name in SINGLE_STEP_RELEASE_BY_PARENT
+    )
+    return route_steps + single_step_steps
 
 
 def missing_route_files(release_dir: Path) -> list[Path]:

--- a/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
+++ b/scripts/paroutes/training-set-prep/05-audit-route-embeddings.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from typing import Literal
 
+from rich.console import Console
+
 from retrocast.chem import InChIKeyLevel
+from retrocast.cli.progress import step_progress
 from retrocast.curation.training import adapt_training_routes
 from retrocast.curation.training.embedding_audit import build_route_embedding_audit
 from retrocast.curation.training.embedding_report import render_route_embedding_audit_markdown
@@ -18,7 +21,7 @@ from retrocast.models.route import Route
 from retrocast.paths import benchmark_definitions_dir, paroutes_assets_dir, paroutes_training_release_file
 from retrocast.utils.logging import configure_script_logging, logger
 
-RELEASE_VERSION = "v2026-05-12"
+RELEASE_VERSION = "v2026-05-29"
 RELEASE_NAME = "route-holdout-n1-n5"
 RELEASE_PATH = paroutes_training_release_file(RELEASE_VERSION, RELEASE_NAME)
 BENCHMARKS = {"mkt-cnv-160": benchmark_definitions_dir() / "mkt-cnv-160.json.gz"}
@@ -28,7 +31,6 @@ MATCH_LEVEL = InChIKeyLevel.FULL
 INCLUDE_PARTIAL = True
 PARTIAL_MIN_REACTIONS = 2
 ALLOW_LEAF_EXTENSION = True
-SHOW_PROGRESS = True
 OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-audit.md"
 LEDGER_OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-ledger.jsonl.gz"
 
@@ -36,39 +38,46 @@ LEDGER_OUTPUT_PATH = RELEASE_PATH.parent / "route-embedding-ledger.jsonl.gz"
 def main() -> None:
     configure_script_logging()
     queries: dict[str, dict[str, Route]] = {}
-    for source, path in BENCHMARKS.items():
-        benchmark_queries: dict[str, Route] = {}
-        for target in load_benchmark(path).targets.values():
-            routes = target.acceptable_routes if ROUTE_SELECTION == "all" else target.acceptable_routes[:1]
-            for index, route in enumerate(routes, start=1):
-                query_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
-                benchmark_queries[query_id] = route
-        queries[source] = benchmark_queries
-        logger.info("loaded %s query routes from %s", len(benchmark_queries), path)
+    with step_progress(console=Console(), total=len(BENCHMARKS) + len(RAW_HOLDOUTS) + 3, transient=True) as step:
+        for source, path in BENCHMARKS.items():
+            with step(f"{source}: load benchmark queries"):
+                benchmark_queries: dict[str, Route] = {}
+                for target in load_benchmark(path).targets.values():
+                    routes = target.acceptable_routes if ROUTE_SELECTION == "all" else target.acceptable_routes[:1]
+                    for index, route in enumerate(routes, start=1):
+                        query_id = target.id if len(routes) == 1 else f"{target.id}:{index}"
+                        benchmark_queries[query_id] = route
+                queries[source] = benchmark_queries
+            logger.info("loaded %s query routes from %s", len(benchmark_queries), path)
 
-    for dataset in RAW_HOLDOUTS:
-        path = paroutes_assets_dir() / f"{dataset}-routes.json.gz"
-        adaptation = adapt_training_routes(path, dataset=dataset, show_progress=SHOW_PROGRESS)
-        queries[f"{dataset}-routes"] = {
-            f"{dataset}-{route.source.raw_index + 1:05d}": route.route for route in adaptation.routes
-        }
-        logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
+        for dataset in RAW_HOLDOUTS:
+            path = paroutes_assets_dir() / f"{dataset}-routes.json.gz"
+            with step(f"{dataset}: adapt holdout routes"):
+                adaptation = adapt_training_routes(path, dataset=dataset, show_progress=False)
+                queries[f"{dataset}-routes"] = {
+                    f"{dataset}-{route.source.raw_index + 1:05d}": route.route for route in adaptation.routes
+                }
+            logger.info("loaded %s adapted %s query routes from %s", adaptation.stats.adapted_routes, dataset, path)
 
-    container_records = load_training_route_records(RELEASE_PATH)
-    audit = build_route_embedding_audit(
-        release_name=RELEASE_NAME,
-        container_records=container_records,
-        queries_by_source=queries,
-        match_level=MATCH_LEVEL,
-        allow_leaf_extension=ALLOW_LEAF_EXTENSION,
-        include_partial=INCLUDE_PARTIAL,
-        partial_min_reactions=PARTIAL_MIN_REACTIONS,
-    )
-
-    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    LEDGER_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(render_route_embedding_audit_markdown(audit, container_label="training"), encoding="utf-8")
-    ledger_rows = save_jsonl_gz(audit.ledger_rows, LEDGER_OUTPUT_PATH)
+        with step(f"{RELEASE_NAME}: load training routes"):
+            container_records = load_training_route_records(RELEASE_PATH)
+        with step(f"{RELEASE_NAME}: build embedding audit"):
+            audit = build_route_embedding_audit(
+                release_name=RELEASE_NAME,
+                container_records=container_records,
+                queries_by_source=queries,
+                match_level=MATCH_LEVEL,
+                allow_leaf_extension=ALLOW_LEAF_EXTENSION,
+                include_partial=INCLUDE_PARTIAL,
+                partial_min_reactions=PARTIAL_MIN_REACTIONS,
+            )
+        with step(f"{RELEASE_NAME}: write audit outputs"):
+            OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+            LEDGER_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+            OUTPUT_PATH.write_text(
+                render_route_embedding_audit_markdown(audit, container_label="training"), encoding="utf-8"
+            )
+            ledger_rows = save_jsonl_gz(audit.ledger_rows, LEDGER_OUTPUT_PATH)
     logger.info(
         "wrote route embedding audit to %s and %s (%s ledger rows)", OUTPUT_PATH, LEDGER_OUTPUT_PATH, ledger_rows
     )

--- a/scripts/paroutes/training-set-prep/06-create-test-set-release.py
+++ b/scripts/paroutes/training-set-prep/06-create-test-set-release.py
@@ -1,0 +1,98 @@
+"""
+create public paroutes n1/n5 test-set release files.
+
+usage:
+    uv run scripts/paroutes/training-set-prep/06-create-test-set-release.py
+    uv run scripts/paroutes/training-set-prep/06-create-test-set-release.py --dataset n1
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import cast
+
+from rich.console import Console
+
+from retrocast.cli.progress import step_progress
+from retrocast.curation.training import (
+    TestSetName,
+    adapt_training_routes,
+    build_test_reaction_records,
+    build_test_route_records,
+    write_test_reaction_release,
+    write_test_route_release,
+)
+from retrocast.utils.logging import configure_script_logging, logger
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+DATA_DIR = BASE_DIR / "data" / "retrocast"
+RAW_DIR = DATA_DIR / "0-assets" / "paroutes"
+RELEASE_VERSION = "v2026-05-29"
+DEFAULT_OUTPUT_DIR = DATA_DIR / "releases" / "paroutes-training-sets" / RELEASE_VERSION
+TEST_DATASETS: tuple[TestSetName, ...] = ("n1", "n5")
+
+
+def main() -> None:
+    configure_script_logging()
+    parser = argparse.ArgumentParser(description="create paroutes n1/n5 test-set release files.")
+    parser.add_argument(
+        "--dataset",
+        choices=[*TEST_DATASETS, "both"],
+        default="both",
+        help="test set to release. default: both.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"output directory root. default: {DEFAULT_OUTPUT_DIR}",
+    )
+    args = parser.parse_args()
+
+    datasets = list(TEST_DATASETS) if args.dataset == "both" else [cast(TestSetName, args.dataset)]
+    with step_progress(console=Console(), total=4 * len(datasets), transient=True) as step:
+        for dataset in datasets:
+            build_test_set_release(dataset=dataset, output_dir=args.output_dir, step=step)
+
+
+def build_test_set_release(*, dataset: TestSetName, output_dir: Path, step) -> None:
+    source_path = RAW_DIR / f"{dataset}-routes.json.gz"
+    with step(f"{dataset}: adapt routes"):
+        adaptation = adapt_training_routes(source_path, dataset=dataset, show_progress=False)
+    with step(f"{dataset}: build route records"):
+        route_records = build_test_route_records(dataset=dataset, routes=adaptation.routes)
+    with step(f"{dataset}: write route release"):
+        write_test_route_release(
+            dataset=dataset,
+            records=route_records,
+            adaptation=adaptation.stats,
+            output_dir=output_dir,
+            source_paths=[source_path],
+            source_root=BASE_DIR,
+        )
+
+    with step(f"{dataset}: build and write reactions"):
+        reaction_records = build_test_reaction_records(dataset=dataset, route_records=route_records)
+        route_manifest_path = output_dir / f"{dataset}-routes" / "manifest.json"
+        reaction_sources = [output_dir / f"{dataset}-routes" / "all.jsonl.gz"]
+        if route_manifest_path.exists():
+            reaction_sources.append(route_manifest_path)
+        write_test_reaction_release(
+            dataset=dataset,
+            records=reaction_records,
+            output_dir=output_dir,
+            source_paths=reaction_sources,
+            source_root=BASE_DIR,
+        )
+
+    logger.info(
+        "wrote %s test release: %s routes, %s single-step reactions.",
+        dataset,
+        f"{len(route_records):,}",
+        f"{len(reaction_records):,}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/retrocast/cli/manifest.py
+++ b/src/retrocast/cli/manifest.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from retrocast import __version__
-from retrocast.io.provenance import calculate_file_hash
-from retrocast.models.provenance import FileInfo, Manifest
+from retrocast.io.provenance import ContentType, create_manifest
 
 
 def write_manifest(
@@ -20,16 +17,14 @@ def write_manifest(
     statistics: dict[str, Any] | None = None,
     summary: dict[str, Any] | None = None,
 ) -> None:
-    manifest = Manifest(
-        schema_version="2",
-        retrocast_version=__version__,
-        created_at=datetime.now(UTC),
+    manifest = create_manifest(
         action=action,
-        parameters=parameters or {},
-        source_files=[_required_file_info(source, root_dir) for source in sources],
-        output_files=[_file_info(output, root_dir) for output in outputs],
-        statistics=statistics or {},
-        summary=summary or {},
+        sources=sources,
+        outputs=[(output, None, ContentType.UNKNOWN) for output in outputs],
+        root_dir=root_dir,
+        parameters=parameters,
+        statistics=statistics,
+        summary=summary,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
@@ -40,22 +35,3 @@ def manifest_sidecar_path(output_path: Path) -> Path:
         if output_path.name.endswith(suffix):
             return output_path.with_name(f"{output_path.name.removesuffix(suffix)}.manifest.json")
     return output_path.with_name(f"{output_path.stem}.manifest.json")
-
-
-def _file_info(path: Path, root_dir: Path) -> FileInfo:
-    return FileInfo(path=_relative_path(path, root_dir), file_hash=calculate_file_hash(path))
-
-
-def _required_file_info(path: Path, root_dir: Path) -> FileInfo:
-    if not path.exists():
-        raise FileNotFoundError(f"manifest source file not found: {path}")
-    return _file_info(path, root_dir)
-
-
-def _relative_path(path: Path, root_dir: Path) -> str:
-    resolved_root = root_dir.resolve()
-    resolved_path = path.resolve()
-    try:
-        return str(resolved_path.relative_to(resolved_root))
-    except ValueError:
-        return str(resolved_path)

--- a/src/retrocast/cli/progress.py
+++ b/src/retrocast/cli/progress.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import AbstractContextManager, contextmanager
 from typing import Any
 
 from rich.console import Console
@@ -50,6 +50,26 @@ def create_cli_progress(
         console=console,
         transient=transient,
     )
+
+
+@contextmanager
+def step_progress(
+    *,
+    console: Console,
+    total: int,
+    unit: str = "steps",
+    transient: bool = False,
+) -> Iterator[Callable[[str], AbstractContextManager[None]]]:
+    with create_cli_progress(console=console, unit=unit, transient=transient) as progress:
+        task_id = progress.add_task("starting", total=total)
+
+        @contextmanager
+        def step(description: str) -> Iterator[None]:
+            progress.update(task_id, description=description)
+            yield
+            progress.advance(task_id)
+
+        yield step
 
 
 def estimate_raw_route_entries(

--- a/src/retrocast/curation/training/__init__.py
+++ b/src/retrocast/curation/training/__init__.py
@@ -2,12 +2,9 @@ from retrocast.curation.training.audit import (
     audit_route_release_sanity,
     audit_single_step_release_if_present,
     build_route_release_split_audit,
-    load_holdout_reference,
     load_route_release_files,
     load_single_step_release_files,
     render_route_release_split_audit_markdown,
-    render_sanity_checks_markdown,
-    render_single_step_sanity_markdown,
     required_route_release_files,
 )
 from retrocast.curation.training.reaction_release import (
@@ -19,6 +16,9 @@ from retrocast.curation.training.records import (
     AdaptedTrainingRoute,
     RawRouteSource,
     SplitName,
+    TestReactionRecord,
+    TestRouteRecord,
+    TestSetName,
     TrainingHoldoutMode,
     TrainingReactionBuildResult,
     TrainingReactionRecord,
@@ -34,12 +34,21 @@ from retrocast.curation.training.route_release import (
     stable_raw_route_hash,
     write_training_release,
 )
+from retrocast.curation.training.testset_release import (
+    build_test_reaction_records,
+    build_test_route_records,
+    write_test_reaction_release,
+    write_test_route_release,
+)
 
 __all__ = [
     "AdaptationStatistics",
     "AdaptedTrainingRoute",
     "RawRouteSource",
     "SplitName",
+    "TestReactionRecord",
+    "TestRouteRecord",
+    "TestSetName",
     "TrainingHoldoutMode",
     "TrainingReactionRecord",
     "TrainingReactionBuildResult",
@@ -54,14 +63,15 @@ __all__ = [
     "audit_route_release_sanity",
     "audit_single_step_release_if_present",
     "build_route_release_split_audit",
-    "load_holdout_reference",
+    "build_test_reaction_records",
+    "build_test_route_records",
     "load_route_release_files",
     "load_single_step_release_files",
     "render_route_release_split_audit_markdown",
-    "render_sanity_checks_markdown",
-    "render_single_step_sanity_markdown",
     "required_route_release_files",
     "stable_raw_route_hash",
     "write_training_reaction_release",
     "write_training_release",
+    "write_test_reaction_release",
+    "write_test_route_release",
 ]

--- a/src/retrocast/curation/training/audit.py
+++ b/src/retrocast/curation/training/audit.py
@@ -152,6 +152,9 @@ def audit_single_step_release_if_present(
     training_exact_reaction_keys = [exact_reaction_record_key(record) for record in files.training]
     if duplicate_training_exact_reaction_keys := duplicate_count(training_exact_reaction_keys):
         failures["duplicate_training_exact_reaction_keys"] = duplicate_training_exact_reaction_keys
+    validation_exact_reaction_keys = [exact_reaction_record_key(record) for record in files.validation]
+    if duplicate_validation_exact_reaction_keys := duplicate_count(validation_exact_reaction_keys):
+        failures["duplicate_validation_exact_reaction_keys"] = duplicate_validation_exact_reaction_keys
     training_identities = {reaction_record_identity_key(record) for record in files.training}
     validation_identities = {reaction_record_identity_key(record) for record in files.validation}
     shared = training_identities & validation_identities

--- a/src/retrocast/curation/training/audit.py
+++ b/src/retrocast/curation/training/audit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,8 +8,8 @@ from typing import Any
 from retrocast.curation.training.records import TrainingReactionRecord
 from retrocast.curation.training.route_release import _route_transform_key
 from retrocast.exceptions import TrainingReleaseError
-from retrocast.io import iter_jsonl_gz, load_lines_gz, load_training_route_records
-from retrocast.markdown import MarkdownRow, markdown_table
+from retrocast.io import iter_jsonl_gz, load_lines_gz
+from retrocast.markdown import format_integer, markdown_table
 
 
 @dataclass(frozen=True)
@@ -36,26 +35,21 @@ def required_route_release_files(release_dir: Path) -> list[Path]:
 
 def load_route_release_files(release_dir: Path) -> RouteReleaseFiles:
     return RouteReleaseFiles(
-        all=load_training_route_records(release_dir / "all.jsonl.gz"),
-        training=load_training_route_records(release_dir / "training.jsonl.gz"),
-        validation=load_training_route_records(release_dir / "validation.jsonl.gz"),
+        all=_load_training_route_records(release_dir / "all.jsonl.gz"),
+        training=_load_training_route_records(release_dir / "training.jsonl.gz"),
+        validation=_load_training_route_records(release_dir / "validation.jsonl.gz"),
     )
 
 
 def build_route_release_split_audit(*, release_name: str, route_records: list[Any]) -> dict[str, Any]:
     by_depth: Counter[int] = Counter()
-    by_convergence: Counter[bool] = Counter()
     by_split: Counter[str] = Counter()
     by_depth_split: Counter[tuple[int, str]] = Counter()
-    by_convergence_split: Counter[tuple[bool, str]] = Counter()
     for record in route_records:
         depth = record.route.depth()
-        convergent = record.route.is_convergent()
         by_depth[depth] += 1
-        by_convergence[convergent] += 1
         by_split[record.split] += 1
         by_depth_split[(depth, record.split)] += 1
-        by_convergence_split[(convergent, record.split)] += 1
     return {
         "release_name": release_name,
         "total": len(route_records),
@@ -70,19 +64,13 @@ def build_route_release_split_audit(*, release_name: str, route_records: list[An
             }
             for depth in sorted(by_depth)
         ],
-        "by_convergence": [
-            {
-                "convergent": convergent,
-                "total": by_convergence[convergent],
-                "training": by_convergence_split[(convergent, "training")],
-                "validation": by_convergence_split[(convergent, "validation")],
-            }
-            for convergent in (False, True)
-        ],
     }
 
 
-def render_route_release_split_audit_markdown(*, release_root_name: str, audits: list[dict[str, Any]]) -> str:
+def render_route_release_split_audit_markdown(
+    *, release_root_name: str, audits: list[dict[str, Any]], summary_rows: list[dict[str, Any]] | None = None
+) -> str:
+    summary = summary_rows if summary_rows is not None else audits
     lines = [
         f"# training release audit: {release_root_name}",
         "",
@@ -90,13 +78,13 @@ def render_route_release_split_audit_markdown(*, release_root_name: str, audits:
             ["release", "total", "training", "validation", "val%"],
             [
                 (
-                    audit["release_name"],
-                    audit["total"],
-                    audit["training"],
-                    audit["validation"],
-                    _format_percent(_fraction(audit["validation"], audit["total"])),
+                    row["release_name"],
+                    format_integer(row["total"]),
+                    format_integer(row["training"]),
+                    format_integer(row["validation"]),
+                    _format_percent(_fraction(row["validation"], row["total"])),
                 )
-                for audit in audits
+                for row in summary
             ],
             align=["left", "right", "right", "right", "right"],
         ),
@@ -109,21 +97,16 @@ def render_route_release_split_audit_markdown(*, release_root_name: str, audits:
                 "",
                 markdown_table(
                     ["depth", "total", "training", "validation"],
-                    [(row["depth"], row["total"], row["training"], row["validation"]) for row in audit["by_depth"]],
-                    align=["right", "right", "right", "right"],
-                ),
-            ]
-        )
-        lines.extend(
-            [
-                "",
-                markdown_table(
-                    ["convergent", "total", "training", "validation"],
                     [
-                        (_format_bool(row["convergent"]), row["total"], row["training"], row["validation"])
-                        for row in audit["by_convergence"]
+                        (
+                            row["depth"],
+                            format_integer(row["total"]),
+                            format_integer(row["training"]),
+                            format_integer(row["validation"]),
+                        )
+                        for row in audit["by_depth"]
                     ],
-                    align=["left", "right", "right", "right"],
+                    align=["right", "right", "right", "right"],
                 ),
             ]
         )
@@ -131,74 +114,34 @@ def render_route_release_split_audit_markdown(*, release_root_name: str, audits:
     return "\n".join(lines)
 
 
-def load_holdout_reference(release_dir: Path) -> dict[str, int]:
-    manifest = json.loads((release_dir / "manifest.json").read_text(encoding="utf-8"))
-    adaptation = manifest["summary"]["adaptation"]
-    return {
-        "n1": adaptation["n1"]["raw_routes"],
-        "n5": adaptation["n5"]["raw_routes"],
-    }
-
-
-def audit_route_release_sanity(
-    *, release_name: str, files: RouteReleaseFiles, holdout: dict[str, int]
-) -> dict[str, Any]:
-    all_by_id = {record.id: record for record in files.all}
-    split_records = [*files.training, *files.validation]
-    split_by_id = {record.id: record for record in split_records}
-    failures: dict[str, Any] = {}
-    if len(all_by_id) != len(files.all):
-        failures["duplicate_record_ids_in_all"] = len(files.all) - len(all_by_id)
-    if len(split_by_id) != len(split_records):
-        failures["duplicate_record_ids_in_splits"] = len(split_records) - len(split_by_id)
-    if set(all_by_id) != set(split_by_id):
-        failures["all_split_id_delta"] = len(set(all_by_id) ^ set(split_by_id))
-    if wrong_training := sum(record.split != "training" for record in files.training):
-        failures["training_file_wrong_split_records"] = wrong_training
-    if wrong_validation := sum(record.split != "validation" for record in files.validation):
-        failures["validation_file_wrong_split_records"] = wrong_validation
-    if duplicate_count(_route_transform_key(record.route) for record in files.training):
-        failures["duplicate_training_route_identities"] = duplicate_count(
-            _route_transform_key(record.route) for record in files.training
-        )
-    if duplicate_count(_route_transform_key(record.route) for record in files.validation):
-        failures["duplicate_validation_route_identities"] = duplicate_count(
-            _route_transform_key(record.route) for record in files.validation
-        )
+def audit_route_release_sanity(*, release_name: str, files: RouteReleaseFiles) -> None:
+    failures = _split_file_failures(files)
+    training_route_identities = [_route_transform_key(record.route) for record in files.training]
+    if duplicate_training_route_identities := duplicate_count(training_route_identities):
+        failures["duplicate_training_route_identities"] = duplicate_training_route_identities
+    validation_route_identities = [_route_transform_key(record.route) for record in files.validation]
+    if duplicate_validation_route_identities := duplicate_count(validation_route_identities):
+        failures["duplicate_validation_route_identities"] = duplicate_validation_route_identities
     if failures:
         raise TrainingReleaseError(
             f"{release_name} failed route release sanity checks",
             code="workflow.route_release_audit_failed",
             context={"release_name": release_name, "failures": failures},
         )
-    return {
-        "release_name": release_name,
-        "all_count": len(files.all),
-        "training_count": len(files.training),
-        "validation_count": len(files.validation),
-        "holdout_count": sum(holdout.values()),
-    }
 
 
-def audit_single_step_release_if_present(*, release_root: Path, parent_route_ids: set[str]) -> dict[str, Any] | None:
-    release_dir = release_root / "single-step-reaction-holdout-n1-n5"
+def audit_single_step_release_if_present(
+    *,
+    release_root: Path,
+    parent_route_ids: set[str],
+    release_name: str = "single-step-reaction-holdout-n1-n5",
+) -> dict[str, Any] | None:
+    release_dir = release_root / release_name
     if not (release_dir / "all.jsonl.gz").exists():
         return None
+    allow_cross_split_overlap = release_name == "single-step-route-holdout-n1-n5"
     files = load_single_step_release_files(release_dir)
-    all_by_id = {record.id: record for record in files.all}
-    split_records = [*files.training, *files.validation]
-    split_by_id = {record.id: record for record in split_records}
-    failures: dict[str, Any] = {}
-    if len(all_by_id) != len(files.all):
-        failures["duplicate_record_ids_in_all"] = len(files.all) - len(all_by_id)
-    if set(all_by_id) != set(split_by_id):
-        failures["all_split_id_delta"] = len(set(all_by_id) ^ set(split_by_id))
-    if any(record.split != "training" for record in files.training):
-        failures["training_file_wrong_split_records"] = sum(record.split != "training" for record in files.training)
-    if any(record.split != "validation" for record in files.validation):
-        failures["validation_file_wrong_split_records"] = sum(
-            record.split != "validation" for record in files.validation
-        )
+    failures = _split_file_failures(files, check_split_duplicate_ids=False)
     rsmi_count_mismatches = {
         "all": len(files.all) - files.all_rsmi_count,
         "training": len(files.training) - files.training_rsmi_count,
@@ -206,13 +149,13 @@ def audit_single_step_release_if_present(*, release_root: Path, parent_route_ids
     }
     if any(rsmi_count_mismatches.values()):
         failures["rsmi_count_mismatches"] = rsmi_count_mismatches
-    if duplicate_count(exact_reaction_record_key(record) for record in files.training):
-        failures["duplicate_training_exact_reaction_keys"] = duplicate_count(
-            exact_reaction_record_key(record) for record in files.training
-        )
+    training_exact_reaction_keys = [exact_reaction_record_key(record) for record in files.training]
+    if duplicate_training_exact_reaction_keys := duplicate_count(training_exact_reaction_keys):
+        failures["duplicate_training_exact_reaction_keys"] = duplicate_training_exact_reaction_keys
     training_identities = {reaction_record_identity_key(record) for record in files.training}
     validation_identities = {reaction_record_identity_key(record) for record in files.validation}
-    if shared := training_identities & validation_identities:
+    shared = training_identities & validation_identities
+    if shared and not allow_cross_split_overlap:
         failures["cross_split_reaction_identity_overlap"] = len(shared)
     if missing_sources := sum(
         source.route_id not in parent_route_ids for record in files.all for source in record.sources
@@ -220,59 +163,18 @@ def audit_single_step_release_if_present(*, release_root: Path, parent_route_ids
         failures["missing_parent_route_sources"] = missing_sources
     if failures:
         raise TrainingReleaseError(
-            "single-step-reaction-holdout-n1-n5 failed single-step sanity checks",
+            f"{release_name} failed single-step sanity checks",
             code="workflow.single_step_release_audit_failed",
             context={"release_name": release_dir.name, "failures": failures},
         )
     return {
         "release_name": release_dir.name,
-        "records": len(files.all),
+        "total": len(files.all),
         "training": len(files.training),
         "validation": len(files.validation),
         "parent_routes": len(parent_route_ids),
+        "cross_split_reaction_identity_overlap": len(shared),
     }
-
-
-def render_sanity_checks_markdown(sanity_checks: dict[str, dict[str, Any]]) -> str:
-    rows: list[MarkdownRow] = [
-        (
-            name,
-            checks["all_count"],
-            checks["training_count"],
-            checks["validation_count"],
-            checks["holdout_count"],
-        )
-        for name, checks in sorted(sanity_checks.items())
-    ]
-    return (
-        "## sanity checks\n\n"
-        + markdown_table(
-            ["release", "records", "training", "validation", "holdout refs"],
-            rows,
-            align=["left", "right", "right", "right", "right"],
-        )
-        + "\n"
-    )
-
-
-def render_single_step_sanity_markdown(checks: dict[str, Any]) -> str:
-    return (
-        "## single-step sanity\n\n"
-        + markdown_table(
-            ["release", "records", "training", "validation", "parent routes"],
-            [
-                (
-                    checks["release_name"],
-                    checks["records"],
-                    checks["training"],
-                    checks["validation"],
-                    checks["parent_routes"],
-                )
-            ],
-            align=["left", "right", "right", "right", "right"],
-        )
-        + "\n"
-    )
 
 
 def load_single_step_release_files(release_dir: Path) -> SingleStepReleaseFiles:
@@ -290,6 +192,30 @@ def load_single_step_release_files(release_dir: Path) -> SingleStepReleaseFiles:
     )
 
 
+def _load_training_route_records(path: Path) -> list[Any]:
+    from retrocast.curation.training.records import TrainingRouteRecord
+
+    return [TrainingRouteRecord.model_validate(row) for row in iter_jsonl_gz(path)]
+
+
+def _split_file_failures(files, *, check_split_duplicate_ids: bool = True) -> dict[str, Any]:
+    all_by_id = {record.id: record for record in files.all}
+    split_records = [*files.training, *files.validation]
+    split_by_id = {record.id: record for record in split_records}
+    failures: dict[str, Any] = {}
+    if len(all_by_id) != len(files.all):
+        failures["duplicate_record_ids_in_all"] = len(files.all) - len(all_by_id)
+    if check_split_duplicate_ids and len(split_by_id) != len(split_records):
+        failures["duplicate_record_ids_in_splits"] = len(split_records) - len(split_by_id)
+    if set(all_by_id) != set(split_by_id):
+        failures["all_split_id_delta"] = len(set(all_by_id) ^ set(split_by_id))
+    if wrong_training := sum(record.split != "training" for record in files.training):
+        failures["training_file_wrong_split_records"] = wrong_training
+    if wrong_validation := sum(record.split != "validation" for record in files.validation):
+        failures["validation_file_wrong_split_records"] = wrong_validation
+    return failures
+
+
 def exact_reaction_record_key(record: TrainingReactionRecord) -> tuple[str, tuple[str, ...], str | None]:
     return (
         str(record.mapped_smiles),
@@ -301,10 +227,17 @@ def exact_reaction_record_key(record: TrainingReactionRecord) -> tuple[str, tupl
 def reaction_record_identity_key(
     record: TrainingReactionRecord,
 ) -> tuple[tuple[str, ...], str, tuple[str, ...] | str | None]:
+    condition_smiles = tuple(str(value) for value in record.condition_slot_smiles)
+    condition_key: tuple[str, ...] | str | None
+    if condition_smiles:
+        condition_key = condition_smiles
+    else:
+        condition_key = record.condition_slot
+
     return (
         tuple(sorted(str(value) for value in record.reactants)),
         str(record.product),
-        tuple(str(value) for value in record.condition_slot_smiles) or record.condition_slot,
+        condition_key,
     )
 
 
@@ -319,7 +252,3 @@ def _fraction(numerator: int, denominator: int) -> float:
 
 def _format_percent(value: float) -> str:
     return f"{value:.4%}"
-
-
-def _format_bool(value: bool) -> str:
-    return "true" if value else "false"

--- a/src/retrocast/curation/training/embedding_report.py
+++ b/src/retrocast/curation/training/embedding_report.py
@@ -8,7 +8,7 @@ from retrocast.curation.training.embedding_audit import (
     QuerySetAudit,
     RouteEmbeddingAudit,
 )
-from retrocast.markdown import MarkdownAlign, MarkdownRow, markdown_table
+from retrocast.markdown import MarkdownAlign, MarkdownRow, format_integer, markdown_table
 
 
 def render_route_embedding_audit_markdown(
@@ -24,9 +24,9 @@ def render_route_embedding_audit_markdown(
         f"- allow leaf extension: `{str(audit.allow_leaf_extension).lower()}`",
         "- partial minimum reactions: "
         f"{f'{audit.partial_min_reactions} reactions' if audit.partial_min_reactions is not None else 'not run'}",
-        f"- {container_label} routes: {_format_integer(audit.container_routes)}",
-        f"- {container_route_label} signatures: {_format_integer(audit.container_route_signatures)}",
-        f"- {container_label} reaction signatures: {_format_integer(audit.container_reaction_signatures)}",
+        f"- {container_label} routes: {format_integer(audit.container_routes)}",
+        f"- {container_route_label} signatures: {format_integer(audit.container_route_signatures)}",
+        f"- {container_label} reaction signatures: {format_integer(audit.container_reaction_signatures)}",
         "",
         "terms: a query route is the route being searched for. "
         f"a container route is a {container_route_label} where an embedding is found.",
@@ -53,7 +53,7 @@ def _summary_table(query_sets: Sequence[QuerySetAudit], *, container_label: str)
         return (label, *values)
 
     rows = [
-        row("query routes", [_format_integer(q.query_routes) for q in query_sets]),
+        row("query routes", [format_integer(q.query_routes) for q in query_sets]),
         row(
             f"reaction signatures in {container_label}",
             [_format_count_rate(q.reaction_signature_overlap, q.query_reaction_signatures) for q in query_sets],
@@ -88,7 +88,7 @@ def _overlap_summary(query_set: QuerySetAudit, *, container_label: str) -> str:
     lines.append(
         f"{_format_count_rate(full.query_routes_with_embedding, query_set.query_routes)} "
         f"query routes are fully embedded somewhere inside {container_label} routes. "
-        f"these produce {_format_integer(full.embedding_occurrences)} total matching occurrences. "
+        f"these produce {format_integer(full.embedding_occurrences)} total matching occurrences. "
         f"{_format_plural(full.query_routes_with_root_shifted_embedding, 'query route has', 'query routes have')} "
         "a root-shifted full embedding; "
         f"{_format_plural(full.query_routes_with_leaf_extended_embedding, 'query route has', 'query routes have')} "
@@ -109,11 +109,11 @@ def _internal_subroute_summary(query_set: QuerySetAudit, summary: InternalSubrou
     return (
         f"{_format_count_rate(summary.query_routes_with_embedding, query_set.query_routes)} "
         f"query routes have at least one embedded internal subroute of {summary.min_reactions}+ reactions. "
-        f"there are {_format_integer(summary.checked_internal_subroutes)} non-root internal subroutes "
+        f"there are {format_integer(summary.checked_internal_subroutes)} non-root internal subroutes "
         f"with at least {summary.min_reactions} reactions. "
         f"{_format_count_rate(summary.embedded_internal_subroutes, summary.checked_internal_subroutes)} "
         "of those internal subroutes are embedded. "
-        f"there are {_format_integer(summary.embedding_occurrences)} total partial matching occurrences "
+        f"there are {format_integer(summary.embedding_occurrences)} total partial matching occurrences "
         f"({matches_per_embedded_subroute:.2f} "
         "matches per embedded internal subroute)."
     )
@@ -136,7 +136,7 @@ def _prefix_depth_summary(query_set: QuerySetAudit, *, container_label: str) -> 
                 [
                     (
                         row.depth,
-                        _format_integer(row.query_routes),
+                        format_integer(row.query_routes),
                         _format_count_rate(row.root_prefix_signature_overlap, row.query_routes),
                         _format_count_rate(row.subtree_prefix_signature_overlap, row.query_routes),
                     )
@@ -204,7 +204,7 @@ def _best_match_coverage(
             markdown_table(
                 ["largest embedded fraction of query-route reactions", "query routes"],
                 [
-                    (bucket, _format_integer(query_routes))
+                    (bucket, format_integer(query_routes))
                     for bucket, query_routes in coverage.matched_fraction_histogram
                 ],
                 align=["left", "right"],
@@ -225,11 +225,11 @@ def _coverage_table(
         ["population", "mean", "median", "p90"],
         [
             (
-                f"all query routes ({_format_integer(all_query_routes)})",
+                f"all query routes ({format_integer(all_query_routes)})",
                 *(_format_percent(value) for value in all_values),
             ),
             (
-                f"query routes with any embedding ({_format_integer(embedded_query_routes)})",
+                f"query routes with any embedding ({format_integer(embedded_query_routes)})",
                 *(_format_percent(value) for value in embedded_values),
             ),
         ],
@@ -239,7 +239,7 @@ def _coverage_table(
 
 def _format_count_rate(count: int, denominator: int) -> str:
     rate = count / denominator if denominator else 0.0
-    return f"{_format_integer(count)} / {_format_integer(denominator)} ({_format_percent(rate)})"
+    return f"{format_integer(count)} / {format_integer(denominator)} ({_format_percent(rate)})"
 
 
 def _format_internal_query_count(query_set: QuerySetAudit) -> str:
@@ -254,12 +254,8 @@ def _format_percent(value: float) -> str:
     return f"{100 * value:.1f}%"
 
 
-def _format_integer(value: int) -> str:
-    return f"{value:,}".replace(",", " ")
-
-
 def _format_plural(value: int, singular: str, plural: str) -> str:
-    return f"{_format_integer(value)} {singular if value == 1 else plural}"
+    return f"{format_integer(value)} {singular if value == 1 else plural}"
 
 
 def _format_root_distance_sentence(counts: Sequence[tuple[int, int]]) -> str:

--- a/src/retrocast/curation/training/reaction_release.py
+++ b/src/retrocast/curation/training/reaction_release.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -27,12 +28,6 @@ class TrainingReactionReleaseBuilder:
         self._started = False
 
     def build(self) -> TrainingReactionBuildResult:
-        if self.config.holdout_mode != "reaction":
-            raise TrainingReleaseError(
-                "single-step training release requires TrainingSetBuildConfig(holdout_mode='reaction')",
-                code="workflow.single_step_requires_reaction_holdout",
-                context={"holdout_mode": self.config.holdout_mode},
-            )
         if self._started:
             raise RuntimeError("TrainingReactionReleaseBuilder instances are single-use")
         self._started = True
@@ -40,19 +35,31 @@ class TrainingReactionReleaseBuilder:
         training, training_postprocessing = self._build_split("training")
         validation_before, validation_postprocessing = self._build_split("validation")
         overlap_before = _summarize_cross_split_overlap(training, validation_before)
-        training_keys = {_reaction_identity(record) for record in training}
-        validation = [record for record in validation_before if _reaction_identity(record) not in training_keys]
-        overlap_removed = len(validation_before) - len(validation)
+        if self.config.holdout_mode == "reaction":
+            training_keys = {_reaction_identity(record) for record in training}
+            validation = [record for record in validation_before if _reaction_identity(record) not in training_keys]
+            overlap_removed = len(validation_before) - len(validation)
+        else:
+            validation = validation_before
+            overlap_removed = 0
         overlap_after = _summarize_cross_split_overlap(training, validation)
-        if overlap_after["shared_reaction_identities"] or overlap_after["shared_exact_reaction_signatures"]:
+        if self.config.holdout_mode == "reaction" and (
+            overlap_after["shared_reaction_identities"] or overlap_after["shared_exact_reaction_signatures"]
+        ):
             raise TrainingReleaseError(
                 "single-step release validation split still overlaps with training after cleanup",
                 code="workflow.single_step_validation_overlap",
                 context=overlap_after,
             )
+        if self.config.holdout_mode == "route" and overlap_after["shared_reaction_identities"]:
+            warnings.warn(
+                "single-step route-holdout release has cross-split reaction identity overlap",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         records = _renumber([*training, *validation], prefix=self.config.route_prefix)
         return TrainingReactionBuildResult(
-            release_name="single-step-reaction-holdout-n1-n5",
+            release_name=f"single-step-{self.config.release_name}",
             records=records,
             summary={
                 "reaction_postprocessing": {

--- a/src/retrocast/curation/training/reaction_release.py
+++ b/src/retrocast/curation/training/reaction_release.py
@@ -164,9 +164,9 @@ def write_training_reaction_release(
         action=TRAINING_REACTION_RELEASE_ACTION,
         sources=source_paths,
         outputs=[
-            ("all", all_path, result.records, ContentType.UNKNOWN),
-            ("training", training_path, training, ContentType.UNKNOWN),
-            ("validation", validation_path, validation, ContentType.UNKNOWN),
+            ("all", all_path, result.records, ContentType.UNKNOWN, reaction_records_content_hash(result.records)),
+            ("training", training_path, training, ContentType.UNKNOWN, reaction_records_content_hash(training)),
+            ("validation", validation_path, validation, ContentType.UNKNOWN, reaction_records_content_hash(validation)),
         ],
         root_dir=source_root,
         parameters=config.to_manifest_dict(),
@@ -175,12 +175,6 @@ def write_training_reaction_release(
         release_name=result.release_name,
         keyed_output_files=True,
     )
-    output_files = manifest.output_files
-    if not isinstance(output_files, dict):
-        raise TypeError("training reaction release manifest must use keyed output files")
-    output_files["all"].content_hash = reaction_records_content_hash(result.records)
-    output_files["training"].content_hash = reaction_records_content_hash(training)
-    output_files["validation"].content_hash = reaction_records_content_hash(validation)
     manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
 
 

--- a/src/retrocast/curation/training/records.py
+++ b/src/retrocast/curation/training/records.py
@@ -10,6 +10,7 @@ from retrocast.models.route import Route
 from retrocast.typing import ReactionSmilesStr, SmilesStr
 
 TrainingHoldoutMode = Literal["route", "reaction"]
+TestSetName = Literal["n1", "n5"]
 SplitName = Literal["training", "validation"]
 
 
@@ -33,6 +34,17 @@ class TrainingRouteRecord(BaseModel):
         return self.route.signature()
 
 
+class TestRouteRecord(BaseModel):
+    id: str
+    dataset: TestSetName
+    route: Route
+    sources: list[RawRouteSource] = Field(default_factory=list)
+
+    @property
+    def route_signature(self) -> str:
+        return self.route.signature()
+
+
 class TrainingReactionSource(BaseModel):
     route_id: str
     step_index: int | None = None
@@ -43,6 +55,21 @@ class TrainingReactionSource(BaseModel):
 class TrainingReactionRecord(BaseModel):
     id: str
     split: SplitName
+    reactants: list[SmilesStr]
+    product: SmilesStr
+    mapped_smiles: ReactionSmilesStr
+    alternative_mapped_smiles: list[ReactionSmilesStr] = Field(default_factory=list)
+    condition_slot: str | None = None
+    condition_slot_smiles: list[SmilesStr] = Field(default_factory=list)
+    sources: list[TrainingReactionSource] = Field(default_factory=list)
+
+    def to_rsmi_line(self) -> str:
+        return self.mapped_smiles
+
+
+class TestReactionRecord(BaseModel):
+    id: str
+    dataset: TestSetName
     reactants: list[SmilesStr]
     product: SmilesStr
     mapped_smiles: ReactionSmilesStr

--- a/src/retrocast/curation/training/route_release.py
+++ b/src/retrocast/curation/training/route_release.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import random
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
+from rich.console import Console
 from tqdm.auto import tqdm
 
 from retrocast._version import __version__
 from retrocast.adapters.paroutes import ConditionSlotParseStatistics, PaRoutesAdapter, analyze_condition_slots
 from retrocast.chem import canonicalize_smiles, get_inchi_key
+from retrocast.cli.progress import step_progress
 from retrocast.curation.filtering import excise_reactions_from_route
 from retrocast.curation.training.records import (
     AdaptationStatistics,
@@ -32,6 +35,12 @@ from retrocast.typing import InChIKeyStr, SmilesStr
 
 TRAINING_RELEASE_ACTION = "scripts/paroutes/training-set-prep/create-training-release"
 PAROUTES_TRAINING_ROUTE_ID_WIDTH = 6
+
+
+def _phase(step, description: str):
+    if step is None:
+        return nullcontext()
+    return step(description)
 
 
 def stable_raw_route_hash(raw_route: dict[str, Any]) -> str:
@@ -134,60 +143,70 @@ class TrainingRouteReleaseBuilder:
             raise RuntimeError("TrainingRouteReleaseBuilder instances are single-use")
         self._started = True
 
-        holdout_route_signatures = {
-            route.route.signature() for routes in self.holdout_routes.values() for route in routes
-        }
-        holdout_reaction_signatures = (
-            {
-                signature
-                for routes in self.holdout_routes.values()
-                for route in routes
-                for signature in route.route.reaction_signatures()
-            }
-            if self.config.holdout_mode == "reaction"
-            else set()
-        )
+        if not self.config.show_progress:
+            return self._build(step=None)
 
-        candidates = []
-        skipped_route_holdout = 0
-        routes_with_overlapping_reactions = 0
-        reaction_excision_fragments = 0
-        routes_fully_removed_after_excision = 0
-        for route in self.all_routes:
-            structural_signature = route.route.signature()
-            if structural_signature in holdout_route_signatures:
-                skipped_route_holdout += 1
-                continue
-            if (
-                self.config.holdout_mode == "reaction"
-                and route.route.reaction_signatures() & holdout_reaction_signatures
-            ):
-                routes_with_overlapping_reactions += 1
-                fragments = excise_reactions_from_route(route.route, holdout_reaction_signatures)
-                if not fragments:
-                    routes_fully_removed_after_excision += 1
+        with step_progress(console=Console(), total=self._build_step_count(), transient=True) as step:
+            return self._build(step=step)
+
+    def _build_step_count(self) -> int:
+        return 6 if self.config.holdout_mode == "reaction" else 5
+
+    def _build(self, *, step) -> TrainingSetBuildResult:
+        with _phase(step, f"{self.config.holdout_mode}: collect holdout routes"):
+            holdout_routes = [route for routes in self.holdout_routes.values() for route in routes]
+            holdout_route_signatures = {route.route.signature() for route in holdout_routes}
+
+        holdout_reaction_signatures = set()
+        if self.config.holdout_mode == "reaction":
+            with _phase(step, "reaction: collect holdout reactions"):
+                for route in holdout_routes:
+                    holdout_reaction_signatures.update(route.route.reaction_signatures())
+
+        with _phase(step, f"{self.config.holdout_mode}: prepare candidates"):
+            candidates = []
+            skipped_route_holdout = 0
+            routes_with_overlapping_reactions = 0
+            reaction_excision_fragments = 0
+            routes_fully_removed_after_excision = 0
+            for route in self.all_routes:
+                structural_signature = route.route.signature()
+                if structural_signature in holdout_route_signatures:
+                    skipped_route_holdout += 1
                     continue
-                reaction_excision_fragments += len(fragments)
-                for fragment in fragments:
-                    candidates.append(
-                        PreparedTrainingRoute(
-                            route=fragment,
-                            structural_signature=fragment.signature(),
-                            sources=[route.source],
+                if (
+                    self.config.holdout_mode == "reaction"
+                    and route.route.reaction_signatures() & holdout_reaction_signatures
+                ):
+                    routes_with_overlapping_reactions += 1
+                    fragments = excise_reactions_from_route(route.route, holdout_reaction_signatures)
+                    if not fragments:
+                        routes_fully_removed_after_excision += 1
+                        continue
+                    reaction_excision_fragments += len(fragments)
+                    for fragment in fragments:
+                        candidates.append(
+                            PreparedTrainingRoute(
+                                route=fragment,
+                                structural_signature=fragment.signature(),
+                                sources=[route.source],
+                            )
                         )
+                    continue
+                candidates.append(
+                    PreparedTrainingRoute(
+                        route=route.route,
+                        structural_signature=structural_signature,
+                        sources=[route.source],
                     )
-                continue
-            candidates.append(
-                PreparedTrainingRoute(
-                    route=route.route,
-                    structural_signature=structural_signature,
-                    sources=[route.source],
                 )
-            )
 
-        exact_unique, exact_duplicates_removed = _merge_exact_route_duplicates(candidates)
-        transform_unique, mapped_variants_collapsed = _merge_transform_route_variants(exact_unique)
-        records = self._build_records(transform_unique)
+        with _phase(step, f"{self.config.holdout_mode}: merge exact duplicates"):
+            exact_unique, exact_duplicates_removed = _merge_exact_route_duplicates(candidates)
+        with _phase(step, f"{self.config.holdout_mode}: collapse mapped variants"):
+            transform_unique, mapped_variants_collapsed = _merge_transform_route_variants(exact_unique)
+        with _phase(step, f"{self.config.holdout_mode}: assign splits"):
+            records = self._build_records(transform_unique)
         summary = {
             "input": {"all_routes": len(self.all_routes)},
             "adaptation": {
@@ -212,7 +231,10 @@ class TrainingRouteReleaseBuilder:
         }
         return TrainingSetBuildResult(release_name=self.config.release_name, records=records, summary=summary)
 
-    def _build_records(self, routes: Sequence[PreparedTrainingRoute]) -> list[TrainingRouteRecord]:
+    def _build_records(
+        self,
+        routes: Sequence[PreparedTrainingRoute],
+    ) -> list[TrainingRouteRecord]:
         validation_ids = _validation_indices(routes, val_fraction=self.config.val_fraction, seed=self.config.seed)
         width = max(6, len(str(len(routes))))
         records = []
@@ -274,9 +296,10 @@ def write_training_release(
 def summarize_records(records: Sequence[TrainingRouteRecord]) -> dict[str, Any]:
     training = sum(1 for record in records if record.split == "training")
     validation = sum(1 for record in records if record.split == "validation")
+    depths = Counter(record.route.depth() for record in records)
     return {
         "all_records": {"total": len(records), "training": training, "validation": validation},
-        "by_depth": _count_by(records, lambda record: str(record.route.depth())),
+        "by_depth": {str(depth): depths[depth] for depth in sorted(depths)},
     }
 
 
@@ -330,7 +353,9 @@ def extract_paroutes_reaction_hash_by_source_id(raw_route: Mapping[str, Any]) ->
     return reaction_hash_by_source_id
 
 
-def _merge_exact_route_duplicates(routes: Sequence[PreparedTrainingRoute]) -> tuple[list[PreparedTrainingRoute], int]:
+def _merge_exact_route_duplicates(
+    routes: Sequence[PreparedTrainingRoute],
+) -> tuple[list[PreparedTrainingRoute], int]:
     grouped: dict[tuple[Any, ...], PreparedTrainingRoute] = {}
     duplicates_removed = 0
     for route in routes:
@@ -346,7 +371,9 @@ def _merge_exact_route_duplicates(routes: Sequence[PreparedTrainingRoute]) -> tu
     return list(grouped.values()), duplicates_removed
 
 
-def _merge_transform_route_variants(routes: Sequence[PreparedTrainingRoute]) -> tuple[list[PreparedTrainingRoute], int]:
+def _merge_transform_route_variants(
+    routes: Sequence[PreparedTrainingRoute],
+) -> tuple[list[PreparedTrainingRoute], int]:
     groups: dict[tuple[Any, ...], list[PreparedTrainingRoute]] = defaultdict(list)
     for route in routes:
         groups[_route_transform_key(route.route)].append(route)
@@ -470,10 +497,3 @@ def _validation_indices(routes: Sequence[PreparedTrainingRoute], *, val_fraction
         if count > 0:
             validation.update(rng.sample(indices, count))
     return validation
-
-
-def _count_by(records: Sequence[TrainingRouteRecord], key_fn) -> dict[str, int]:
-    counts: dict[str, int] = defaultdict(int)
-    for record in records:
-        counts[key_fn(record)] += 1
-    return dict(sorted(counts.items()))

--- a/src/retrocast/curation/training/route_release.py
+++ b/src/retrocast/curation/training/route_release.py
@@ -273,9 +273,9 @@ def write_training_release(
         action=TRAINING_RELEASE_ACTION,
         sources=source_paths,
         outputs=[
-            ("all", all_path, result.records, ContentType.UNKNOWN),
-            ("training", training_path, training, ContentType.UNKNOWN),
-            ("validation", validation_path, validation, ContentType.UNKNOWN),
+            ("all", all_path, result.records, ContentType.UNKNOWN, route_records_content_hash(result.records)),
+            ("training", training_path, training, ContentType.UNKNOWN, route_records_content_hash(training)),
+            ("validation", validation_path, validation, ContentType.UNKNOWN, route_records_content_hash(validation)),
         ],
         root_dir=source_root,
         parameters=config.to_manifest_dict(),
@@ -284,12 +284,6 @@ def write_training_release(
         release_name=result.release_name,
         keyed_output_files=True,
     )
-    output_files = manifest.output_files
-    if not isinstance(output_files, dict):
-        raise TypeError("training route release manifest must use keyed output files")
-    output_files["all"].content_hash = route_records_content_hash(result.records)
-    output_files["training"].content_hash = route_records_content_hash(training)
-    output_files["validation"].content_hash = route_records_content_hash(validation)
     manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
 
 

--- a/src/retrocast/curation/training/testset_release.py
+++ b/src/retrocast/curation/training/testset_release.py
@@ -40,6 +40,12 @@ def build_test_reaction_records(
 ) -> list[TestReactionRecord]:
     records: list[TestReactionRecord] = []
     for route_record in route_records:
+        if route_record.dataset != dataset:
+            raise TrainingReleaseError(
+                "test single-step release route dataset does not match requested dataset",
+                code="workflow.test_single_step_dataset_mismatch",
+                context={"dataset": dataset, "route_id": route_record.id, "route_dataset": route_record.dataset},
+            )
         for step_index, reaction in enumerate(route_record.route.iter_reactions(), start=1):
             mapped_smiles = reaction.value.mapped_reaction_smiles
             if mapped_smiles is None:
@@ -49,6 +55,18 @@ def build_test_reaction_records(
                     context={"route_id": route_record.id, "reaction_id": reaction.id()},
                 )
             annotations = reaction.value.annotations
+            condition_slot_smiles = _string_list_annotation(
+                annotations,
+                "condition_slot_smiles",
+                route_id=route_record.id,
+                reaction_id=reaction.id(),
+            )
+            alternative_mapped_smiles = _string_list_annotation(
+                annotations,
+                "alternative_mapped_smiles",
+                route_id=route_record.id,
+                reaction_id=reaction.id(),
+            )
             records.append(
                 TestReactionRecord(
                     id=f"{route_prefix}-{dataset}-single-step-reactions-{len(records) + 1:06d}",
@@ -59,11 +77,7 @@ def build_test_reaction_records(
                     condition_slot=annotations.get("condition_slot")
                     if isinstance(annotations.get("condition_slot"), str)
                     else None,
-                    condition_slot_smiles=[
-                        SmilesStr(value)
-                        for value in annotations.get("condition_slot_smiles", [])
-                        if isinstance(value, str)
-                    ],
+                    condition_slot_smiles=[SmilesStr(value) for value in condition_slot_smiles],
                     sources=[
                         TrainingReactionSource(
                             route_id=route_record.id,
@@ -76,7 +90,7 @@ def build_test_reaction_records(
                     ],
                     alternative_mapped_smiles=[
                         ReactionSmilesStr(value)
-                        for value in annotations.get("alternative_mapped_smiles", [])
+                        for value in alternative_mapped_smiles
                         if isinstance(value, str) and value != mapped_smiles
                     ],
                 )
@@ -162,7 +176,7 @@ def write_test_reaction_release(
                 all_rsmi_path,
                 [record.to_rsmi_line() for record in records],
                 ContentType.UNKNOWN,
-                hash_json([record.to_rsmi_line() for record in records]),
+                hash_json(sorted(record.to_rsmi_line() for record in records)),
             ),
         ],
         root_dir=source_root,
@@ -173,6 +187,17 @@ def write_test_reaction_release(
         keyed_output_files=True,
     )
     manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+
+def _string_list_annotation(annotations: dict[str, object], key: str, *, route_id: str, reaction_id: str) -> list[str]:
+    value = annotations.get(key, [])
+    if not isinstance(value, list):
+        raise TrainingReleaseError(
+            f"test single-step release annotation '{key}' must be a list",
+            code=f"workflow.test_single_step_invalid_{key}",
+            context={"route_id": route_id, "reaction_id": reaction_id},
+        )
+    return [item for item in value if isinstance(item, str)]
 
 
 def _condition_identity(record: TestReactionRecord) -> tuple[str, ...]:

--- a/src/retrocast/curation/training/testset_release.py
+++ b/src/retrocast/curation/training/testset_release.py
@@ -109,19 +109,23 @@ def write_test_route_release(
     manifest = create_manifest(
         action=TEST_RELEASE_ACTION,
         sources=source_paths,
-        outputs=[("all", all_path, records, ContentType.UNKNOWN)],
+        outputs=[
+            (
+                "all",
+                all_path,
+                records,
+                ContentType.UNKNOWN,
+                hash_json(
+                    sorted(record.route.content_signature(fields=("mapped_reaction_smiles",)) for record in records)
+                ),
+            )
+        ],
         root_dir=source_root,
         parameters={"dataset": dataset, "artifact": release_name},
         statistics=summary["output"],
         summary=summary,
         release_name=release_name,
         keyed_output_files=True,
-    )
-    output_files = manifest.output_files
-    if not isinstance(output_files, dict):
-        raise TypeError("test route release manifest must use keyed output files")
-    output_files["all"].content_hash = hash_json(
-        sorted(record.route.content_signature(fields=("mapped_reaction_smiles",)) for record in records)
     )
     manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
 
@@ -146,8 +150,20 @@ def write_test_reaction_release(
         action=TEST_RELEASE_ACTION,
         sources=source_paths,
         outputs=[
-            ("all", all_path, records, ContentType.UNKNOWN),
-            ("all_rsmi", all_rsmi_path, [record.to_rsmi_line() for record in records], ContentType.UNKNOWN),
+            (
+                "all",
+                all_path,
+                records,
+                ContentType.UNKNOWN,
+                hash_json(sorted((str(record.mapped_smiles), _condition_identity(record)) for record in records)),
+            ),
+            (
+                "all_rsmi",
+                all_rsmi_path,
+                [record.to_rsmi_line() for record in records],
+                ContentType.UNKNOWN,
+                hash_json([record.to_rsmi_line() for record in records]),
+            ),
         ],
         root_dir=source_root,
         parameters={"dataset": dataset, "artifact": release_name},
@@ -156,13 +172,6 @@ def write_test_reaction_release(
         release_name=release_name,
         keyed_output_files=True,
     )
-    output_files = manifest.output_files
-    if not isinstance(output_files, dict):
-        raise TypeError("test reaction release manifest must use keyed output files")
-    output_files["all"].content_hash = hash_json(
-        sorted((str(record.mapped_smiles), _condition_identity(record)) for record in records)
-    )
-    output_files["all_rsmi"].content_hash = hash_json([record.to_rsmi_line() for record in records])
     manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
 
 

--- a/src/retrocast/curation/training/testset_release.py
+++ b/src/retrocast/curation/training/testset_release.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path
+
+from retrocast.curation.training.records import (
+    AdaptationStatistics,
+    AdaptedTrainingRoute,
+    TestReactionRecord,
+    TestRouteRecord,
+    TestSetName,
+    TrainingReactionSource,
+)
+from retrocast.exceptions import TrainingReleaseError
+from retrocast.hashing import hash_json
+from retrocast.io import ContentType, create_manifest, save_jsonl_gz, save_lines_gz
+from retrocast.typing import ReactionSmilesStr, SmilesStr
+
+TEST_RELEASE_ACTION = "scripts/paroutes/training-set-prep/create-test-set-release"
+
+
+def build_test_route_records(
+    *, dataset: TestSetName, routes: Sequence[AdaptedTrainingRoute], route_prefix: str = "paroutes"
+) -> list[TestRouteRecord]:
+    width = max(5, len(str(len(routes))))
+    return [
+        TestRouteRecord(
+            id=f"{route_prefix}-{dataset}-routes-{index:0{width}d}",
+            dataset=dataset,
+            route=route.route,
+            sources=[route.source],
+        )
+        for index, route in enumerate(routes, start=1)
+    ]
+
+
+def build_test_reaction_records(
+    *, dataset: TestSetName, route_records: Sequence[TestRouteRecord], route_prefix: str = "paroutes"
+) -> list[TestReactionRecord]:
+    records: list[TestReactionRecord] = []
+    for route_record in route_records:
+        for step_index, reaction in enumerate(route_record.route.iter_reactions(), start=1):
+            mapped_smiles = reaction.value.mapped_reaction_smiles
+            if mapped_smiles is None:
+                raise TrainingReleaseError(
+                    f"test single-step release requires mapped_reaction_smiles; missing on route {route_record.id} reaction {reaction.id()}",
+                    code="workflow.test_single_step_missing_mapped_smiles",
+                    context={"route_id": route_record.id, "reaction_id": reaction.id()},
+                )
+            annotations = reaction.value.annotations
+            records.append(
+                TestReactionRecord(
+                    id=f"{route_prefix}-{dataset}-single-step-reactions-{len(records) + 1:06d}",
+                    dataset=dataset,
+                    reactants=[reactant.value.smiles for reactant in reaction.reactants()],
+                    product=reaction.product().value.smiles,
+                    mapped_smiles=mapped_smiles,
+                    condition_slot=annotations.get("condition_slot")
+                    if isinstance(annotations.get("condition_slot"), str)
+                    else None,
+                    condition_slot_smiles=[
+                        SmilesStr(value)
+                        for value in annotations.get("condition_slot_smiles", [])
+                        if isinstance(value, str)
+                    ],
+                    sources=[
+                        TrainingReactionSource(
+                            route_id=route_record.id,
+                            step_index=step_index,
+                            reaction_id=reaction.id(),
+                            source_id=annotations.get("source_id")
+                            if isinstance(annotations.get("source_id"), str)
+                            else None,
+                        )
+                    ],
+                    alternative_mapped_smiles=[
+                        ReactionSmilesStr(value)
+                        for value in annotations.get("alternative_mapped_smiles", [])
+                        if isinstance(value, str) and value != mapped_smiles
+                    ],
+                )
+            )
+    return records
+
+
+def write_test_route_release(
+    *,
+    dataset: TestSetName,
+    records: Sequence[TestRouteRecord],
+    adaptation: AdaptationStatistics,
+    output_dir: Path,
+    source_paths: list[Path],
+    source_root: Path,
+) -> None:
+    release_name = f"{dataset}-routes"
+    release_dir = output_dir / release_name
+    all_path = release_dir / "all.jsonl.gz"
+    manifest_path = release_dir / "manifest.json"
+    save_jsonl_gz(records, all_path)
+    depths = Counter(record.route.depth() for record in records)
+    summary = {
+        "adaptation": adaptation.to_manifest_dict(),
+        "output": {
+            "all_records": {"total": len(records)},
+            "by_depth": {str(depth): depths[depth] for depth in sorted(depths)},
+        },
+    }
+    manifest = create_manifest(
+        action=TEST_RELEASE_ACTION,
+        sources=source_paths,
+        outputs=[("all", all_path, records, ContentType.UNKNOWN)],
+        root_dir=source_root,
+        parameters={"dataset": dataset, "artifact": release_name},
+        statistics=summary["output"],
+        summary=summary,
+        release_name=release_name,
+        keyed_output_files=True,
+    )
+    output_files = manifest.output_files
+    if not isinstance(output_files, dict):
+        raise TypeError("test route release manifest must use keyed output files")
+    output_files["all"].content_hash = hash_json(
+        sorted(record.route.content_signature(fields=("mapped_reaction_smiles",)) for record in records)
+    )
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+
+def write_test_reaction_release(
+    *,
+    dataset: TestSetName,
+    records: Sequence[TestReactionRecord],
+    output_dir: Path,
+    source_paths: list[Path],
+    source_root: Path,
+) -> None:
+    release_name = f"{dataset}-single-step-reactions"
+    release_dir = output_dir / release_name
+    all_path = release_dir / "all.jsonl.gz"
+    all_rsmi_path = release_dir / "all.rsmi.txt.gz"
+    manifest_path = release_dir / "manifest.json"
+    save_jsonl_gz(records, all_path)
+    save_lines_gz((record.to_rsmi_line() for record in records), all_rsmi_path)
+    summary = {"output": {"all_records": {"total": len(records)}}}
+    manifest = create_manifest(
+        action=TEST_RELEASE_ACTION,
+        sources=source_paths,
+        outputs=[
+            ("all", all_path, records, ContentType.UNKNOWN),
+            ("all_rsmi", all_rsmi_path, [record.to_rsmi_line() for record in records], ContentType.UNKNOWN),
+        ],
+        root_dir=source_root,
+        parameters={"dataset": dataset, "artifact": release_name},
+        statistics=summary["output"],
+        summary=summary,
+        release_name=release_name,
+        keyed_output_files=True,
+    )
+    output_files = manifest.output_files
+    if not isinstance(output_files, dict):
+        raise TypeError("test reaction release manifest must use keyed output files")
+    output_files["all"].content_hash = hash_json(
+        sorted((str(record.mapped_smiles), _condition_identity(record)) for record in records)
+    )
+    output_files["all_rsmi"].content_hash = hash_json([record.to_rsmi_line() for record in records])
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+
+def _condition_identity(record: TestReactionRecord) -> tuple[str, ...]:
+    condition_smiles = tuple(str(value) for value in record.condition_slot_smiles)
+    if condition_smiles:
+        return condition_smiles
+    return (record.condition_slot,) if record.condition_slot is not None else ()

--- a/src/retrocast/datasets.py
+++ b/src/retrocast/datasets.py
@@ -26,8 +26,13 @@ from retrocast.paths import resolve_cache_dir, validate_filename
 
 TrainingDatasetName = Literal["paroutes"]
 TrainingArtifactName = Literal[
+    "n1-routes",
+    "n5-routes",
     "route-holdout-n1-n5",
     "reaction-holdout-n1-n5",
+    "n1-single-step-reactions",
+    "n5-single-step-reactions",
+    "single-step-route-holdout-n1-n5",
     "single-step-reaction-holdout-n1-n5",
 ]
 TrainingSplitName = Literal["all", "training", "validation"]
@@ -61,20 +66,49 @@ class DownloadedBenchmarkAssets:
 
 @dataclass(frozen=True)
 class TrainingArtifactSpec:
+    supported_splits: tuple[TrainingSplitName, ...]
     supported_formats: tuple[TrainingSetFormat, ...]
     suffix_by_format: dict[TrainingSetFormat, str]
 
 
 TRAINING_ARTIFACT_SPECS: dict[str, TrainingArtifactSpec] = {
+    "n1-routes": TrainingArtifactSpec(
+        supported_splits=("all",),
+        supported_formats=("jsonl",),
+        suffix_by_format={"jsonl": ".jsonl.gz"},
+    ),
+    "n5-routes": TrainingArtifactSpec(
+        supported_splits=("all",),
+        supported_formats=("jsonl",),
+        suffix_by_format={"jsonl": ".jsonl.gz"},
+    ),
     "route-holdout-n1-n5": TrainingArtifactSpec(
+        supported_splits=("all", "training", "validation"),
         supported_formats=("jsonl",),
         suffix_by_format={"jsonl": ".jsonl.gz"},
     ),
     "reaction-holdout-n1-n5": TrainingArtifactSpec(
+        supported_splits=("all", "training", "validation"),
         supported_formats=("jsonl",),
         suffix_by_format={"jsonl": ".jsonl.gz"},
     ),
+    "n1-single-step-reactions": TrainingArtifactSpec(
+        supported_splits=("all",),
+        supported_formats=("jsonl", "rsmi"),
+        suffix_by_format={"jsonl": ".jsonl.gz", "rsmi": ".rsmi.txt.gz"},
+    ),
+    "n5-single-step-reactions": TrainingArtifactSpec(
+        supported_splits=("all",),
+        supported_formats=("jsonl", "rsmi"),
+        suffix_by_format={"jsonl": ".jsonl.gz", "rsmi": ".rsmi.txt.gz"},
+    ),
+    "single-step-route-holdout-n1-n5": TrainingArtifactSpec(
+        supported_splits=("all", "training", "validation"),
+        supported_formats=("jsonl", "rsmi"),
+        suffix_by_format={"jsonl": ".jsonl.gz", "rsmi": ".rsmi.txt.gz"},
+    ),
     "single-step-reaction-holdout-n1-n5": TrainingArtifactSpec(
+        supported_splits=("all", "training", "validation"),
         supported_formats=("jsonl", "rsmi"),
         suffix_by_format={"jsonl": ".jsonl.gz", "rsmi": ".rsmi.txt.gz"},
     ),
@@ -265,13 +299,20 @@ def validate_training_dataset_request(
             code="dataset.unsupported_split",
             context={"split": split},
         )
+    artifact_spec = TRAINING_ARTIFACT_SPECS[artifact]
+    if split not in artifact_spec.supported_splits:
+        raise ConfigurationError(
+            f"artifact '{artifact}' does not support split '{split}'",
+            code="dataset.split_mismatch",
+            context={"artifact": artifact, "split": split, "supported_splits": list(artifact_spec.supported_splits)},
+        )
     if format not in {"jsonl", "rsmi"}:
         raise ConfigurationError(
             f"unsupported training dataset format: {format}",
             code="dataset.unsupported_format",
             context={"format": format},
         )
-    supported_formats = TRAINING_ARTIFACT_SPECS[artifact].supported_formats
+    supported_formats = artifact_spec.supported_formats
     if format not in supported_formats:
         raise ConfigurationError(
             f"artifact '{artifact}' does not support format '{format}'",

--- a/src/retrocast/io/provenance.py
+++ b/src/retrocast/io/provenance.py
@@ -24,7 +24,8 @@ class ContentType(StrEnum):
 ContentTypeHint = Literal["benchmark", "predictions", "route_corpus", "stock", "unknown"]
 UnlabeledManifestOutput: TypeAlias = tuple[Path, Any, ContentType | ContentTypeHint]
 LabeledManifestOutput: TypeAlias = tuple[str, Path, Any, ContentType | ContentTypeHint]
-ManifestOutput: TypeAlias = UnlabeledManifestOutput | LabeledManifestOutput
+LabeledManifestOutputWithHash: TypeAlias = tuple[str, Path, Any, ContentType | ContentTypeHint, str]
+ManifestOutput: TypeAlias = UnlabeledManifestOutput | LabeledManifestOutput | LabeledManifestOutputWithHash
 
 
 def calculate_file_hash(path: Path) -> str:
@@ -51,14 +52,15 @@ def create_manifest(
 
     output_infos = []
     for output in outputs:
-        label, path, obj, content_type = _normalize_manifest_output(output)
+        label, path, obj, content_type, content_hash = _normalize_manifest_output(output)
+        content_type = ContentType(content_type)
         file_hash = calculate_file_hash(path) if path.exists() else "file-not-written"
         output_infos.append(
             FileInfo(
                 label=label,
                 path=_relative_path(path, root_dir),
                 file_hash=file_hash,
-                content_hash=_content_hash(obj, ContentType(content_type)),
+                content_hash=content_hash if content_hash is not None else _content_hash(obj, content_type),
             )
         )
 
@@ -89,21 +91,30 @@ def create_manifest(
 
 def _normalize_manifest_output(
     output: ManifestOutput,
-) -> tuple[str | None, Path, Any, ContentType | ContentTypeHint]:
+) -> tuple[str | None, Path, Any, ContentType | ContentTypeHint, str | None]:
     items: tuple[Any, ...] = tuple(output)
     if len(items) == 3:
         path, obj, content_type = items
         if not isinstance(path, Path):
             raise TypeError(f"manifest output path must be Path, got {type(path).__name__}")
-        return None, path, obj, content_type
+        return None, path, obj, content_type, None
     if len(items) == 4:
         label, path, obj, content_type = items
         if not isinstance(label, str):
             raise TypeError(f"manifest output label must be str, got {type(label).__name__}")
         if not isinstance(path, Path):
             raise TypeError(f"manifest output path must be Path, got {type(path).__name__}")
-        return label, path, obj, content_type
-    raise ValueError(f"manifest output must have 3 or 4 items, got {len(items)}")
+        return label, path, obj, content_type, None
+    if len(items) == 5:
+        label, path, obj, content_type, content_hash = items
+        if not isinstance(label, str):
+            raise TypeError(f"manifest output label must be str, got {type(label).__name__}")
+        if not isinstance(path, Path):
+            raise TypeError(f"manifest output path must be Path, got {type(path).__name__}")
+        if not isinstance(content_hash, str):
+            raise TypeError(f"manifest output content hash must be str, got {type(content_hash).__name__}")
+        return label, path, obj, content_type, content_hash
+    raise ValueError(f"manifest output must have 3, 4, or 5 items, got {len(items)}")
 
 
 def _relative_path(path: Path, root_dir: Path) -> str:

--- a/src/retrocast/markdown.py
+++ b/src/retrocast/markdown.py
@@ -7,6 +7,10 @@ MarkdownAlign = Literal["left", "right", "center"]
 MarkdownRow = Sequence[object]
 
 
+def format_integer(value: int) -> str:
+    return f"{value:,}".replace(",", " ")
+
+
 def markdown_table(
     headers: MarkdownRow,
     rows: Sequence[MarkdownRow],

--- a/tests/curation/test_training_release.py
+++ b/tests/curation/test_training_release.py
@@ -182,6 +182,55 @@ def test_test_set_reaction_release_hashes_conditionless_records(tmp_path: Path) 
     assert (tmp_path / "n1-single-step-reactions" / "manifest.json").exists()
 
 
+def test_test_set_reaction_release_rejects_mixed_dataset_records() -> None:
+    route_records = build_test_route_records(dataset="n5", routes=[adapted_route("n5-a", one_step_route("C.C>>CC"))])
+
+    with pytest.raises(TrainingReleaseError) as error:
+        build_test_reaction_records(dataset="n1", route_records=route_records)
+
+    assert error.value.code == "workflow.test_single_step_dataset_mismatch"
+    assert error.value.context["route_dataset"] == "n5"
+
+
+def test_test_set_reaction_release_rejects_non_list_annotations() -> None:
+    route = one_step_route("C.C>>CC")
+    assert route.target.product_of is not None
+    route.target.product_of.annotations["condition_slot_smiles"] = "O"
+    route_records = build_test_route_records(dataset="n1", routes=[adapted_route("n1-a", route)])
+
+    with pytest.raises(TrainingReleaseError) as error:
+        build_test_reaction_records(dataset="n1", route_records=route_records)
+
+    assert error.value.code == "workflow.test_single_step_invalid_condition_slot_smiles"
+
+
+def test_test_set_reaction_release_rsmi_content_hash_is_order_independent(tmp_path: Path) -> None:
+    record_a = build_test_reaction_records(
+        dataset="n1",
+        route_records=build_test_route_records(dataset="n1", routes=[adapted_route("n1-a", two_step_route())]),
+    )[0]
+    record_b = record_a.model_copy(update={"id": "other", "mapped_smiles": ReactionSmilesStr("N.N>>NN")})
+
+    write_test_reaction_release(
+        dataset="n1",
+        records=[record_a, record_b],
+        output_dir=tmp_path / "first",
+        source_paths=[],
+        source_root=tmp_path,
+    )
+    write_test_reaction_release(
+        dataset="n1",
+        records=[record_b, record_a],
+        output_dir=tmp_path / "second",
+        source_paths=[],
+        source_root=tmp_path,
+    )
+
+    first = json.loads((tmp_path / "first" / "n1-single-step-reactions" / "manifest.json").read_text())
+    second = json.loads((tmp_path / "second" / "n1-single-step-reactions" / "manifest.json").read_text())
+    assert first["output_files"]["all_rsmi"]["content_hash"] == second["output_files"]["all_rsmi"]["content_hash"]
+
+
 def test_route_release_keeps_condition_variants_separate() -> None:
     route_a = one_step_route("C.C>O>CC", condition_slot_smiles=["O"])
     route_b = one_step_route("C.C>N>CC", condition_slot_smiles=["N"])
@@ -396,12 +445,16 @@ def test_single_step_audit_rejects_release_identity_failures(tmp_path: Path) -> 
     release_dir = tmp_path / "single-step-reaction-holdout-n1-n5"
     training = reaction_record("train", "route-train", split="training")
     validation = reaction_record("validation", "missing-route", split="validation")
+    duplicate_validation = validation.model_copy(update={"id": "reaction-validation-duplicate"})
     save_jsonl_gz([training, validation], release_dir / "all.jsonl.gz")
     save_jsonl_gz([training], release_dir / "training.jsonl.gz")
-    save_jsonl_gz([validation], release_dir / "validation.jsonl.gz")
+    save_jsonl_gz([validation, duplicate_validation], release_dir / "validation.jsonl.gz")
     save_lines_gz([training.to_rsmi_line()], release_dir / "all.rsmi.txt.gz")
     save_lines_gz([training.to_rsmi_line()], release_dir / "training.rsmi.txt.gz")
-    save_lines_gz([validation.to_rsmi_line()], release_dir / "validation.rsmi.txt.gz")
+    save_lines_gz(
+        [validation.to_rsmi_line(), duplicate_validation.to_rsmi_line()],
+        release_dir / "validation.rsmi.txt.gz",
+    )
 
     with pytest.raises(TrainingReleaseError) as error:
         audit_single_step_release_if_present(release_root=tmp_path, parent_route_ids={"route-train"})
@@ -411,6 +464,7 @@ def test_single_step_audit_rejects_release_identity_failures(tmp_path: Path) -> 
     assert failures["rsmi_count_mismatches"] == {"all": 1, "training": 0, "validation": 0}
     assert failures["cross_split_reaction_identity_overlap"] == 1
     assert failures["missing_parent_route_sources"] == 1
+    assert failures["duplicate_validation_exact_reaction_keys"] == 1
 
 
 def test_single_step_audit_success_absent_release_and_identity_helpers(tmp_path: Path) -> None:

--- a/tests/curation/test_training_release.py
+++ b/tests/curation/test_training_release.py
@@ -17,6 +17,10 @@ from retrocast.curation.training import (
     TrainingRouteReleaseBuilder,
     TrainingSetBuildConfig,
     adapt_training_routes,
+    build_test_reaction_records,
+    build_test_route_records,
+    write_test_reaction_release,
+    write_test_route_release,
     write_training_reaction_release,
     write_training_release,
 )
@@ -28,14 +32,12 @@ from retrocast.curation.training.audit import (
     build_route_release_split_audit,
     duplicate_count,
     exact_reaction_record_key,
-    load_holdout_reference,
     reaction_record_identity_key,
     render_route_release_split_audit_markdown,
-    render_sanity_checks_markdown,
-    render_single_step_sanity_markdown,
 )
+from retrocast.curation.training.route_release import summarize_records
 from retrocast.exceptions import AdapterError, TrainingReleaseError
-from retrocast.io import load_training_route_records, save_json_gz, save_jsonl_gz, save_lines_gz
+from retrocast.io import iter_jsonl_gz, load_training_route_records, save_json_gz, save_jsonl_gz, save_lines_gz
 from retrocast.models import Molecule, Reaction, Route
 from retrocast.typing import InChIKeyStr, ReactionSmilesStr, SmilesStr
 
@@ -89,6 +91,19 @@ def test_schema_v2_training_route_and_reaction_release_roundtrip(
     assert reaction_manifest["output_files"]["all"]["content_hash"] is not None
 
 
+def test_route_summary_depth_counts_are_sorted_numerically() -> None:
+    summary = summarize_records(
+        [
+            route_record("depth-10", linear_route(depth=10), split="training"),
+            route_record("depth-2-a", linear_route(depth=2), split="training"),
+            route_record("depth-3", linear_route(depth=3), split="training"),
+            route_record("depth-2-b", linear_route(depth=2), split="training"),
+        ]
+    )
+
+    assert summary["by_depth"] == {"2": 2, "3": 1, "10": 1}
+
+
 def test_route_release_collapses_mapped_variants_and_preserves_sources() -> None:
     route_a = one_step_route("C.C>>CC", patent_id="patent-a")
     route_b = one_step_route("[CH3:1].[CH3:2]>>[CH3:1][CH3:2]", patent_id="patent-b")
@@ -112,6 +127,59 @@ def test_route_release_collapses_mapped_variants_and_preserves_sources() -> None
     assert record.route.target.product_of.annotations["alternative_mapped_smiles"] == [
         "[CH3:1].[CH3:2]>>[CH3:1][CH3:2]"
     ]
+
+
+def test_test_set_release_writes_routes_and_occurrence_preserving_reactions(tmp_path: Path) -> None:
+    adapted = [adapted_route("n1-a", two_step_route())]
+    route_records = build_test_route_records(dataset="n1", routes=adapted)
+    reaction_records = build_test_reaction_records(dataset="n1", route_records=route_records)
+
+    assert route_records[0].id == "paroutes-n1-routes-00001"
+    assert len(reaction_records) == 2
+    assert [source.route_id for record in reaction_records for source in record.sources] == [
+        "paroutes-n1-routes-00001",
+        "paroutes-n1-routes-00001",
+    ]
+    assert [source.step_index for record in reaction_records for source in record.sources] == [1, 2]
+
+    write_test_route_release(
+        dataset="n1",
+        records=route_records,
+        adaptation=adaptation_stats(raw=1, adapted=1),
+        output_dir=tmp_path,
+        source_paths=[],
+        source_root=tmp_path,
+    )
+    write_test_reaction_release(
+        dataset="n1",
+        records=reaction_records,
+        output_dir=tmp_path,
+        source_paths=[tmp_path / "n1-routes" / "all.jsonl.gz", tmp_path / "n1-routes" / "manifest.json"],
+        source_root=tmp_path,
+    )
+
+    assert len(list(iter_jsonl_gz(tmp_path / "n1-routes" / "all.jsonl.gz"))) == 1
+    assert len(list(iter_jsonl_gz(tmp_path / "n1-single-step-reactions" / "all.jsonl.gz"))) == 2
+    assert (tmp_path / "n1-routes" / "manifest.json").exists()
+    assert (tmp_path / "n1-single-step-reactions" / "all.rsmi.txt.gz").exists()
+
+
+def test_test_set_reaction_release_hashes_conditionless_records(tmp_path: Path) -> None:
+    route_records = build_test_route_records(dataset="n1", routes=[adapted_route("n1-a", one_step_route("C.C>>CC"))])
+    reaction_records = build_test_reaction_records(dataset="n1", route_records=route_records)
+
+    assert reaction_records[0].condition_slot is None
+    assert reaction_records[0].condition_slot_smiles == []
+
+    write_test_reaction_release(
+        dataset="n1",
+        records=reaction_records,
+        output_dir=tmp_path,
+        source_paths=[],
+        source_root=tmp_path,
+    )
+
+    assert (tmp_path / "n1-single-step-reactions" / "manifest.json").exists()
 
 
 def test_route_release_keeps_condition_variants_separate() -> None:
@@ -139,38 +207,36 @@ def test_route_audit_allows_condition_distinct_same_structure() -> None:
     audit_route_release_sanity(
         release_name="route-holdout-n1-n5",
         files=RouteReleaseFiles(all=records, training=records, validation=[]),
-        holdout={},
     )
 
 
-def test_route_split_audit_markdown_summarizes_depth_and_convergence(tmp_path: Path) -> None:
+def test_route_split_audit_markdown_summarizes_releases_and_depth() -> None:
     records = [
         route_record("train", one_step_route("C.C>>CC"), split="training"),
         route_record("val", two_step_route(), split="validation"),
     ]
-    release_dir = tmp_path / "route-holdout-n1-n5"
-    release_dir.mkdir()
-    (release_dir / "manifest.json").write_text(
-        json.dumps({"summary": {"adaptation": {"n1": {"raw_routes": 1}, "n5": {"raw_routes": 0}}}}),
-        encoding="utf-8",
-    )
 
     audit = build_route_release_split_audit(release_name="route-holdout-n1-n5", route_records=records)
-    markdown = render_route_release_split_audit_markdown(release_root_name="v1", audits=[audit])
+    markdown = render_route_release_split_audit_markdown(
+        release_root_name="v1",
+        audits=[audit],
+        summary_rows=[
+            audit,
+            {
+                "release_name": "single-step-route-holdout-n1-n5",
+                "total": 2000,
+                "training": 1500,
+                "validation": 500,
+            },
+        ],
+    )
 
-    assert load_holdout_reference(release_dir) == {"n1": 1, "n5": 0}
     assert audit["total"] == 2
     assert "| route-holdout-n1-n5 | 2 | 1 | 1 | 50.0000% |" in markdown
-    assert "| false |" in markdown
-    assert "| true |" in markdown
-
-
-def test_route_sanity_markdown_reports_success_counts() -> None:
-    checks = {"route": {"all_count": 2, "training_count": 1, "validation_count": 1, "holdout_count": 3}}
-
-    markdown = render_sanity_checks_markdown(checks)
-
-    assert "| route | 2 | 1 | 1 | 3 |" in markdown
+    assert "| single-step-route-holdout-n1-n5 | 2 000 | 1 500 | 500 | 25.0000% |" in markdown
+    assert "## sanity checks" not in markdown
+    assert "## single-step sanity" not in markdown
+    assert "convergent" not in markdown
 
 
 def test_route_audit_rejects_release_identity_failures() -> None:
@@ -210,7 +276,6 @@ def test_route_audit_rejects_release_identity_failures() -> None:
                 training=all_records[:4] + [wrong_split],
                 validation=[duplicate_validation_a, duplicate_validation_b, wrong_validation],
             ),
-            holdout={},
         )
 
     assert error.value.code == "workflow.route_release_audit_failed"
@@ -275,6 +340,29 @@ def test_reaction_release_deduplicates_and_removes_validation_overlap() -> None:
     )
 
 
+def test_route_holdout_reaction_release_keeps_validation_overlap_with_warning() -> None:
+    training_route = one_step_route("C.C>O>CC", condition_slot_smiles=["O"])
+    validation_overlap = one_step_route("[CH3:1].[CH3:2]>O>[CH3:1][CH3:2]", condition_slot_smiles=["O"])
+    config = TrainingSetBuildConfig(holdout_mode="route", val_fraction=0.0, show_progress=False)
+
+    with pytest.warns(RuntimeWarning, match="cross-split reaction identity overlap"):
+        result = TrainingReactionReleaseBuilder(
+            route_records=[
+                route_record("train", training_route, split="training"),
+                route_record("val-overlap", validation_overlap, split="validation"),
+            ],
+            config=config,
+        ).build()
+
+    assert result.release_name == "single-step-route-holdout-n1-n5"
+    assert [record.split for record in result.records] == ["training", "validation"]
+    assert result.summary["reaction_postprocessing"]["validation"]["overlap_removed_from_validation"] == 0
+    assert (
+        result.summary["reaction_postprocessing"]["cross_split_overlap_after_cleanup"]["shared_reaction_identities"]
+        == 1
+    )
+
+
 def test_reaction_release_merges_exact_duplicate_sources() -> None:
     route = one_step_route("C.C>>CC")
     config = TrainingSetBuildConfig(holdout_mode="reaction", val_fraction=0.0, show_progress=False)
@@ -293,15 +381,8 @@ def test_reaction_release_merges_exact_duplicate_sources() -> None:
     assert result.summary["reaction_postprocessing"]["training"]["mapped_smiles_variants_collapsed"] == 0
 
 
-def test_reaction_release_requires_reaction_holdout_and_mapped_reactions() -> None:
+def test_reaction_release_requires_mapped_reactions() -> None:
     route = one_step_route(None)
-
-    with pytest.raises(TrainingReleaseError, match="requires") as config_error:
-        TrainingReactionReleaseBuilder(
-            route_records=[route_record("route", route, split="training")],
-            config=TrainingSetBuildConfig(holdout_mode="route", show_progress=False),
-        ).build()
-    assert config_error.value.code == "workflow.single_step_requires_reaction_holdout"
 
     with pytest.raises(TrainingReleaseError, match="mapped_reaction_smiles") as mapped_error:
         TrainingReactionReleaseBuilder(
@@ -353,12 +434,12 @@ def test_single_step_audit_success_absent_release_and_identity_helpers(tmp_path:
 
     assert result == {
         "release_name": "single-step-reaction-holdout-n1-n5",
-        "records": 2,
+        "total": 2,
         "training": 1,
         "validation": 1,
         "parent_routes": 2,
+        "cross_split_reaction_identity_overlap": 0,
     }
-    assert "| single-step-reaction-holdout-n1-n5 | 2 | 1 | 1 | 2 |" in render_single_step_sanity_markdown(result)
     assert duplicate_count([1, 1, 2]) == 1
     assert exact_reaction_record_key(training) == ("C.C>>CC", ("O",), None)
     assert reaction_record_identity_key(training) == (("C", "C"), "CC", ("O",))
@@ -539,6 +620,20 @@ def two_step_route() -> Route:
         ),
         annotations={"patent_id": "patent"},
     )
+
+
+def linear_route(*, depth: int) -> Route:
+    current = molecule("C")
+    for index in range(depth):
+        current = molecule(
+            "C" * (index + 2),
+            product_of=Reaction(
+                reactants=[current, molecule("C")],
+                mapped_reaction_smiles=ReactionSmilesStr("C.C>>CC"),
+                annotations={"source_id": f"patent;{index + 1}"},
+            ),
+        )
+    return Route(target=current, annotations={"patent_id": "patent"})
 
 
 def molecule(smiles: str, *, product_of: Reaction | None = None) -> Molecule:

--- a/tests/io/test_provenance.py
+++ b/tests/io/test_provenance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -30,16 +31,38 @@ def test_manifest_supports_keyed_labeled_outputs_and_stock_identity_hash(tmp_pat
         root_dir=tmp_path,
         keyed_output_files=True,
     )
-
     assert isinstance(manifest_a.output_files, dict)
+    assert isinstance(manifest_b.output_files, dict)
     assert manifest_a.output_files["stock"].path == "stock.csv.gz"
     assert manifest_a.output_files["stock"].content_hash == manifest_b.output_files["stock"].content_hash
+
+
+@pytest.mark.unit
+def test_manifest_uses_explicit_labeled_output_content_hash(tmp_path: Path) -> None:
+    output = tmp_path / "artifact.json"
+    output.write_text("{}", encoding="utf-8")
+
+    manifest = create_manifest(
+        action="explicit",
+        sources=[],
+        outputs=[("artifact", output, {"ignored": True}, ContentType.UNKNOWN, "explicit-hash")],
+        root_dir=tmp_path,
+        keyed_output_files=True,
+    )
+
+    assert isinstance(manifest.output_files, dict)
+    assert manifest.output_files["artifact"].content_hash == "explicit-hash"
 
 
 @pytest.mark.unit
 def test_manifest_rejects_malformed_outputs_and_unlabeled_keyed_outputs(tmp_path: Path) -> None:
     output = tmp_path / "artifact.json"
     output.write_text("{}", encoding="utf-8")
+    invalid_label_output: list[Any] = [(1, output, {}, ContentType.UNKNOWN)]
+    invalid_unlabeled_path_output: list[Any] = [("not-path", {}, ContentType.UNKNOWN)]
+    invalid_labeled_path_output: list[Any] = [("label", "not-path", {}, ContentType.UNKNOWN)]
+    invalid_content_hash_output: list[Any] = [("label", output, {}, ContentType.UNKNOWN, 42)]
+    invalid_arity_output: list[Any] = [(output,)]
 
     with pytest.raises(ValueError, match="requires every output"):
         create_manifest(
@@ -50,15 +73,40 @@ def test_manifest_rejects_malformed_outputs_and_unlabeled_keyed_outputs(tmp_path
             keyed_output_files=True,
         )
     with pytest.raises(TypeError, match="label must be str"):
-        create_manifest(action="bad", sources=[], outputs=[(1, output, {}, ContentType.UNKNOWN)], root_dir=tmp_path)
-    with pytest.raises(TypeError, match="path must be Path"):
-        create_manifest(action="bad", sources=[], outputs=[("not-path", {}, ContentType.UNKNOWN)], root_dir=tmp_path)
+        create_manifest(
+            action="bad",
+            sources=[],
+            outputs=invalid_label_output,
+            root_dir=tmp_path,
+        )
     with pytest.raises(TypeError, match="path must be Path"):
         create_manifest(
-            action="bad", sources=[], outputs=[("label", "not-path", {}, ContentType.UNKNOWN)], root_dir=tmp_path
+            action="bad",
+            sources=[],
+            outputs=invalid_unlabeled_path_output,
+            root_dir=tmp_path,
         )
-    with pytest.raises(ValueError, match="3 or 4 items"):
-        create_manifest(action="bad", sources=[], outputs=[(output,)], root_dir=tmp_path)  # type: ignore[list-item]
+    with pytest.raises(TypeError, match="path must be Path"):
+        create_manifest(
+            action="bad",
+            sources=[],
+            outputs=invalid_labeled_path_output,
+            root_dir=tmp_path,
+        )
+    with pytest.raises(TypeError, match="content hash must be str"):
+        create_manifest(
+            action="bad",
+            sources=[],
+            outputs=invalid_content_hash_output,
+            root_dir=tmp_path,
+        )
+    with pytest.raises(ValueError, match="3, 4, or 5 items"):
+        create_manifest(
+            action="bad",
+            sources=[],
+            outputs=invalid_arity_output,
+            root_dir=tmp_path,
+        )
 
 
 @pytest.mark.unit
@@ -77,8 +125,9 @@ def test_manifest_logs_unhashable_or_external_paths(tmp_path: Path, caplog: pyte
     )
 
     assert calculate_file_hash(missing) == "error-hashing-file"
-    assert manifest.output_files[0].path == str(external.resolve())
-    assert manifest.output_files[0].content_hash is not None
+    output_info = manifest.iter_output_files()[0]
+    assert output_info.path == str(external.resolve())
+    assert output_info.content_hash is not None
     assert "could not hash file" in caplog.text
     assert "is not inside root" in caplog.text
 
@@ -95,4 +144,4 @@ def test_manifest_hashes_plain_jsonable_content(tmp_path: Path) -> None:
         root_dir=tmp_path,
     )
 
-    assert manifest.output_files[0].content_hash is not None
+    assert manifest.iter_output_files()[0].content_hash is not None

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -71,6 +71,26 @@ def test_download_training_set_rejects_unsupported_format(tmp_path: Path) -> Non
         )
 
 
+def test_download_training_set_allows_n1_all_only_artifacts(tmp_path: Path) -> None:
+    remote_root = tmp_path / "remote"
+    write_n1_test_release(remote_root)
+
+    path = download_training_set(
+        "paroutes",
+        artifact="n1-single-step-reactions",
+        split="all",
+        format="rsmi",
+        base_url=remote_root.resolve().as_uri(),
+        cache_dir=tmp_path / "cache",
+    )
+
+    assert path == tmp_path / "cache" / "paroutes" / "v2026-05-12" / "n1-single-step-reactions" / "all.rsmi.txt.gz"
+    assert path.exists()
+    with pytest.raises(ConfigurationError) as exc_info:
+        validate_training_dataset_request(dataset="paroutes", artifact="n1-routes", split="training", format="jsonl")
+    assert exc_info.value.code == "dataset.split_mismatch"
+
+
 @pytest.mark.parametrize(
     ("kwargs", "code"),
     [
@@ -338,6 +358,27 @@ def write_training_release(remote_root: Path) -> None:
         paths=[
             Path("single-step-reaction-holdout-n1-n5/training.rsmi.txt.gz"),
             Path("single-step-reaction-holdout-n1-n5/manifest.json"),
+        ],
+    )
+
+
+def write_n1_test_release(remote_root: Path) -> None:
+    artifact_dir = remote_root / "paroutes" / "v2026-05-12" / "n1-single-step-reactions"
+    artifact_dir.mkdir(parents=True)
+    (remote_root / "paroutes").mkdir(exist_ok=True)
+    (remote_root / "paroutes" / "latest.json").write_text(
+        json.dumps({"dataset": "paroutes", "latest_release": "v2026-05-12"}),
+        encoding="utf-8",
+    )
+    with gzip.open(artifact_dir / "all.rsmi.txt.gz", "wt", encoding="utf-8") as handle:
+        handle.write("c>o>cc\n")
+    (artifact_dir / "manifest.json").write_text('{"schema_version":"2"}', encoding="utf-8")
+    write_sha256sums(
+        remote_root / "paroutes" / "v2026-05-12" / "SHA256SUMS",
+        root=remote_root / "paroutes" / "v2026-05-12",
+        paths=[
+            Path("n1-single-step-reactions/all.rsmi.txt.gz"),
+            Path("n1-single-step-reactions/manifest.json"),
         ],
     )
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 import pytest
 
-from retrocast.markdown import markdown_table
+from retrocast.markdown import format_integer, markdown_table
+
+
+@pytest.mark.unit
+def test_format_integer_uses_space_grouping() -> None:
+    assert format_integer(0) == "0"
+    assert format_integer(999) == "999"
+    assert format_integer(1000) == "1 000"
+    assert format_integer(1234567) == "1 234 567"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## why

this adds code to create pre-adapted PaRoutes n1 and n5 test-set releases, plus their single-step reaction correspondents.

those raw PaRoutes test sets are useful outside this repo, but making everyone rerun the adapter just to get RetroCast-shaped route/reaction records is pointless friction. the release artifacts should exist directly, with manifests and checksums like the existing training sets.

## what changed

added builders and a release script for `n1-routes`, `n5-routes`, `n1-single-step-reactions`, and `n5-single-step-reactions`.

also updated the downloader, dataset api, manifests, docs, and tests so those artifacts can be published and fetched through the same release path as the holdout training sets.

## risk

mostly release-surface risk: artifact names, downloader behavior, and manifest/checksum shape. existing generated files still go through local release directories and checksum-verified downloads.

## verification

- `uv run ruff check`
- `uv run pytest tests/curation/test_training_release.py tests/io/test_provenance.py tests/test_datasets.py tests/test_markdown.py`
- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added test set releases for n1 and n5 datasets.
  * Introduced n1-routes and n5-routes training artifacts.
  * Enhanced download script with SHA256 checksum verification and `--omit` flag for selective file downloads.

* **Documentation**
  * Updated training set guides and release documentation to reflect new artifact availability and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds code infrastructure to publish pre-adapted PaRoutes n1/n5 test sets (`n1-routes`, `n5-routes`, `n1-single-step-reactions`, `n5-single-step-reactions`) as release artifacts, alongside a new `single-step-route-holdout-n1-n5` training release. The downloader, dataset API, manifests, and audit pipeline are all extended to handle the new artifacts.

- **New `testset_release.py`**: occurrence-preserving route and reaction builders with sorted, order-independent content hashes; mirrors the training release pattern cleanly.
- **`get-training-set.sh`**: refactored to multi-file download with `--omit` flag and full-release download mode; now echoes every downloaded path (including `manifest.json`), which is a breaking change from the previous single-path output contract.
- **`datasets.py` / `provenance.py`**: `TrainingArtifactSpec` gains `supported_splits` validation; `create_manifest` supports an explicit content hash in the 5-tuple output form.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one caveat: the shell script now echoes multiple output paths per invocation, breaking the previously documented single-path contract for any callers that capture stdout.

The Python API changes are well-tested and structurally sound. The get-training-set.sh download loop changed from echoing exactly one path to echoing every downloaded key including manifest.json, silently breaking path=$(./get-training-set.sh artifact --split=X) patterns. All other changes look correct and are covered by tests.

get-training-set.sh

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| get-training-set.sh | Refactored from single-file to multi-file download; adds --omit flag and release-only download; the loop now echoes every downloaded path (including manifest.json), changing the output contract from one path to N paths |
| src/retrocast/curation/training/testset_release.py | New module implementing test-set release builders; both content hashes are sorted (order-independent); occurrence-preserving reaction flattening; clean structure mirroring the training release pattern |
| src/retrocast/io/provenance.py | Extended ManifestOutput to support 5-tuple form with explicit content hash; clean implementation with proper type checking |
| src/retrocast/datasets.py | Added new test-set artifacts to TrainingArtifactName and TRAINING_ARTIFACT_SPECS; added supported_splits validation; well-structured with tests covering all-only split enforcement |
| src/retrocast/curation/training/audit.py | Refactored audit functions; removed markdown renderers for sanity checks (now unified in route audit table); allow_cross_split_overlap still resolved via hardcoded string comparison |
| src/retrocast/curation/training/reaction_release.py | Removed reaction-holdout restriction from TrainingReactionReleaseBuilder; route-holdout mode now warns on cross-split overlap instead of raising; content hashes passed at construction time |
| scripts/paroutes/training-set-prep/06-create-test-set-release.py | New entrypoint script for test-set release; clean step-progress integration; correct 4 steps x datasets count |
| tests/curation/test_training_release.py | Comprehensive new tests covering test-set release builders, dataset mismatch rejection, annotation validation, and content hash order-independence |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/retrocast/curation/training/audit.py`, line 1365 ([link](https://github.com/ischemist/project-procrustes/blob/a3f0a2fc8ea1e11f4ac7e20129be36d4d78d3764/src/retrocast/curation/training/audit.py#L1365)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Behavior coupled to hardcoded release name**

   `allow_cross_split_overlap` is resolved by comparing `release_name` to the literal string `"single-step-route-holdout-n1-n5"`. If a second route-holdout variant is ever introduced, this check silently treats it like the reaction-holdout and raises an error on legitimate cross-split overlap. A small refactor — e.g., accepting a boolean `allow_cross_split_overlap` parameter alongside `release_name` — would make the caller's intent explicit and remove the undocumented string coupling.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/retrocast/curation/training/audit.py
   Line: 1365

   Comment:
   **Behavior coupled to hardcoded release name**

   `allow_cross_split_overlap` is resolved by comparing `release_name` to the literal string `"single-step-route-holdout-n1-n5"`. If a second route-holdout variant is ever introduced, this check silently treats it like the reaction-holdout and raises an error on legitimate cross-split overlap. A small refactor — e.g., accepting a boolean `allow_cross_split_overlap` parameter alongside `release_name` — would make the caller's intent explicit and remove the undocumented string coupling.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
get-training-set.sh:287-292
**Script now echoes multiple paths, breaking single-path callers**

The old script always echoed exactly one line — the data file path. The new loop echoes every downloaded key, including `manifest.json`. Any caller that captured the output with `path=$(./get-training-set.sh artifact --split=training)` would now receive two lines (e.g., `artifact/manifest.json` and `artifact/training.jsonl.gz`) instead of one, silently producing a multi-line path variable that will fail on subsequent use.

The `--dry-run` path has the same issue: it now prints all matched keys, not just the data file.

If the echo is intentional, the change should be documented prominently as a breaking change. Alternatively, restricting `echo` to non-manifest keys (or echoing only the last path, consistent with the old contract) would preserve compatibility.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address training release review com..."](https://github.com/ischemist/project-procrustes/commit/8828e18013812b38733949f80466a4fe1554ef9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35699469)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->