### PR TITLE
fix: skip malformed synplanner routes

### DIFF
--- a/src/retrocast/adapters/synplanner.py
+++ b/src/retrocast/adapters/synplanner.py
@@ -59,7 +59,18 @@ class SynPlannerAdapter:
             except ValidationError as exc:
                 source_index = source_order - 1
                 errors = exc.errors(include_url=False)
-                summary = str(errors[0]) if errors else "validation failed"
+                if errors:
+                    first_error = errors[0]
+                    raw_location = first_error.get("loc", ())
+                    location = (
+                        ".".join(str(part) for part in raw_location)
+                        if isinstance(raw_location, tuple | list)
+                        else str(raw_location)
+                    )
+                    message = str(first_error.get("msg", "validation failed"))
+                    summary = f"{location}: {message}" if location else message
+                else:
+                    summary = "validation failed"
                 if len(errors) > 1:
                     summary = f"{summary} (+ {len(errors) - 1} more)"
                 invalid_count += 1

--- a/src/retrocast/adapters/synplanner.py
+++ b/src/retrocast/adapters/synplanner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+import logging
+from collections.abc import Iterator, Sequence
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, RootModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from retrocast.adapters.base import AdaptMode, RawRouteEntry
 from retrocast.adapters.common import build_bipartite_molecule
@@ -12,6 +13,8 @@ from retrocast.chem import canonicalize_smiles
 from retrocast.exceptions import AdapterLogicError
 from retrocast.models.route import Route
 from retrocast.models.task import Target
+
+logger = logging.getLogger(__name__)
 
 # SECTION: Raw SynPlanner Schema
 
@@ -33,22 +36,69 @@ class SynPlannerReactionInput(SynPlannerBaseNode):
 SynPlannerNode = Annotated[SynPlannerMoleculeInput | SynPlannerReactionInput, Field(discriminator="type")]
 
 
-class SynPlannerRouteList(RootModel[list[SynPlannerMoleculeInput]]):
-    pass
-
-
 # SECTION: Adapter
 
 
 class SynPlannerAdapter:
     def iter_raw_routes(self, raw_payload: Any, *, source_key: str | None = None) -> Iterator[RawRouteEntry]:
         target_id = source_key or "<unknown>"
-        try:
-            routes = SynPlannerRouteList.model_validate(raw_payload)
-        except ValidationError as exc:
-            raise adapter_schema_error("synplanner", target_id, "invalid route list") from exc
-        for source_order, route_root in enumerate(routes.root, start=1):
+        if not isinstance(raw_payload, Sequence) or isinstance(raw_payload, (str, bytes, bytearray)):
+            raise adapter_schema_error(
+                "synplanner",
+                target_id,
+                "invalid route list",
+                raw_type=type(raw_payload).__name__,
+            )
+
+        valid_count = 0
+        invalid_count = 0
+        first_invalid: tuple[int, int, str] | None = None
+        for source_order, route_payload in enumerate(raw_payload, start=1):
+            try:
+                route_root = SynPlannerMoleculeInput.model_validate(route_payload)
+            except ValidationError as exc:
+                source_index = source_order - 1
+                errors = exc.errors(include_url=False)
+                summary = str(errors[0]) if errors else "validation failed"
+                if len(errors) > 1:
+                    summary = f"{summary} (+ {len(errors) - 1} more)"
+                invalid_count += 1
+                if first_invalid is None:
+                    first_invalid = (source_index, source_order, summary)
+                logger.warning(
+                    "skipping invalid synplanner route: target=%s source_index=%s source_order=%s error=%s",
+                    target_id,
+                    source_index,
+                    source_order,
+                    summary,
+                )
+                continue
+
+            valid_count += 1
             yield RawRouteEntry(payload=route_root, source_key=source_key, source_order=source_order)
+
+        if invalid_count:
+            logger.warning(
+                "skipped %s invalid synplanner route(s) for target %s; valid_routes=%s",
+                invalid_count,
+                target_id,
+                valid_count,
+            )
+        if valid_count == 0 and first_invalid is not None:
+            first_source_index, first_source_order, first_error = first_invalid
+            raise adapter_schema_error(
+                "synplanner",
+                target_id,
+                (
+                    f"no valid routes; skipped {invalid_count} invalid route(s), "
+                    f"first invalid route source_index={first_source_index} "
+                    f"source_order={first_source_order}: {first_error}"
+                ),
+                skipped_routes=invalid_count,
+                first_invalid_source_index=first_source_index,
+                first_invalid_source_order=first_source_order,
+                first_validation_error=first_error,
+            )
 
     def cast(self, raw_route: Any, *, mode: AdaptMode = "strict", target: Target | None = None) -> Route:
         target_id = target.id if target is not None else "<unknown>"

--- a/tests/adapters/test_synplanner.py
+++ b/tests/adapters/test_synplanner.py
@@ -148,7 +148,7 @@ def test_synplanner_skips_route_with_null_reaction_child(
     assert entries[0].payload.smiles == "CCO"
     assert entries[0].source_order == 2
     assert "skipping invalid synplanner route: target=Apararenone source_index=0 source_order=1" in caplog.text
-    assert "'loc': ('children', 0" in caplog.text
+    assert "children.0" in caplog.text
     assert "skipped 1 invalid synplanner route(s) for target Apararenone; valid_routes=1" in caplog.text
 
 
@@ -164,7 +164,7 @@ def test_synplanner_all_invalid_routes_raise_explicit_failure(raw_synplanner_nul
     assert exc_info.value.context["skipped_routes"] == 1
     assert exc_info.value.context["first_invalid_source_index"] == 0
     assert exc_info.value.context["first_invalid_source_order"] == 1
-    assert "'loc': ('children', 0" in exc_info.value.context["first_validation_error"]
+    assert "children.0" in exc_info.value.context["first_validation_error"]
 
 
 @pytest.mark.contract

--- a/tests/adapters/test_synplanner.py
+++ b/tests/adapters/test_synplanner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from retrocast.adapters.synplanner import SynPlannerAdapter
@@ -61,6 +63,24 @@ def raw_synplanner_invalid_leaf_route() -> dict:
     }
 
 
+@pytest.fixture
+def raw_synplanner_null_reactant_route() -> dict:
+    return {
+        "type": "mol",
+        "smiles": "CCO",
+        "children": [
+            {
+                "type": "reaction",
+                "smiles": "CC(C)(C(=O)O)Br.C>>CCO",
+                "children": [
+                    None,
+                    {"type": "mol", "smiles": "CC(C)(C(=O)O)Br", "in_stock": True},
+                ],
+            }
+        ],
+    }
+
+
 # SECTION: Shared Contract Suite
 
 
@@ -99,6 +119,59 @@ def test_synplanner_preserves_reaction_smiles_annotation(raw_synplanner_route) -
 def test_synplanner_rejects_non_list_payload() -> None:
     with pytest.raises(AdapterSchemaError) as exc_info:
         list(SynPlannerAdapter().iter_raw_routes({"not": "a list"}))
+    assert exc_info.value.code == "adapter.schema_invalid"
+
+
+@pytest.mark.contract
+def test_synplanner_valid_route_list_yields_all_routes(raw_synplanner_payload) -> None:
+    entries = list(SynPlannerAdapter().iter_raw_routes(raw_synplanner_payload, source_key="synplanner-run"))
+
+    assert len(entries) == 2
+    assert [entry.source_key for entry in entries] == ["synplanner-run", "synplanner-run"]
+    assert [entry.source_order for entry in entries] == [1, 2]
+
+
+@pytest.mark.contract
+def test_synplanner_skips_route_with_null_reaction_child(
+    raw_synplanner_route, raw_synplanner_null_reactant_route, caplog
+) -> None:
+    caplog.set_level(logging.WARNING, logger="retrocast.adapters.synplanner")
+
+    entries = list(
+        SynPlannerAdapter().iter_raw_routes(
+            [raw_synplanner_null_reactant_route, raw_synplanner_route],
+            source_key="Apararenone",
+        )
+    )
+
+    assert len(entries) == 1
+    assert entries[0].payload.smiles == "CCO"
+    assert entries[0].source_order == 2
+    assert "skipping invalid synplanner route: target=Apararenone source_index=0 source_order=1" in caplog.text
+    assert "'loc': ('children', 0" in caplog.text
+    assert "skipped 1 invalid synplanner route(s) for target Apararenone; valid_routes=1" in caplog.text
+
+
+@pytest.mark.contract
+def test_synplanner_all_invalid_routes_raise_explicit_failure(raw_synplanner_null_reactant_route) -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        list(SynPlannerAdapter().iter_raw_routes([raw_synplanner_null_reactant_route], source_key="Apararenone"))
+
+    assert exc_info.value.code == "adapter.schema_invalid"
+    assert "no valid routes" in str(exc_info.value)
+    assert exc_info.value.context["adapter"] == "synplanner"
+    assert exc_info.value.context["target_id"] == "Apararenone"
+    assert exc_info.value.context["skipped_routes"] == 1
+    assert exc_info.value.context["first_invalid_source_index"] == 0
+    assert exc_info.value.context["first_invalid_source_order"] == 1
+    assert "'loc': ('children', 0" in exc_info.value.context["first_validation_error"]
+
+
+@pytest.mark.contract
+def test_synplanner_prune_does_not_drop_null_reaction_child(raw_synplanner_null_reactant_route) -> None:
+    with pytest.raises(AdapterSchemaError) as exc_info:
+        SynPlannerAdapter().cast(raw_synplanner_null_reactant_route, target=target_for("CCO"), mode="prune")
+
     assert exc_info.value.code == "adapter.schema_invalid"
 
 


### PR DESCRIPTION
## why
synplanner raw outputs can contain malformed individual route trees, including `null` entries inside reaction `children`. validating the whole target route list at once made one bad route abort ingestion for the entire target and then the full multi-model ingest.

## what changed
`SynPlannerAdapter.iter_raw_routes()` now validates the top-level payload as a list-like value, validates each route independently, logs malformed route entries with target/source order/context, and keeps yielding valid routes. if every route for a target is invalid, it still raises an explicit adapter schema error instead of treating the target as empty.

added regression tests for valid route lists, mixed valid/malformed route lists, all-invalid route lists, and prune mode not dropping a `null` reactant child.

## risk
low. this is scoped to synplanner raw-route iteration. it does not relax the node schema or prune missing reactants, so malformed chemistry remains rejected; the change only isolates failures to individual source routes when other valid routes exist.

## verification
- `uv run pytest tests/adapters/test_synplanner.py`
- `uv run ruff check src/retrocast/adapters/synplanner.py tests/adapters/test_synplanner.py`
- `uv run ty check src/retrocast/adapters/synplanner.py`
- `git diff --check -- src/retrocast/adapters/synplanner.py tests/adapters/test_synplanner.py`
- commit hooks: ruff linter, ruff formatter, ty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784179959&installation_id=125602297&pr_number=134&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F134&signature=5e8aadd2e436ddb3f9ca027d5ee67503bcd5cdd5501efde0ae6c158a287b0692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SynPlanner adapter to gracefully skip invalid routes with detailed logging instead of failing immediately, improving robustness when processing route data.
  * Provides clearer error context when validation fails, including specific failure details and counts.

* **Tests**
  * Added comprehensive test coverage for route validation scenarios and edge cases, including null reaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes `SynPlannerAdapter.iter_raw_routes()` to validate each route entry independently rather than validating the whole list at once, so a single malformed route no longer aborts ingestion for the entire target. Malformed entries are skipped with structured warning logs, and an explicit `AdapterSchemaError` is raised only when every route in the list is invalid.

- The new Sequence type-guard correctly rejects non-list payloads (dicts, scalars, strings/bytes) before the per-route loop.
- Per-route error extraction reformats Pydantic's `loc` tuple into a stable dot-joined string (e.g. `children.0`) for log messages and error context.
- Four new contract tests cover the happy path, mixed valid/invalid input, all-invalid input, and prune mode preserving the null-child rejection.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is narrowly scoped to per-route iteration and does not relax node-level schema validation or prune missing reactants.

The logic correctly isolates per-route failures, preserves the all-invalid error path, and is covered by regression tests. No correctness bugs were found in the adapter code; the only weakness is a redundant assertion in one test.

No files require special attention; the test weakness is a minor assertion quality issue and does not affect production behaviour.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/retrocast/adapters/synplanner.py | Refactors iter_raw_routes to validate routes individually, skip invalid ones with structured warning logs, and raise an explicit error only when all routes are invalid; removes SynPlannerRouteList RootModel. |
| tests/adapters/test_synplanner.py | Adds four new contract tests covering valid lists, mixed valid/invalid lists, all-invalid lists, and prune-mode null child handling; the smiles assertion in test_synplanner_skips_route_with_null_reaction_child is vacuous because both fixtures share the same root SMILES. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([iter_raw_routes called]) --> B{payload is Sequence\nand not str/bytes?}
    B -- No --> C[raise AdapterSchemaError\ninvalid route list]
    B -- Yes --> D[for each route_payload]
    D --> E{model_validate\nSynPlannerMoleculeInput}
    E -- ValidationError --> F[build error summary\nfrom loc + msg]
    F --> G[log WARNING\nskipping invalid route]
    G --> H[increment invalid_count\nstore first_invalid if needed]
    H --> D
    E -- OK --> I[increment valid_count]
    I --> J[yield RawRouteEntry]
    J --> D
    D -- exhausted --> K{invalid_count > 0?}
    K -- Yes --> L[log WARNING\nskipped N route summary]
    L --> M{valid_count == 0 AND\nfirst_invalid not None?}
    K -- No --> M
    M -- Yes --> N[raise AdapterSchemaError\nno valid routes]
    M -- No --> O([return])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([iter_raw_routes called]) --> B{payload is Sequence\nand not str/bytes?}
    B -- No --> C[raise AdapterSchemaError\ninvalid route list]
    B -- Yes --> D[for each route_payload]
    D --> E{model_validate\nSynPlannerMoleculeInput}
    E -- ValidationError --> F[build error summary\nfrom loc + msg]
    F --> G[log WARNING\nskipping invalid route]
    G --> H[increment invalid_count\nstore first_invalid if needed]
    H --> D
    E -- OK --> I[increment valid_count]
    I --> J[yield RawRouteEntry]
    J --> D
    D -- exhausted --> K{invalid_count > 0?}
    K -- Yes --> L[log WARNING\nskipped N route summary]
    L --> M{valid_count == 0 AND\nfirst_invalid not None?}
    K -- No --> M
    M -- Yes --> N[raise AdapterSchemaError\nno valid routes]
    M -- No --> O([return])
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: stabilize synplanner validation as..."](https://github.com/ischemist/project-procrustes/commit/9dabad8bae8b315e9460d38fe19fbe35e48c54bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37813045)</sub>

<!-- /greptile_comment -->