### PR TITLE
fix: close producer contract gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,16 @@ import retrocast
 task = retrocast.load_task("benchmark.json.gz")
 stock_smiles = retrocast.load_stock("buyables-stock.csv.gz")
 retrocast.write_json_gz(raw_results, "results.json.gz")
+manifest = retrocast.create_planner_manifest(
+    "planner-run",
+    "aizynthfinder",
+    "results.json.gz",
+    ["benchmark.json.gz", "buyables-stock.csv.gz"],
+    ".",
+)
 ```
 
-Task validation, stock parsing, artifact serialization, execution-stat validation, and manifest hashing stay in `retrocast-core`; the runner owns model-specific serialization, logging, and progress presentation.
+Structural task loading, explicit chemistry validation, stock parsing, artifact serialization, execution-stat validation, and manifest provenance stay in `retrocast-core`; the runner owns model-specific serialization, logging, and progress presentation.
 
 ```python
 import retrocast

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,10 @@ v0.8.2 adds the Rust-backed Python surface needed by external planner runners. P
 
 The wheel remains a direct PyO3 binding with no Python implementation or runtime dependencies. A bundled type stub and `py.typed` marker describe the curated public API.
 
+Task loading now has an explicit trust boundary: normal reads validate structure without recalculating chemistry, while `validate_task` and `write_task` reject invalid SMILES and SMILES/InChIKey mismatches. Runners can ask RetroCast to resolve each target's effective stock requirement without reproducing constraint override rules.
+
+Planner manifests now require existing artifacts and can hash raw outputs from disk without serializing their full values across the Python/Rust boundary. Verification is strict by default, and the planner-specific creator and verifier enforce the adapter and safe raw-results directive contract consumed by project ingest. Producer schema errors surface as `ValueError`; filesystem failures surface as `OSError`.
+
 ## v0.8.1
 
 v0.8.1 keeps corpus-sized artifacts inside Rust across ingest, score, and analyze. It also narrows ASKCOS pathway graphs before route casting and exposes `--workers` consistently across project commands.

--- a/docs/dev/reference/public-api.md
+++ b/docs/dev/reference/public-api.md
@@ -12,9 +12,12 @@ The PyPI distribution exposes one import surface: the Maturin-built `retrocast` 
 - Corpus-sized stages return opaque Rust-owned handles. Materialization must be explicit through `.to_dict()`, `.json()`, or `.write()`.
 - File entry points pass paths into Rust; Python must not read or decompress corpus artifacts first.
 - Producer functions expose task, stock, execution-stat, artifact, and provenance contracts as JSON-compatible Python values.
+- Trusted task loads perform structural validation. Chemistry validation is explicit at validation time and mandatory at the task-writing boundary.
+- Planner manifests have a dedicated semantic profile: a supported adapter, a safe raw-results filename, and a declared raw output compatible with project ingest.
 - Chemistry helpers call the same RDKit C++ bridge as the CLI.
 - Low-level `*_json` functions are binding plumbing and are not the preferred user API.
 - `retrocast.__all__` and `retrocast.pyi` define the curated Python surface. Names absent from both are internal even when extension-module introspection can see them.
+- Private stub-only `TypedDict` names describe accepted and normalized values without pretending those types are runtime imports.
 - Adding or removing a top-level function is a public API change even when the Rust core function already exists.
 
 The frozen `packages/retrocast-py` tree has its own v0.7.1 package surface. It is a differential-testing oracle, not a fallback imported by the native distribution.

--- a/docs/guides/library/index.md
+++ b/docs/guides/library/index.md
@@ -112,6 +112,7 @@ A planner runner owns model setup, progress presentation, logging policy, and th
 import retrocast
 
 task = retrocast.load_task(benchmark_path)
+stock_names = retrocast.resolve_stock_bindings(task)
 stock_smiles = retrocast.load_stock(stock_path)
 
 # The runner calls its planner for task["targets"] and serializes the planner's
@@ -120,26 +121,19 @@ raw_results, execution_stats = run_planner(task["targets"], stock_smiles)
 
 retrocast.write_json_gz(raw_results, results_path)
 retrocast.write_execution_stats(execution_stats, execution_stats_path)
-manifest = retrocast.create_manifest(
+manifest = retrocast.create_planner_manifest(
     "my-planner-run",
+    "aizynthfinder",
+    results_path,
     [benchmark_path, stock_path],
-    [
-        {
-            "path": results_path,
-            "value": raw_results,
-            "content_type": "unknown",
-        }
-    ],
     data_root,
-    directives={
-        "adapter": "my-planner",
-        "raw_results_filename": results_path.name,
-    },
 )
 retrocast.write_json(manifest, manifest_path)
 ```
 
-`load_task` validates target ids and constraint records in `retrocast-core`. `load_stock` reads the SMILES needed by a planner or the InChIKeys used by scoring. The artifact writers and manifest builder use the same deterministic serialization and hash policy as the standalone executable.
+`load_task` performs structural validation without recalculating target chemistry on every trusted read. Use `validate_task` for an explicit chemistry check, or `write_task` when preparing a task; both reject invalid target SMILES and SMILES/InChIKey mismatches. `resolve_stock_bindings` applies RetroCast's default and per-target constraint rules, leaving the runner to map stock names to its own files or configuration.
+
+`load_stock` reads the SMILES needed by a planner or the InChIKeys used by scoring. `create_planner_manifest` records the supported adapter and raw-results filename required by project ingest, verifies that all input and output files exist, and hashes the raw file directly. It never serializes `raw_results` again. Generic producers can use `create_manifest`; outputs with a known content type require either their value or an explicit content hash.
 
 RetroCast does not configure Python logging, choose a progress library, or serialize live objects from third-party planner libraries. Those decisions belong to the runner because RetroCast never owns the external model call. Once the runner writes the planner's documented raw format, the corresponding RetroCast adapter owns parsing it.
 

--- a/docs/guides/library/reference.md
+++ b/docs/guides/library/reference.md
@@ -76,15 +76,23 @@ The Python boundary represents individual models as JSON-compatible dictionaries
 
 | Function | Purpose | Returns |
 | --- | --- | --- |
-| `load_task(path)` | Read and validate a schema-2 task | normalized `dict` |
-| `validate_task(value)` | Validate an in-memory task | normalized `dict` |
+| `load_task(path, chemistry=False)` | Read and structurally validate a trusted schema-2 task | normalized `dict` |
+| `validate_task(value, chemistry=True)` | Validate an in-memory task, including target chemistry by default | normalized `dict` |
+| `write_task(value, path)` | Chemistry-check and write a task | `None` |
+| `resolve_stock_bindings(value)` | Apply default and per-target constraints | target-to-stock `dict` |
 | `load_stock(path, representation="smiles")` | Read planner SMILES or scoring InChIKeys | sorted `list[str]` |
 | `validate_execution_stats(value)` | Validate per-target wall and CPU times | normalized `dict` |
 | `write_execution_stats(value, path)` | Validate and write execution statistics | `None` |
 | `create_manifest(action, sources, outputs, root_dir, *, ...)` | Hash producer inputs and outputs | manifest `dict` |
-| `verify_manifest(manifest_path, root_dir, *, ...)` | Check lineage and physical hashes | verification `dict` |
+| `create_planner_manifest(action, adapter, raw_results_path, sources, root_dir, *, ...)` | Create a project-ingest-compatible planner manifest | manifest `dict` |
+| `verify_manifest(manifest_path, root_dir, *, lenient=False, ...)` | Check lineage and physical hashes strictly by default | verification `dict` |
+| `verify_planner_manifest(manifest_path, root_dir, *, ...)` | Check hashes and project-ingest directives | verification `dict` |
 
 These functions expose `retrocast-core` schema and provenance behavior to Python runners. They do not recreate the Rust models as Python classes.
+
+Task files have an explicit trust boundary. Ordinary loads check the schema and constraint structure without repeating RDKit work. `validate_task` checks chemistry unless disabled, and `write_task` always verifies that every target SMILES is valid and produces the declared InChIKey.
+
+Manifest creation requires every source and output file to exist. An output with `content_type="unknown"` can omit `value`, so large planner results are hashed from disk without a second Python-to-Rust serialization. Known content types require either `value` or an explicit `content_hash`. Lenient verification remains available only when requested for historical manifests.
 
 ## Chemistry
 
@@ -176,7 +184,7 @@ No RDKit object crosses the Rust or Python API. Invalid chemical input raises `V
 
 ## Errors
 
-- Python uses `ValueError` for invalid chemistry or producer input, `OSError` for artifact-path failures, and `RuntimeError` for adapter or workflow failures.
+- Python uses `ValueError` for invalid chemistry, malformed JSON data, or invalid producer schemas; `OSError` for missing or unreadable artifacts; and `RuntimeError` for adapter or workflow failures.
 - Rust returns `retrocast_core::error::EngineError` from core operations.
 
 See [Error Handling](../../dev/reference/errors.md) for stable failure codes and candidate-level accounting.

--- a/packages/retrocast-rs/crates/retrocast-cli/src/project.rs
+++ b/packages/retrocast-rs/crates/retrocast-cli/src/project.rs
@@ -9,7 +9,7 @@ use retrocast_core::{
     adapt, adapters, analyze,
     io::{read_json, read_stock, validate_path_component, write_json},
     model::{AnalysisReport, Evaluation, ExecutionStats, Predictions, Task},
-    provenance::{ContentType, ManifestOutput, create_manifest},
+    provenance::{ContentType, ManifestOutput, create_manifest, validate_planner_directives},
     route::AdaptMode,
     score::{Stocks, score_owned},
 };
@@ -145,8 +145,9 @@ pub fn ingest_project(
                 })?;
             let raw_filename = manifest_directive(&manifest_path, "raw_results_filename")?
                 .unwrap_or_else(|| "results.json.gz".to_owned());
-            safe_name(&raw_filename, "raw results filename")?;
-            let raw_path = raw_dir.join(raw_filename);
+            let planner = validate_planner_directives(&adapter_name, &raw_filename)?;
+            let adapter_name = planner.adapter;
+            let raw_path = raw_dir.join(planner.raw_results_filename);
             let task_path = paths.benchmarks.join(format!("{dataset}.json.gz"));
             let task: Task = read_json(&task_path)?;
             let adapter = adapters::built_in(&adapter_name)

--- a/packages/retrocast-rs/crates/retrocast-cli/tests/project_workflow.rs
+++ b/packages/retrocast-rs/crates/retrocast-cli/tests/project_workflow.rs
@@ -9,6 +9,7 @@ use retrocast_core::{
     chem,
     io::{read_json, write_csv_gz, write_json},
     model::{Constraint, Evaluation, Target, Task},
+    provenance::{ContentType, ManifestOutput, create_manifest},
 };
 use serde_json::{Map, Value, json};
 
@@ -53,24 +54,36 @@ fn standalone_binary_runs_the_project_lifecycle() {
         ],
     )
     .unwrap();
-    write_json(
-        &raw_dir.join("results.json.gz"),
-        &json!({"ethanol": raw_route()}),
-    )
-    .unwrap();
+    let raw_path = raw_dir.join("results.json.gz");
+    write_json(&raw_path, &json!({"ethanol": raw_route()})).unwrap();
     write_json(
         &raw_dir.join("execution_stats.json.gz"),
         &json!({"wall_time": {"ethanol": 12.5}, "cpu_time": {"ethanol": 3.25}}),
     )
     .unwrap();
-    write_json(
-        &raw_dir.join("manifest.json"),
-        &json!({
-            "schema_version": "2",
-            "directives": {"adapter": "paroutes", "raw_results_filename": "results.json.gz"}
-        }),
+    let manifest = create_manifest(
+        "planner-run",
+        std::slice::from_ref(&benchmark_path),
+        &[ManifestOutput {
+            label: None,
+            path: raw_path,
+            value: Value::Null,
+            content_type: ContentType::Unknown,
+            content_hash: None,
+        }],
+        &root,
+        Map::new(),
+        Map::new(),
+        Map::from_iter([
+            ("adapter".to_owned(), json!("paroutes")),
+            ("raw_results_filename".to_owned(), json!("results.json.gz")),
+        ]),
+        Map::new(),
+        None,
+        false,
     )
     .unwrap();
+    write_json(&raw_dir.join("manifest.json"), &manifest).unwrap();
 
     run(
         &root,

--- a/packages/retrocast-rs/crates/retrocast-core/src/error.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/error.rs
@@ -45,6 +45,8 @@ pub enum EngineError {
     InvalidTask(String),
     #[error("invalid execution statistics: {0}")]
     InvalidExecutionStats(String),
+    #[error("invalid stock: {0}")]
+    InvalidStock(String),
     #[error("unknown adapter {name:?}; available adapters: {available}")]
     UnknownAdapter { name: String, available: String },
     #[error("unregistered stock: {0}")]

--- a/packages/retrocast-rs/crates/retrocast-core/src/io.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/io.rs
@@ -243,7 +243,7 @@ fn read_stock_csv_column(path: &Path, accepted_headers: &[&str]) -> Result<BTree
                 .any(|expected| header.eq_ignore_ascii_case(expected))
         })
         .ok_or_else(|| {
-            EngineError::AdapterSchema(format!(
+            EngineError::InvalidStock(format!(
                 "stock CSV has no {} column",
                 accepted_headers.join(" or ")
             ))
@@ -284,7 +284,7 @@ pub(crate) fn open_reader(path: &Path) -> Result<Box<dyn Read>> {
 }
 
 fn csv_error(error: csv::Error) -> EngineError {
-    EngineError::AdapterSchema(format!("stock CSV error: {error}"))
+    EngineError::InvalidStock(format!("CSV error: {error}"))
 }
 
 #[cfg(test)]

--- a/packages/retrocast-rs/crates/retrocast-core/src/model.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/model.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    chem,
     error::{EngineError, Result},
     schema::{CanonicalSmiles, InchiKey, ReactionSmiles, SchemaVersion},
 };
@@ -222,6 +223,25 @@ impl Task {
         Ok(())
     }
 
+    /// Recompute each target identity when accepting or publishing an untrusted task.
+    pub fn validate_chemistry(&self) -> Result<()> {
+        for target in self.targets.values() {
+            let (_, expected) = chem::normalize(target.smiles.as_str()).map_err(|error| {
+                EngineError::InvalidTask(format!(
+                    "target {:?} has invalid SMILES: {error}",
+                    target.id
+                ))
+            })?;
+            if expected != target.inchikey {
+                return Err(EngineError::InvalidTask(format!(
+                    "target {:?} InChIKey does not match its SMILES: expected {expected}, got {}",
+                    target.id, target.inchikey
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub fn effective_constraints(&self, target_id: &str) -> Vec<Constraint> {
         let mut by_kind: BTreeMap<&str, &Constraint> = self
             .default_constraints
@@ -234,6 +254,27 @@ impl Task {
             }
         }
         by_kind.into_values().cloned().collect()
+    }
+
+    /// Resolve the stock name each target inherits after constraint overrides.
+    pub fn stock_bindings(&self) -> BTreeMap<String, Option<String>> {
+        self.targets
+            .keys()
+            .map(|target_id| {
+                let stock = self
+                    .effective_constraints(target_id)
+                    .into_iter()
+                    .find(|constraint| constraint.kind == "retrocast.stock_termination")
+                    .and_then(|constraint| {
+                        constraint
+                            .fields
+                            .get("stock")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned)
+                    });
+                (target_id.clone(), stock)
+            })
+            .collect()
     }
 
     pub fn derived_metric_label(&self) -> String {
@@ -569,6 +610,8 @@ impl ExecutionStats {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use serde_json::json;
 
     use super::{Candidate, Constraint, ExecutionStats, ScoredCandidate, Task};
@@ -665,6 +708,86 @@ mod tests {
         assert_eq!(
             extensible_constraint.default_constraints[0].kind,
             "example.custom_constraint"
+        );
+    }
+
+    #[test]
+    fn chemistry_validation_is_explicit_and_checks_target_identity() {
+        let mismatched: Task = serde_json::from_value(json!({
+            "name": "mismatched",
+            "targets": {
+                "target-1": {
+                    "id": "target-1",
+                    "smiles": "CCO",
+                    "inchikey": "VNWKTOKETHGBQD-UHFFFAOYSA-N"
+                }
+            }
+        }))
+        .unwrap();
+        assert!(mismatched.validate().is_ok());
+        assert!(
+            mismatched
+                .validate_chemistry()
+                .unwrap_err()
+                .to_string()
+                .contains("does not match")
+        );
+
+        let invalid: Task = serde_json::from_value(json!({
+            "name": "invalid",
+            "targets": {
+                "target-1": {
+                    "id": "target-1",
+                    "smiles": "not-smiles",
+                    "inchikey": "VNWKTOKETHGBQD-UHFFFAOYSA-N"
+                }
+            }
+        }))
+        .unwrap();
+        assert!(
+            invalid
+                .validate_chemistry()
+                .unwrap_err()
+                .to_string()
+                .contains("invalid SMILES")
+        );
+    }
+
+    #[test]
+    fn stock_bindings_apply_target_overrides() {
+        let task: Task = serde_json::from_value(json!({
+            "name": "stocks",
+            "targets": {
+                "target-1": {
+                    "id": "target-1",
+                    "smiles": "CCO",
+                    "inchikey": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+                },
+                "target-2": {
+                    "id": "target-2",
+                    "smiles": "C",
+                    "inchikey": "VNWKTOKETHGBQD-UHFFFAOYSA-N"
+                }
+            },
+            "default_constraints": [{
+                "kind": "retrocast.stock_termination",
+                "stock": "default-stock"
+            }],
+            "constraints": {
+                "target-2": [{
+                    "kind": "retrocast.stock_termination",
+                    "stock": "override-stock"
+                }]
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            task.stock_bindings(),
+            BTreeMap::from([
+                ("target-1".to_owned(), Some("default-stock".to_owned())),
+                ("target-2".to_owned(), Some("override-stock".to_owned())),
+            ])
         );
     }
 

--- a/packages/retrocast-rs/crates/retrocast-core/src/provenance.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/provenance.rs
@@ -11,8 +11,9 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    VERSION,
+    VERSION, adapters,
     error::{EngineError, Result},
+    io::validate_path_component,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -119,6 +120,71 @@ pub struct ManifestOutput {
     pub content_hash: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PlannerDirectives {
+    pub adapter: String,
+    pub raw_results_filename: String,
+}
+
+/// Validate the two directives that project ingest uses to locate planner output.
+pub fn validate_planner_directives(
+    adapter: &str,
+    raw_results_filename: &str,
+) -> Result<PlannerDirectives> {
+    let adapter = adapters::normalize_slug(adapter);
+    if adapters::built_in(&adapter).is_none() {
+        return Err(EngineError::UnknownAdapter {
+            name: adapter,
+            available: adapters::BUILT_IN_ADAPTERS.join(", "),
+        });
+    }
+    validate_path_component(raw_results_filename, "raw results filename")?;
+    Ok(PlannerDirectives {
+        adapter,
+        raw_results_filename: raw_results_filename.to_owned(),
+    })
+}
+
+/// Require a planner manifest to name a supported adapter and its declared raw output.
+pub fn validate_planner_manifest(
+    manifest: &Manifest,
+    manifest_path: &Path,
+    root_dir: &Path,
+) -> Result<PlannerDirectives> {
+    let adapter = required_string_directive(manifest, "adapter")?;
+    let raw_results_filename = required_string_directive(manifest, "raw_results_filename")?;
+    let directives = validate_planner_directives(adapter, raw_results_filename)?;
+
+    let resolved_manifest = resolve_tracked_path(manifest_path, root_dir);
+    let raw_path = resolved_manifest
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .join(&directives.raw_results_filename);
+    let declares_raw_output = manifest
+        .output_files()
+        .any(|output| resolve_tracked_path(Path::new(&output.path), root_dir) == raw_path);
+    if !declares_raw_output {
+        return Err(EngineError::Provenance(format!(
+            "planner manifest does not declare raw output {}",
+            raw_path.display()
+        )));
+    }
+    Ok(directives)
+}
+
+fn required_string_directive<'a>(manifest: &'a Manifest, key: &str) -> Result<&'a str> {
+    manifest
+        .directives
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            EngineError::Provenance(format!(
+                "planner manifest requires a non-empty directives.{key} string"
+            ))
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn create_manifest(
     action: impl Into<String>,
@@ -153,11 +219,13 @@ pub fn create_manifest(
     let output_files = outputs
         .iter()
         .map(|output| {
-            let file_hash = if output.path.exists() {
-                file_hash(&output.path).unwrap_or_else(|_| "error-hashing-file".to_owned())
-            } else {
-                "file-not-written".to_owned()
-            };
+            if !output.path.exists() {
+                return Err(EngineError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("manifest output file not found: {}", output.path.display()),
+                )));
+            }
+            let file_hash = file_hash(&output.path)?;
             Ok(FileInfo {
                 label: output.label.clone(),
                 path: tracked_file_path(&output.path, root_dir),
@@ -432,6 +500,34 @@ pub fn verify_manifest(
         return report;
     }
     verify_physical_integrity(&graph, root_dir, &mut report, output_only, lenient);
+    report
+}
+
+/// Verify hashes and the semantic contract consumed by project-mode ingest.
+pub fn verify_planner_manifest(
+    manifest_path: &Path,
+    root_dir: &Path,
+    deep: bool,
+    output_only: bool,
+) -> VerificationReport {
+    let mut report = verify_manifest(manifest_path, root_dir, deep, output_only, false);
+    let resolved = resolve_tracked_path(manifest_path, root_dir);
+    match read_manifest(&resolved)
+        .and_then(|manifest| validate_planner_manifest(&manifest, manifest_path, root_dir))
+    {
+        Ok(_) => report.add(
+            VerificationLevel::Pass,
+            tracked_path_key(manifest_path, root_dir),
+            "Planner directives identify a declared raw output and supported adapter.",
+            Some(VerificationCategory::Context),
+        ),
+        Err(error) => report.add(
+            VerificationLevel::Fail,
+            tracked_path_key(manifest_path, root_dir),
+            format!("Planner manifest is not ingestible: {error}"),
+            Some(VerificationCategory::Context),
+        ),
+    }
     report
 }
 
@@ -726,9 +822,15 @@ fn retrocast_version() -> String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use std::fs;
 
-    use super::{Manifest, ManifestOutputs, content_hash};
+    use serde_json::{Map, Value, json};
+
+    use super::{
+        ContentType, Manifest, ManifestOutput, ManifestOutputs, content_hash, create_manifest,
+        validate_planner_directives, validate_planner_manifest,
+    };
+    use crate::error::EngineError;
 
     #[test]
     fn content_hash_is_object_order_independent() {
@@ -747,5 +849,80 @@ mod tests {
         .unwrap();
         assert_eq!(manifest.extensions["future_field"]["kept"], true);
         assert!(matches!(manifest.output_files, ManifestOutputs::List(_)));
+    }
+
+    #[test]
+    fn manifest_creation_requires_hashable_outputs() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("missing.json");
+        let error = create_manifest(
+            "planner",
+            &[],
+            &[ManifestOutput {
+                label: None,
+                path: missing,
+                value: Value::Null,
+                content_type: ContentType::Unknown,
+                content_hash: None,
+            }],
+            directory.path(),
+            Map::new(),
+            Map::new(),
+            Map::new(),
+            Map::new(),
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(error, EngineError::Io(_)));
+    }
+
+    #[test]
+    fn planner_manifest_contract_matches_project_ingest() {
+        let directory = tempfile::tempdir().unwrap();
+        let raw_dir = directory.path().join("2-raw/model/task");
+        fs::create_dir_all(&raw_dir).unwrap();
+        let raw_path = raw_dir.join("results.json.gz");
+        fs::write(&raw_path, b"raw").unwrap();
+        let manifest_path = raw_dir.join("manifest.json");
+        let directives = validate_planner_directives("retro-star", "results.json.gz").unwrap();
+        let manifest = create_manifest(
+            "planner",
+            &[],
+            &[ManifestOutput {
+                label: None,
+                path: raw_path,
+                value: Value::Null,
+                content_type: ContentType::Unknown,
+                content_hash: None,
+            }],
+            directory.path(),
+            Map::new(),
+            Map::new(),
+            Map::from_iter([
+                ("adapter".to_owned(), json!(directives.adapter)),
+                (
+                    "raw_results_filename".to_owned(),
+                    json!(directives.raw_results_filename),
+                ),
+            ]),
+            Map::new(),
+            None,
+            false,
+        )
+        .unwrap();
+
+        let validated =
+            validate_planner_manifest(&manifest, &manifest_path, directory.path()).unwrap();
+        assert_eq!(validated.adapter, "retrostar");
+        assert_eq!(validated.raw_results_filename, "results.json.gz");
+
+        let mut missing_adapter = manifest;
+        missing_adapter.directives.remove("adapter");
+        assert!(
+            validate_planner_manifest(&missing_adapter, &manifest_path, directory.path()).is_err()
+        );
+        assert!(validate_planner_directives("unknown", "results.json.gz").is_err());
+        assert!(validate_planner_directives("retrostar", "../results.json.gz").is_err());
     }
 }

--- a/packages/retrocast-rs/crates/retrocast-python/src/lib.rs
+++ b/packages/retrocast-rs/crates/retrocast-python/src/lib.rs
@@ -139,13 +139,29 @@ fn python_error(error: impl std::fmt::Display) -> PyErr {
 
 fn artifact_read_error(error: retrocast_core::error::EngineError) -> PyErr {
     match error {
-        retrocast_core::error::EngineError::Json(error) if error.is_data() => {
-            PyValueError::new_err(error.to_string())
-        }
+        retrocast_core::error::EngineError::Json(error) => PyValueError::new_err(error.to_string()),
         retrocast_core::error::EngineError::UnsafePathComponent { .. } => {
             PyValueError::new_err(error.to_string())
         }
         retrocast_core::error::EngineError::Io(error) => PyOSError::new_err(error.to_string()),
+        error => python_error(error),
+    }
+}
+
+fn producer_input_error(error: retrocast_core::error::EngineError) -> PyErr {
+    match error {
+        retrocast_core::error::EngineError::Io(error) => PyOSError::new_err(error.to_string()),
+        retrocast_core::error::EngineError::InvalidSmiles { .. }
+        | retrocast_core::error::EngineError::InvalidInchiKey { .. }
+        | retrocast_core::error::EngineError::InchiKeyUpscale { .. }
+        | retrocast_core::error::EngineError::InvalidTask(_)
+        | retrocast_core::error::EngineError::InvalidExecutionStats(_)
+        | retrocast_core::error::EngineError::InvalidStock(_)
+        | retrocast_core::error::EngineError::UnsafePathComponent { .. }
+        | retrocast_core::error::EngineError::UnknownAdapter { .. }
+        | retrocast_core::error::EngineError::Provenance(_)
+        | retrocast_core::error::EngineError::Schema(_)
+        | retrocast_core::error::EngineError::Json(_) => PyValueError::new_err(error.to_string()),
         error => python_error(error),
     }
 }
@@ -1296,21 +1312,54 @@ fn evaluate_files_json(
     to_json(&stats)
 }
 
-/// Validate a JSON-compatible task and return its normalized schema-2 value.
+/// Validate a task at a trust boundary, including target chemistry by default.
 #[pyfunction(name = "validate_task")]
-fn validate_task_py(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+#[pyo3(signature = (value, *, chemistry=true))]
+fn validate_task_py(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+    chemistry: bool,
+) -> PyResult<Py<PyAny>> {
     let task: Task = serde_json::from_value(python_value(value)?)
         .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    if chemistry {
+        task.validate_chemistry().map_err(producer_input_error)?;
+    }
     json_loads(py, &to_json(&task)?)
 }
 
-/// Load and validate a task without recreating the Rust schema in Python.
+/// Load a structurally validated task, with opt-in chemistry checks for untrusted files.
 #[pyfunction(name = "load_task")]
-fn load_task_py(py: Python<'_>, path: PathBuf) -> PyResult<Py<PyAny>> {
+#[pyo3(signature = (path, *, chemistry=false))]
+fn load_task_py(py: Python<'_>, path: PathBuf, chemistry: bool) -> PyResult<Py<PyAny>> {
     let task: Task = py
         .detach(|| io::read_json(&path))
         .map_err(artifact_read_error)?;
+    if chemistry {
+        py.detach(|| task.validate_chemistry())
+            .map_err(producer_input_error)?;
+    }
     json_loads(py, &to_json(&task)?)
+}
+
+/// Validate target chemistry before writing a trusted task artifact.
+#[pyfunction(name = "write_task")]
+fn write_task_py(py: Python<'_>, value: &Bound<'_, PyAny>, path: PathBuf) -> PyResult<()> {
+    let task: Task = serde_json::from_value(python_value(value)?)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    py.detach(|| {
+        task.validate_chemistry()?;
+        io::write_json(&path, &task)
+    })
+    .map_err(producer_input_error)
+}
+
+/// Return the effective stock name inherited by every target.
+#[pyfunction(name = "resolve_stock_bindings")]
+fn resolve_stock_bindings_py(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+    let task: Task = serde_json::from_value(python_value(value)?)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    json_loads(py, &to_json(&task.stock_bindings())?)
 }
 
 /// Read a JSON or JSON-gzip artifact into ordinary Python values.
@@ -1353,7 +1402,7 @@ fn load_stock_py(py: Python<'_>, path: PathBuf, representation: &str) -> PyResul
     };
     py.detach(|| io::read_stock_values(&path, representation))
         .map(|values| values.into_iter().collect())
-        .map_err(artifact_read_error)
+        .map_err(producer_input_error)
 }
 
 /// Validate per-target planner timings before they enter an evaluation.
@@ -1395,12 +1444,25 @@ fn manifest_output_from_python(
             )));
         }
     };
+    let content_hash: Option<String> = value.call_method1("get", ("content_hash",))?.extract()?;
+    let has_value: bool = value.call_method1("__contains__", ("value",))?.extract()?;
+    let output_value = if has_value {
+        python_value(&value.get_item("value")?)?
+    } else if content_type == retrocast_core::provenance::ContentType::Unknown
+        || content_hash.is_some()
+    {
+        Value::Null
+    } else {
+        return Err(PyValueError::new_err(
+            "manifest output value is required unless content_type is 'unknown' or content_hash is supplied",
+        ));
+    };
     Ok(retrocast_core::provenance::ManifestOutput {
         label: value.call_method1("get", ("label",))?.extract()?,
         path: value.get_item("path")?.extract()?,
-        value: python_value(&value.get_item("value")?)?,
+        value: output_value,
         content_type,
-        content_hash: value.call_method1("get", ("content_hash",))?.extract()?,
+        content_hash,
     })
 }
 
@@ -1449,13 +1511,76 @@ fn create_manifest_py(
         release_name,
         keyed_output_files,
     )
-    .map_err(artifact_read_error)?;
+    .map_err(producer_input_error)?;
+    json_loads(py, &to_json(&manifest)?)
+}
+
+/// Create a strict raw-output manifest accepted by project-mode ingest.
+#[pyfunction(name = "create_planner_manifest")]
+#[pyo3(signature = (
+    action,
+    adapter,
+    raw_results_path,
+    sources,
+    root_dir,
+    *,
+    parameters=None,
+    statistics=None,
+    summary=None,
+    release_name=None
+))]
+#[allow(clippy::too_many_arguments)]
+fn create_planner_manifest_py(
+    py: Python<'_>,
+    action: String,
+    adapter: String,
+    raw_results_path: PathBuf,
+    sources: Vec<PathBuf>,
+    root_dir: PathBuf,
+    parameters: Option<&Bound<'_, PyAny>>,
+    statistics: Option<&Bound<'_, PyAny>>,
+    summary: Option<&Bound<'_, PyAny>>,
+    release_name: Option<String>,
+) -> PyResult<Py<PyAny>> {
+    let raw_results_filename = raw_results_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| PyValueError::new_err("raw_results_path requires a UTF-8 filename"))?;
+    let planner =
+        retrocast_core::provenance::validate_planner_directives(&adapter, raw_results_filename)
+            .map_err(producer_input_error)?;
+    let directives = serde_json::Map::from_iter([
+        ("adapter".to_owned(), Value::String(planner.adapter)),
+        (
+            "raw_results_filename".to_owned(),
+            Value::String(planner.raw_results_filename),
+        ),
+    ]);
+    let manifest = retrocast_core::provenance::create_manifest(
+        action,
+        &sources,
+        &[retrocast_core::provenance::ManifestOutput {
+            label: None,
+            path: raw_results_path,
+            value: Value::Null,
+            content_type: retrocast_core::provenance::ContentType::Unknown,
+            content_hash: None,
+        }],
+        &root_dir,
+        python_map("parameters", parameters)?,
+        python_map("statistics", statistics)?,
+        directives,
+        python_map("summary", summary)?,
+        release_name,
+        false,
+    )
+    .map_err(producer_input_error)?;
     json_loads(py, &to_json(&manifest)?)
 }
 
 /// Verify one manifest and return the same structured report as the Rust CLI.
 #[pyfunction(name = "verify_manifest")]
-#[pyo3(signature = (manifest_path, root_dir, *, deep=false, output_only=false, lenient=true))]
+#[pyo3(signature = (manifest_path, root_dir, *, deep=false, output_only=false, lenient=false))]
 fn verify_manifest_py(
     py: Python<'_>,
     manifest_path: PathBuf,
@@ -1471,6 +1596,27 @@ fn verify_manifest_py(
             deep,
             output_only,
             lenient,
+        )
+    });
+    json_loads(py, &to_json(&report)?)
+}
+
+/// Verify hashes plus the adapter and raw-output contract used by project ingest.
+#[pyfunction(name = "verify_planner_manifest")]
+#[pyo3(signature = (manifest_path, root_dir, *, deep=false, output_only=false))]
+fn verify_planner_manifest_py(
+    py: Python<'_>,
+    manifest_path: PathBuf,
+    root_dir: PathBuf,
+    deep: bool,
+    output_only: bool,
+) -> PyResult<Py<PyAny>> {
+    let report = py.detach(|| {
+        retrocast_core::provenance::verify_planner_manifest(
+            &manifest_path,
+            &root_dir,
+            deep,
+            output_only,
         )
     });
     json_loads(py, &to_json(&report)?)
@@ -2124,6 +2270,8 @@ fn retrocast(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(molecular_descriptors, module)?)?;
     module.add_function(wrap_pyfunction!(validate_task_py, module)?)?;
     module.add_function(wrap_pyfunction!(load_task_py, module)?)?;
+    module.add_function(wrap_pyfunction!(write_task_py, module)?)?;
+    module.add_function(wrap_pyfunction!(resolve_stock_bindings_py, module)?)?;
     module.add_function(wrap_pyfunction!(read_json_py, module)?)?;
     module.add_function(wrap_pyfunction!(write_json_py, module)?)?;
     module.add_function(wrap_pyfunction!(write_json_gz_py, module)?)?;
@@ -2131,7 +2279,9 @@ fn retrocast(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(validate_execution_stats_py, module)?)?;
     module.add_function(wrap_pyfunction!(write_execution_stats_py, module)?)?;
     module.add_function(wrap_pyfunction!(create_manifest_py, module)?)?;
+    module.add_function(wrap_pyfunction!(create_planner_manifest_py, module)?)?;
     module.add_function(wrap_pyfunction!(verify_manifest_py, module)?)?;
+    module.add_function(wrap_pyfunction!(verify_planner_manifest_py, module)?)?;
     module.add_function(wrap_pyfunction!(adapt_candidates_json, module)?)?;
     module.add_function(wrap_pyfunction!(adapt_route_json, module)?)?;
     module.add_function(wrap_pyfunction!(adapter_entries_json, module)?)?;
@@ -2251,6 +2401,7 @@ fn retrocast(module: &Bound<'_, PyModule>) -> PyResult<()> {
             "analyze_file",
             "canonicalize_smiles",
             "create_manifest",
+            "create_planner_manifest",
             "engine_info",
             "evaluate",
             "get_inchi_key",
@@ -2261,13 +2412,16 @@ fn retrocast(module: &Bound<'_, PyModule>) -> PyResult<()> {
             "molecular_descriptors",
             "read_json",
             "reduce_inchi_key",
+            "resolve_stock_bindings",
             "score",
             "validate_execution_stats",
             "validate_task",
             "verify_manifest",
+            "verify_planner_manifest",
             "write_execution_stats",
             "write_json",
             "write_json_gz",
+            "write_task",
         ],
     )?;
     Ok(())

--- a/packages/retrocast-rs/python-tests/test_bindings.py
+++ b/packages/retrocast-rs/python-tests/test_bindings.py
@@ -61,6 +61,7 @@ def test_distribution_is_the_native_module() -> None:
         "analyze_file",
         "canonicalize_smiles",
         "create_manifest",
+        "create_planner_manifest",
         "engine_info",
         "evaluate",
         "get_inchi_key",
@@ -71,13 +72,16 @@ def test_distribution_is_the_native_module() -> None:
         "molecular_descriptors",
         "read_json",
         "reduce_inchi_key",
+        "resolve_stock_bindings",
         "score",
         "validate_execution_stats",
         "validate_task",
         "verify_manifest",
+        "verify_planner_manifest",
         "write_execution_stats",
         "write_json",
         "write_json_gz",
+        "write_task",
     }
 
 
@@ -220,6 +224,41 @@ def test_task_loading_and_validation_return_normalized_dicts(tmp_path: Path) -> 
     with pytest.raises(ValueError, match="does not match"):
         retrocast.validate_task(invalid)
 
+    mismatched = task()
+    mismatched["targets"][TARGET_ID]["inchikey"] = retrocast.get_inchi_key("C")
+    retrocast.write_json_gz(mismatched, path)
+    assert retrocast.load_task(path)["targets"][TARGET_ID]["smiles"] == "CCO"
+    assert retrocast.validate_task(mismatched, chemistry=False)["schema_version"] == "2"
+    with pytest.raises(ValueError, match="does not match"):
+        retrocast.load_task(path, chemistry=True)
+    with pytest.raises(ValueError, match="does not match"):
+        retrocast.validate_task(mismatched)
+    with pytest.raises(ValueError, match="does not match"):
+        retrocast.write_task(mismatched, tmp_path / "invalid-task.json.gz")
+
+    retrocast.write_task(task(), path)
+    assert retrocast.load_task(path) == validated
+
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text("{", encoding="utf-8")
+    with pytest.raises(ValueError):
+        retrocast.load_task(malformed_path)
+
+
+def test_stock_bindings_apply_task_override_rules() -> None:
+    value = task()
+    value["targets"]["methane"] = {
+        "id": "methane",
+        "smiles": "C",
+        "inchikey": retrocast.get_inchi_key("C"),
+    }
+    value["constraints"] = {"methane": [{"kind": "retrocast.stock_termination", "stock": "special-stock"}]}
+
+    assert retrocast.resolve_stock_bindings(value) == {
+        TARGET_ID: "test-stock",
+        "methane": "special-stock",
+    }
+
 
 def test_producer_artifacts_use_rust_io_and_provenance(tmp_path: Path) -> None:
     source_path = tmp_path / "task.json.gz"
@@ -240,7 +279,6 @@ def test_producer_artifacts_use_rust_io_and_provenance(tmp_path: Path) -> None:
         [
             {
                 "path": results_path,
-                "value": results,
                 "content_type": "unknown",
             }
         ],
@@ -248,14 +286,14 @@ def test_producer_artifacts_use_rust_io_and_provenance(tmp_path: Path) -> None:
         directives={"adapter": "aizynthfinder"},
     )
     retrocast.write_json(manifest, manifest_path)
-    report = retrocast.verify_manifest(manifest_path, tmp_path, lenient=False)
+    report = retrocast.verify_manifest(manifest_path, tmp_path)
 
     assert manifest["action"] == "planner-run"
     assert manifest["directives"]["adapter"] == "aizynthfinder"
     assert report["is_valid"] is True
 
 
-def test_manifest_missing_source_is_a_filesystem_error(tmp_path: Path) -> None:
+def test_manifest_creation_requires_existing_sources_and_outputs(tmp_path: Path) -> None:
     with pytest.raises(OSError, match="manifest source file not found"):
         retrocast.create_manifest(
             "planner-run",
@@ -263,6 +301,87 @@ def test_manifest_missing_source_is_a_filesystem_error(tmp_path: Path) -> None:
             [],
             tmp_path,
         )
+
+    with pytest.raises(OSError, match="manifest output file not found"):
+        retrocast.create_manifest(
+            "planner-run",
+            [],
+            [{"path": tmp_path / "missing.json", "content_type": "unknown"}],
+            tmp_path,
+        )
+
+    output = tmp_path / "output.json"
+    output.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="value is required"):
+        retrocast.create_manifest(
+            "known-content",
+            [],
+            [{"path": output, "content_type": "benchmark"}],
+            tmp_path,
+        )
+
+    manifest = retrocast.create_manifest(
+        "prehashed-content",
+        [],
+        [
+            {
+                "path": output,
+                "content_type": "benchmark",
+                "content_hash": "sha256:producer-supplied",
+            }
+        ],
+        tmp_path,
+    )
+    assert manifest["output_files"][0]["content_hash"] == "sha256:producer-supplied"
+
+
+def test_manifest_verification_is_strict_by_default(tmp_path: Path) -> None:
+    output = tmp_path / "output.json"
+    manifest_path = tmp_path / "manifest.json"
+    output.write_text("{}", encoding="utf-8")
+    manifest = retrocast.create_manifest(
+        "producer",
+        [],
+        [{"path": output, "content_type": "unknown"}],
+        tmp_path,
+    )
+    retrocast.write_json(manifest, manifest_path)
+    output.unlink()
+
+    assert retrocast.verify_manifest(manifest_path, tmp_path)["is_valid"] is False
+    assert retrocast.verify_manifest(manifest_path, tmp_path, lenient=True)["is_valid"] is True
+
+
+def test_planner_manifest_is_project_ingest_compatible(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "2-raw" / "model" / "task"
+    raw_dir.mkdir(parents=True)
+    raw_path = raw_dir / "routes.json.gz"
+    source_path = tmp_path / "task.json"
+    manifest_path = raw_dir / "manifest.json"
+    raw_path.write_bytes(b"raw")
+    source_path.write_text("{}", encoding="utf-8")
+
+    manifest = retrocast.create_planner_manifest(
+        "planner-run",
+        "retro-star",
+        raw_path,
+        [source_path],
+        tmp_path,
+    )
+    retrocast.write_json(manifest, manifest_path)
+    report = retrocast.verify_planner_manifest(manifest_path, tmp_path)
+
+    assert manifest["directives"] == {
+        "adapter": "retrostar",
+        "raw_results_filename": "routes.json.gz",
+    }
+    assert report["is_valid"] is True
+
+    manifest["directives"].pop("adapter")
+    retrocast.write_json(manifest, manifest_path)
+    report = retrocast.verify_planner_manifest(manifest_path, tmp_path)
+    assert report["is_valid"] is False
+    assert any("not ingestible" in issue["message"] for issue in report["issues"])
 
 
 def test_stock_loader_selects_the_planner_representation(tmp_path: Path) -> None:
@@ -277,6 +396,16 @@ def test_stock_loader_selects_the_planner_representation(tmp_path: Path) -> None
         "LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
         "VNWKTOKETHGBQD-UHFFFAOYSA-N",
     ]
+
+    missing_column = tmp_path / "missing-column.csv"
+    missing_column.write_text("molecule\nCCO\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="stock CSV has no smiles column"):
+        retrocast.load_stock(missing_column)
+
+    invalid_smiles = tmp_path / "invalid.smi"
+    invalid_smiles.write_text("not-smiles\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid SMILES"):
+        retrocast.load_stock(invalid_smiles, representation="inchikey")
 
 
 def test_execution_stats_are_validated_before_writing(tmp_path: Path) -> None:

--- a/retrocast.pyi
+++ b/retrocast.pyi
@@ -2,76 +2,97 @@ from collections.abc import Collection, Mapping, Sequence
 from os import PathLike
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
 
-StrPath: TypeAlias = str | PathLike[str]
-JSONScalar: TypeAlias = None | bool | int | float | str
-JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+_StrPath: TypeAlias = str | PathLike[str]
+_JSONScalar: TypeAlias = None | bool | int | float | str
+_JSONValue: TypeAlias = _JSONScalar | list["_JSONValue"] | dict[str, "_JSONValue"]
 
 __version__: str
 __engine__: Literal["rust"]
 __all__: list[str]
 
-class Target(TypedDict):
+class _TargetInput(TypedDict):
     id: str
     smiles: str
     inchikey: str
     acceptable_routes: NotRequired[list[dict[str, Any]]]
-    annotations: NotRequired[dict[str, JSONValue]]
+    annotations: NotRequired[dict[str, _JSONValue]]
 
-class Task(TypedDict):
+class _Target(TypedDict):
+    id: str
+    smiles: str
+    inchikey: str
+    acceptable_routes: list[dict[str, Any]]
+    annotations: dict[str, _JSONValue]
+
+class _TaskInput(TypedDict):
     name: str
-    targets: dict[str, Target]
+    targets: dict[str, _TargetInput]
     description: NotRequired[str]
-    default_constraints: NotRequired[list[dict[str, JSONValue]]]
-    constraints: NotRequired[dict[str, list[dict[str, JSONValue]]]]
+    default_constraints: NotRequired[list[dict[str, _JSONValue]]]
+    constraints: NotRequired[dict[str, list[dict[str, _JSONValue]]]]
     metric_label: NotRequired[str | None]
-    annotations: NotRequired[dict[str, JSONValue]]
+    annotations: NotRequired[dict[str, _JSONValue]]
     schema_version: NotRequired[Literal["2"]]
 
-class ExecutionStats(TypedDict):
+class _Task(TypedDict):
+    name: str
+    targets: dict[str, _Target]
+    description: str
+    default_constraints: list[dict[str, _JSONValue]]
+    constraints: dict[str, list[dict[str, _JSONValue]]]
+    metric_label: str | None
+    annotations: dict[str, _JSONValue]
+    schema_version: Literal["2"]
+
+class _ExecutionStatsInput(TypedDict):
     wall_time: NotRequired[dict[str, float]]
     cpu_time: NotRequired[dict[str, float]]
 
-class ManifestOutput(TypedDict):
-    path: StrPath
-    value: JSONValue
+class _ExecutionStats(TypedDict):
+    wall_time: dict[str, float]
+    cpu_time: dict[str, float]
+
+class _ManifestOutput(TypedDict):
+    path: _StrPath
     content_type: Literal["benchmark", "predictions", "route_corpus", "stock", "unknown"]
+    value: NotRequired[_JSONValue]
     label: NotRequired[str]
     content_hash: NotRequired[str]
 
 class NativePredictions:
     def json(self) -> str: ...
-    def write(self, path: StrPath) -> None: ...
+    def write(self, path: _StrPath) -> None: ...
     def to_dict(self) -> dict[str, list[dict[str, Any]]]: ...
 
 class NativeEvaluation:
     def json(self) -> str: ...
-    def write(self, path: StrPath) -> None: ...
+    def write(self, path: _StrPath) -> None: ...
     def metric_label(self) -> str: ...
     def to_dict(self) -> dict[str, Any]: ...
 
 def adapt(
-    raw: JSONValue,
+    raw: _JSONValue,
     adapter: str,
     *,
     mode: Literal["strict", "lenient"] = "strict",
-    target: Mapping[str, JSONValue] | None = None,
+    target: _TargetInput | Mapping[str, _JSONValue] | None = None,
     source_key: str | None = None,
     max_candidates: int | None = None,
     workers: int = 1,
 ) -> list[dict[str, Any]]: ...
 def ingest(
-    raw: JSONValue,
+    raw: _JSONValue,
     adapter: str,
-    task: Task,
+    task: _TaskInput | Mapping[str, _JSONValue],
     *,
     mode: Literal["strict", "lenient"] = "strict",
     max_candidates: int | None = None,
     workers: int = 1,
 ) -> NativePredictions: ...
 def ingest_file(
-    raw_path: StrPath,
+    raw_path: _StrPath,
     adapter: str,
-    task_path: StrPath,
+    task_path: _StrPath,
     *,
     mode: Literal["strict", "lenient"] = "strict",
     max_candidates: int | None = None,
@@ -79,12 +100,12 @@ def ingest_file(
 ) -> NativePredictions: ...
 def score(
     predictions: NativePredictions,
-    task: Task,
+    task: _TaskInput | Mapping[str, _JSONValue],
     stocks: Mapping[str, Collection[str]],
     *,
     match_level: Literal["full", "no_stereo", "connectivity"] = "full",
     acceptable_route_match: Literal["prefix", "exact"] = "prefix",
-    execution_stats: ExecutionStats | None = None,
+    execution_stats: _ExecutionStatsInput | Mapping[str, Mapping[str, float]] | None = None,
     workers: int = 1,
 ) -> NativeEvaluation: ...
 def analyze(
@@ -97,23 +118,23 @@ def analyze(
     workers: int = 1,
 ) -> dict[str, Any]: ...
 def analyze_file(
-    evaluation_path: StrPath,
+    evaluation_path: _StrPath,
     *,
     ks: Sequence[int] = ...,
     prefix_depths: Sequence[int] = ...,
-    execution_stats_path: StrPath | None = None,
+    execution_stats_path: _StrPath | None = None,
     n_boot: int = 10_000,
     seed: int = 42,
     workers: int = 1,
 ) -> dict[str, Any]: ...
 def evaluate(
-    raw_path: StrPath,
-    benchmark_path: StrPath,
-    stock_path: StrPath,
-    output_dir: StrPath,
+    raw_path: _StrPath,
+    benchmark_path: _StrPath,
+    stock_path: _StrPath,
+    output_dir: _StrPath,
     *,
     stock_name: str | None = None,
-    execution_stats_path: StrPath | None = None,
+    execution_stats_path: _StrPath | None = None,
     adapter: str = "aizynthfinder",
     workers: int = 1,
     mode: Literal["strict", "lenient"] = "strict",
@@ -125,36 +146,59 @@ def evaluate(
     n_boot: int = 10_000,
     seed: int = 42,
 ) -> dict[str, Any]: ...
-def validate_task(value: Task | Mapping[str, JSONValue]) -> Task: ...
-def load_task(path: StrPath) -> Task: ...
-def load_stock(path: StrPath, *, representation: Literal["smiles", "inchikey"] = "smiles") -> list[str]: ...
-def read_json(path: StrPath) -> JSONValue: ...
-def write_json(value: JSONValue, path: StrPath) -> None: ...
-def write_json_gz(value: JSONValue, path: StrPath) -> None: ...
+def validate_task(value: _TaskInput | Mapping[str, _JSONValue], *, chemistry: bool = True) -> _Task: ...
+def load_task(path: _StrPath, *, chemistry: bool = False) -> _Task: ...
+def write_task(value: _TaskInput | Mapping[str, _JSONValue], path: _StrPath) -> None: ...
+def resolve_stock_bindings(
+    value: _TaskInput | Mapping[str, _JSONValue],
+) -> dict[str, str | None]: ...
+def load_stock(path: _StrPath, *, representation: Literal["smiles", "inchikey"] = "smiles") -> list[str]: ...
+def read_json(path: _StrPath) -> _JSONValue: ...
+def write_json(value: _JSONValue, path: _StrPath) -> None: ...
+def write_json_gz(value: _JSONValue, path: _StrPath) -> None: ...
 def validate_execution_stats(
-    value: ExecutionStats | Mapping[str, Mapping[str, float]],
-) -> ExecutionStats: ...
-def write_execution_stats(value: ExecutionStats | Mapping[str, Mapping[str, float]], path: StrPath) -> None: ...
+    value: _ExecutionStatsInput | Mapping[str, Mapping[str, float]],
+) -> _ExecutionStats: ...
+def write_execution_stats(value: _ExecutionStatsInput | Mapping[str, Mapping[str, float]], path: _StrPath) -> None: ...
 def create_manifest(
     action: str,
-    sources: Sequence[StrPath],
-    outputs: Sequence[ManifestOutput],
-    root_dir: StrPath,
+    sources: Sequence[_StrPath],
+    outputs: Sequence[_ManifestOutput],
+    root_dir: _StrPath,
     *,
-    parameters: Mapping[str, JSONValue] | None = None,
-    statistics: Mapping[str, JSONValue] | None = None,
-    directives: Mapping[str, JSONValue] | None = None,
-    summary: Mapping[str, JSONValue] | None = None,
+    parameters: Mapping[str, _JSONValue] | None = None,
+    statistics: Mapping[str, _JSONValue] | None = None,
+    directives: Mapping[str, _JSONValue] | None = None,
+    summary: Mapping[str, _JSONValue] | None = None,
     release_name: str | None = None,
     keyed_output_files: bool = False,
 ) -> dict[str, Any]: ...
+def create_planner_manifest(
+    action: str,
+    adapter: str,
+    raw_results_path: _StrPath,
+    sources: Sequence[_StrPath],
+    root_dir: _StrPath,
+    *,
+    parameters: Mapping[str, _JSONValue] | None = None,
+    statistics: Mapping[str, _JSONValue] | None = None,
+    summary: Mapping[str, _JSONValue] | None = None,
+    release_name: str | None = None,
+) -> dict[str, Any]: ...
 def verify_manifest(
-    manifest_path: StrPath,
-    root_dir: StrPath,
+    manifest_path: _StrPath,
+    root_dir: _StrPath,
     *,
     deep: bool = False,
     output_only: bool = False,
-    lenient: bool = True,
+    lenient: bool = False,
+) -> dict[str, Any]: ...
+def verify_planner_manifest(
+    manifest_path: _StrPath,
+    root_dir: _StrPath,
+    *,
+    deep: bool = False,
+    output_only: bool = False,
 ) -> dict[str, Any]: ...
 def canonicalize_smiles(smiles: str, remove_mapping: bool = False, ignore_stereo: bool = False) -> str: ...
 def get_inchi_key(smiles: str, level: Literal["full", "no_stereo", "connectivity"] = "full") -> str: ...

--- a/scripts/smoke-native-wheel.py
+++ b/scripts/smoke-native-wheel.py
@@ -50,9 +50,23 @@ def main() -> None:
         "default_constraints": [{"kind": "retrocast.stock_termination", "stock": "test-stock"}],
     }
     with tempfile.TemporaryDirectory() as directory:
-        task_path = Path(directory) / "task.json.gz"
-        retrocast.write_json_gz(task, task_path)
+        root = Path(directory)
+        task_path = root / "task.json.gz"
+        raw_path = root / "routes.json.gz"
+        manifest_path = root / "manifest.json"
+        retrocast.write_task(task, task_path)
         assert retrocast.load_task(task_path)["targets"][target_id]["id"] == target_id
+        assert retrocast.resolve_stock_bindings(task) == {target_id: "test-stock"}
+        retrocast.write_json_gz({"ethanol": []}, raw_path)
+        manifest = retrocast.create_planner_manifest(
+            "wheel-smoke",
+            "aizynthfinder",
+            raw_path,
+            [task_path],
+            root,
+        )
+        retrocast.write_json(manifest, manifest_path)
+        assert retrocast.verify_planner_manifest(manifest_path, root)["is_valid"]
 
     raw = json.loads(args.fixture.read_text(encoding="utf-8"))
     predictions = retrocast.ingest(


### PR DESCRIPTION
## why

The initial Rust-backed producer facade exposed the right ownership boundary, but several details made it unsafe or unnecessarily expensive for real planner runners. Unknown planner outputs could be serialized across Python a second time just to create a manifest, missing outputs could be recorded with placeholder hashes, verification was lenient by default, and Pandora still had to reproduce task constraint override rules. The task chemistry question also needed an explicit trust boundary rather than paying for RDKit identity checks on every trusted read.

Planner manifests additionally needed a semantic contract with project ingest, not only valid physical hashes. Producer input failures should surface as Python input or filesystem errors, and the type stub should describe normalized return values without advertising non-existent runtime classes.

## what changed

- Keep `load_task()` structural by default, add opt-in chemistry checking, make `validate_task()` chemistry-check by default, and add `write_task()` as the mandatory chemistry-checking publication boundary.
- Add `resolve_stock_bindings()` so RetroCast applies default and per-target constraint overrides while runners retain ownership of stock file/config resolution.
- Allow manifest outputs to omit `value` for unknown content or when an explicit content hash is supplied; require all source/output files to exist and make friendly verification strict by default.
- Add planner-specific manifest creation and verification that require a supported adapter, safe raw-results filename, and a declared raw output. Project ingest now shares the same directive validation.
- Map malformed producer data and stock schemas to `ValueError`, filesystem failures to `OSError`, and split private input/normalized `TypedDict` shapes in the stub.
- Document the ownership and trust boundaries and exercise them in the packaged-wheel smoke test.

## risk

The intentional behavior changes are at producer trust boundaries. Existing callers that relied on placeholder hashes for missing outputs or lenient verification must now opt into leniency or write artifacts before creating a manifest. Ordinary task loads remain cheap and do not repeat chemistry work; code accepting untrusted tasks should use `validate_task()`, `write_task()`, or `load_task(..., chemistry=True)`.

No release, tag, or PyPI publication is included.

## verification

- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (111 Rust tests)
- `uv run pytest -q` (17 Python binding tests)
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run ty check`
- `pnpm exec oxfmt --check ...`
- `uv run zensical build --strict`
- Built the release wheel, installed it into a clean Python 3.12 environment without Python RDKit, and passed the native-wheel smoke test.
- Loaded Pandora's 332-target `ursa-dca-2026` task, resolved all targets to `ursa-stock`, loaded 251,910 stock entries, and completed the explicit chemistry audit. Structural task loading took about 5 ms; chemistry validation took about 97 ms on this machine.
- The end-to-end Rust project lifecycle test now ingests a generated planner manifest rather than a hand-written directive stub.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787803210&installation_model_id=19379&pr_number=145&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F145&signature=a39da1c2aad4ea8ed39392a671b22aa8b51e14726054cd44f2feed5fea2a8e29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens producer trust and provenance contracts.
- Separates structural task loading from explicit chemistry validation and adds a chemistry-checking task writer.
- Adds effective per-target stock binding resolution.
- Requires manifest artifacts to exist, makes verification strict by default, and adds planner-specific manifest creation and verification.
- Aligns project ingest directive validation, Python exception categories, type stubs, documentation, and smoke tests with the new contracts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new task-validation, stock-resolution, manifest-integrity, planner-directive, and Python binding paths preserve their documented contracts and are covered across core, binding, project-workflow, and wheel-smoke tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/retrocast-rs/crates/retrocast-core/src/model.rs | Adds explicit target chemistry validation and deterministic effective stock binding resolution. |
| packages/retrocast-rs/crates/retrocast-core/src/provenance.rs | Enforces existing manifest outputs and introduces the planner directive and declared-output contract. |
| packages/retrocast-rs/crates/retrocast-python/src/lib.rs | Exposes the new task and planner APIs, tightens verification defaults, and categorizes producer errors for Python callers. |
| packages/retrocast-rs/crates/retrocast-cli/src/project.rs | Reuses shared planner directive validation during project ingest. |
| retrocast.pyi | Describes normalized return shapes and the expanded producer API using private stub-only types. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Task input] --> L[Structural load]
  T --> V[Chemistry validation]
  V --> W[Write trusted task]
  L --> S[Resolve stock bindings]
  R[Raw planner output] --> M[Create planner manifest]
  M --> H[Hash existing artifacts]
  H --> P[Validate adapter and raw-output directive]
  P --> I[Project ingest]
  M --> X[Strict verification]
```

<sub>Reviews (1): Last reviewed commit: ["fix: close producer contract gaps"](https://github.com/ischemist/project-procrustes/commit/2d75e9bd3275054933f4bcfdbae90d911451cea4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47827706)</sub>

**Context used:**

- Knowledge Base — [Rust Core (retrocast-rs)](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/rust-core.md)
- Knowledge Base — [I/O, Caching, and Provenance](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/io-caching.md)

<!-- /greptile_comment -->