### PR TITLE
fix: align template reaction provenance

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ Task loading now has an explicit trust boundary: normal reads validate structure
 
 Planner manifests now require existing artifacts and can hash raw outputs from disk without serializing their full values across the Python/Rust boundary. Verification is strict by default, and the planner-specific creator and verifier enforce the adapter and safe raw-results directive contract consumed by project ingest. Producer schema errors surface as `ValueError`; filesystem failures surface as `OSError`.
 
+Reaction provenance now distinguishes source-reported templates from concrete atom-mapped reactions. Template-based adapters populate `template` only from an explicit planner template, while `mapped_reaction_smiles` stores the full mapped reaction in forward `reactants>>product` direction; reaction names and rendered actions remain annotations.
+
 ## v0.8.1
 
 v0.8.1 keeps corpus-sized artifacts inside Rust across ingest, score, and analyze. It also narrows ASKCOS pathway graphs before route casting and exposes `--workers` consistently across project commands.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,6 +35,8 @@ Route -> Molecule -> Reaction -> Molecule -> Reaction -> ...
 
 The root is `Route.target`. A non-leaf `Molecule` has `product_of: Reaction`; a leaf molecule has `product_of = None`. A `Reaction` stores the reactant molecules used to make its product.
 
+`mapped_reaction_smiles` is the full concrete atom-mapped reaction in `reactants>>product` direction, matching the surrounding `Reaction.reactants` and product `Molecule`. `template` is populated only when the planner reports the reaction template itself, usually as reaction SMARTS. Adapters do not infer a template from a reaction name or from a planner's rendered reaction action.
+
 ```python
 class Molecule(BaseModel):
     smiles: SmilesStr

--- a/docs/dev/rationale/schema-design.md
+++ b/docs/dev/rationale/schema-design.md
@@ -155,6 +155,8 @@ Basic schema
         schema_version: str = "2"
     ```
 
+`mapped_reaction_smiles` owns the full concrete atom-mapped reaction in `reactants>>product` direction, aligned with the reaction's child molecules and owning product molecule. `template` owns only a source-reported reaction template, typically reaction SMARTS. Reaction names and planner-specific action renderings are not promoted to either field.
+
 `CanonicalSmiles`, `InchiKey`, and `SchemaVersion` are validated Rust newtypes rather than aliases for `String`. Serde deserialization calls their validation path, so loading an artifact cannot bypass the constraints used by adapters.
 
 Identical molecules in different positions (e.g. same building block used in two branches) are different nodes; whence a Route is a tree, not just a DAG. Primarily because enforcing a 1 molecule = 1 node would introduce operational (serialization, signatures) complexity without any clear/obvious benefit beyond just marginally smaller disk usage.

--- a/packages/retrocast-py/src/retrocast/adapters/aizynth.py
+++ b/packages/retrocast-py/src/retrocast/adapters/aizynth.py
@@ -95,8 +95,17 @@ class AiZynthFinderAdapter:
 def _reaction_fields(node: AizynthReactionInput) -> dict[str, Any]:
     fields: dict[str, Any] = {}
     if "mapped_reaction_smiles" in node.metadata:
-        fields["mapped_reaction_smiles"] = node.metadata["mapped_reaction_smiles"]
+        fields["mapped_reaction_smiles"] = _forward_reaction_smiles(node.metadata["mapped_reaction_smiles"])
     if "template" in node.metadata:
         fields["template"] = node.metadata["template"]
     fields["annotations"] = dict(node.metadata)
     return fields
+
+
+def _forward_reaction_smiles(reaction_smiles: Any) -> Any:
+    if not isinstance(reaction_smiles, str):
+        return reaction_smiles
+    target, separator, precursors = reaction_smiles.partition(">>")
+    if not separator:
+        return reaction_smiles
+    return f"{precursors}>>{target}"

--- a/packages/retrocast-py/src/retrocast/adapters/molbuilder.py
+++ b/packages/retrocast-py/src/retrocast/adapters/molbuilder.py
@@ -128,4 +128,4 @@ def _reaction_fields(node: MolBuilderNode) -> dict[str, Any]:
     if disconnection.precursors:
         annotations["precursors"] = [precursor.model_dump() for precursor in disconnection.precursors]
 
-    return {"template": reaction_name or None, "annotations": annotations}
+    return {"annotations": annotations}

--- a/packages/retrocast-py/tests/adapters/test_aizynth.py
+++ b/packages/retrocast-py/tests/adapters/test_aizynth.py
@@ -32,8 +32,11 @@ def raw_aizynth_route() -> dict:
         "children": [
             {
                 "type": "reaction",
-                "smiles": "CCO",
-                "metadata": {"template": "tmpl-1", "mapped_reaction_smiles": "CC=O.[H][H]>>CCO"},
+                "smiles": "[CH2:1][OH:2]>>[CH:1]=[O:2]",
+                "metadata": {
+                    "template": "[C:1]-[OH:2]>>[CH:1]=[O:2]",
+                    "mapped_reaction_smiles": "[CH3:1][CH2:2][OH:3]>>[CH3:1][CH:2]=[O:3].[H:4][H:5]",
+                },
                 "children": [
                     {"type": "mol", "smiles": "CC=O", "in_stock": True},
                     {"type": "mol", "smiles": "[H][H]", "in_stock": True},
@@ -99,9 +102,10 @@ def test_aizynth_preserves_scores_and_reaction_metadata(raw_aizynth_route) -> No
     reaction = route.reaction_at("rc:r:/").value
 
     assert route.annotations == {"scores": {"state score": 0.75}, "state_score": 0.75}
-    assert reaction.template == "tmpl-1"
-    assert reaction.mapped_reaction_smiles == "CC=O.[H][H]>>CCO"
-    assert reaction.annotations["template"] == "tmpl-1"
+    assert reaction.template == "[C:1]-[OH:2]>>[CH:1]=[O:2]"
+    assert reaction.mapped_reaction_smiles == ("[CH3:1][CH:2]=[O:3].[H:4][H:5]>>[CH3:1][CH2:2][OH:3]")
+    assert reaction.annotations["template"] == "[C:1]-[OH:2]>>[CH:1]=[O:2]"
+    assert reaction.annotations["mapped_reaction_smiles"] == ("[CH3:1][CH2:2][OH:3]>>[CH3:1][CH:2]=[O:3].[H:4][H:5]")
 
 
 @pytest.mark.contract

--- a/packages/retrocast-py/tests/adapters/test_askcos.py
+++ b/packages/retrocast-py/tests/adapters/test_askcos.py
@@ -50,8 +50,19 @@ def askcos_output(pathways: list[list[dict[str, str]]] | None = None) -> dict[st
                         "smiles": "CC(=O)O.CCO>>CCOC(C)=O",
                         "id": "rxn-1",
                         "type": "reaction",
-                        "reaction_properties": {"mapped_smiles": "CC(=O)O.CCO>>CCOC(C)=O"},
-                        "model_metadata": [{"source": {"template": {"reaction_smarts": "esterification"}}}],
+                        "reaction_properties": {
+                            "mapped_smiles": (
+                                "[CH3:1][C:2](=[O:3])[OH:4].[CH3:5][CH2:6][OH:7]"
+                                ">>[CH3:1][C:2](=[O:3])[O:7][CH2:6][CH3:5]"
+                            )
+                        },
+                        "model_metadata": [
+                            {
+                                "source": {
+                                    "template": {"reaction_smarts": "[C:1](=[O:2])[OH:3].[OH:4]>>[C:1](=[O:2])[O:4]"}
+                                }
+                            }
+                        ],
                     },
                 },
                 "uuid2smiles": {
@@ -182,8 +193,10 @@ def test_askcos_reaction_fields_and_annotations(askcos_route_payload) -> None:
     route = AskcosAdapter().cast(askcos_route_payload, target=target_for("CCOC(C)=O"))
     reaction = route.reaction_at("rc:r:/").value
 
-    assert reaction.mapped_reaction_smiles == "CC(=O)O.CCO>>CCOC(C)=O"
-    assert reaction.template == "esterification"
+    assert reaction.mapped_reaction_smiles == (
+        "[CH3:1][C:2](=[O:3])[OH:4].[CH3:5][CH2:6][OH:7]>>[CH3:1][C:2](=[O:3])[O:7][CH2:6][CH3:5]"
+    )
+    assert reaction.template == "[C:1](=[O:2])[OH:3].[OH:4]>>[C:1](=[O:2])[O:4]"
     assert reaction.annotations == {"source_id": "rxn-1"}
 
 

--- a/packages/retrocast-py/tests/adapters/test_molbuilder.py
+++ b/packages/retrocast-py/tests/adapters/test_molbuilder.py
@@ -101,7 +101,7 @@ def test_molbuilder_preserves_route_molecule_and_reaction_annotations(raw_molbui
 
     assert route.annotations == {}
     assert route.target.annotations == {"functional_groups": ["alcohol"]}
-    assert reaction.template == "Reduction"
+    assert reaction.template is None
     assert reaction.annotations["reaction_name"] == "Reduction"
     assert reaction.annotations["named_reaction"] == "NaBH4 Reduction"
     assert reaction.annotations["category"] == "reduction"

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/askcos.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/askcos.rs
@@ -488,8 +488,17 @@ mod tests {
                     "CO": {"smiles": "CO", "id": "chem-unused", "type": "chemical", "terminal": true},
                     "CCO>>CCOC(C)=O": {
                         "smiles": "CCO>>CCOC(C)=O", "id": "rxn-1", "type": "reaction",
-                        "reaction_properties": {"mapped_smiles": "CCO>>CCOC(C)=O"},
-                        "model_metadata": [{"source": {"template": {"reaction_smarts": "esterification"}}}]
+                        "reaction_properties": {
+                            "mapped_smiles":
+                                "[CH3:1][CH2:2][OH:3]>>[CH3:1][CH2:2][O:3][C:4]([CH3:5])=[O:6]"
+                        },
+                        "model_metadata": [{
+                            "source": {
+                                "template": {
+                                    "reaction_smarts": "[OH:1]>>[O:1][C:2]([CH3:3])=[O:4]"
+                                }
+                            }
+                        }]
                     }
                 },
                 "uuid2smiles": {
@@ -525,7 +534,17 @@ mod tests {
             .unwrap();
         assert_eq!(route.annotations["total_paths"], 1);
         let reaction = route.target.product_of.unwrap();
-        assert_eq!(reaction.template.as_deref(), Some("esterification"));
+        assert_eq!(
+            reaction.template.as_deref(),
+            Some("[OH:1]>>[O:1][C:2]([CH3:3])=[O:4]")
+        );
+        assert_eq!(
+            reaction
+                .mapped_reaction_smiles
+                .as_ref()
+                .map(|value| value.as_str()),
+            Some("[CH3:1][CH2:2][OH:3]>>[CH3:1][CH2:2][O:3][C:4]([CH3:5])=[O:6]")
+        );
         assert_eq!(reaction.annotations["source_id"], "rxn-1");
     }
 

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/mod.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/mod.rs
@@ -427,7 +427,7 @@ pub fn normalize_slug(name: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use super::{AiZynthFinderAdapter, adapt_candidates};
+    use super::{Adapter, AiZynthFinderAdapter, adapt_candidates};
     use crate::route::AdaptMode;
 
     #[test]
@@ -448,6 +448,49 @@ mod tests {
         assert_eq!(
             candidates[1].failure.as_ref().unwrap().code,
             "chem.invalid_smiles"
+        );
+    }
+
+    #[test]
+    fn aizynth_separates_template_from_forward_mapped_reaction() {
+        let route = AiZynthFinderAdapter
+            .cast(
+                json!({
+                    "type": "mol",
+                    "smiles": "CCO",
+                    "children": [{
+                        "type": "reaction",
+                        "smiles": "[CH2:1][OH:2]>>[CH:1]=[O:2]",
+                        "metadata": {
+                            "template": "[C:1]-[OH:2]>>[CH:1]=[O:2]",
+                            "mapped_reaction_smiles":
+                                "[CH3:1][CH2:2][OH:3]>>[CH3:1][CH:2]=[O:3].[H:4][H:5]"
+                        },
+                        "children": [
+                            {"type": "mol", "smiles": "CC=O", "in_stock": true},
+                            {"type": "mol", "smiles": "[H][H]", "in_stock": true}
+                        ]
+                    }]
+                }),
+                AdaptMode::Strict,
+                None,
+            )
+            .unwrap();
+        let reaction = route.target.product_of.unwrap();
+        assert_eq!(
+            reaction.template.as_deref(),
+            Some("[C:1]-[OH:2]>>[CH:1]=[O:2]")
+        );
+        assert_eq!(
+            reaction
+                .mapped_reaction_smiles
+                .as_ref()
+                .map(|value| value.as_str()),
+            Some("[CH3:1][CH:2]=[O:3].[H:4][H:5]>>[CH3:1][CH2:2][OH:3]")
+        );
+        assert_eq!(
+            reaction.annotations["mapped_reaction_smiles"],
+            "[CH3:1][CH2:2][OH:3]>>[CH3:1][CH:2]=[O:3].[H:4][H:5]"
         );
     }
 }

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/molbuilder.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/molbuilder.rs
@@ -147,14 +147,14 @@ fn build_node(
         };
     }
     normalize_reactants(&mut reactants);
-    let (template, annotations) = reaction_fields(node);
+    let annotations = reaction_annotations(node);
     Ok(Some(Molecule {
         smiles,
         inchikey,
         product_of: Some(Box::new(Reaction {
             reactants,
             mapped_reaction_smiles: None,
-            template,
+            template: None,
             reagents: None,
             solvents: None,
             annotations,
@@ -163,9 +163,9 @@ fn build_node(
     }))
 }
 
-fn reaction_fields(node: &Node) -> (Option<String>, Map<String, Value>) {
+fn reaction_annotations(node: &Node) -> Map<String, Value> {
     let Some(disconnection) = &node.best_disconnection else {
-        return (None, Map::new());
+        return Map::new();
     };
     let reaction_name = disconnection.reaction_name.trim();
     let mut annotations = Map::from_iter([("score".to_owned(), json!(disconnection.score))]);
@@ -184,10 +184,7 @@ fn reaction_fields(node: &Node) -> (Option<String>, Map<String, Value>) {
             serde_json::to_value(&disconnection.precursors).expect("precursors are serializable"),
         );
     }
-    (
-        (!reaction_name.is_empty()).then(|| reaction_name.to_owned()),
-        annotations,
-    )
+    annotations
 }
 
 #[cfg(test)]
@@ -218,7 +215,8 @@ mod tests {
             .unwrap();
         assert_eq!(route.target.annotations["functional_groups"][0], "alcohol");
         let reaction = route.target.product_of.unwrap();
-        assert_eq!(reaction.template.as_deref(), Some("Reduction"));
+        assert_eq!(reaction.template, None);
+        assert_eq!(reaction.annotations["reaction_name"], "Reduction");
         assert_eq!(reaction.annotations["precursors"][0]["cost_per_kg"], 15.0);
     }
 }

--- a/packages/retrocast-rs/crates/retrocast-core/src/route.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/route.rs
@@ -133,7 +133,7 @@ fn build_molecule(
         .metadata
         .get("mapped_reaction_smiles")
         .and_then(Value::as_str)
-        .map(str::to_owned);
+        .map(forward_reaction_smiles);
     let template = reaction_node
         .metadata
         .get("template")
@@ -155,6 +155,13 @@ fn build_molecule(
         })),
         annotations: serde_json::Map::new(),
     }))
+}
+
+fn forward_reaction_smiles(reaction_smiles: &str) -> String {
+    reaction_smiles.split_once(">>").map_or_else(
+        || reaction_smiles.to_owned(),
+        |(target, precursors)| format!("{precursors}>>{target}"),
+    )
 }
 
 fn adapter_logic(code: &'static str, message: impl Into<String>) -> EngineError {


### PR DESCRIPTION
## why

Reaction provenance had two incompatible meanings across adapters: MolBuilder promoted a human reaction name into `template`, while AiZynthFinder exposed its retrosynthetic mapped reaction without aligning it to RetroCast's forward route structure. That makes downstream template and atom-mapping analysis depend on planner-specific accidents rather than the shared Route contract.

## what changed

- Define `template` as an explicit source-reported reaction template, usually SMARTS.
- Define `mapped_reaction_smiles` as the full concrete atom-mapped reaction in forward `reactants>>product` direction.
- Reverse AiZynthFinder's source-reported retrosynthetic mapped reaction during adaptation while retaining the untouched source value in annotations.
- Keep ASKCOS's already-forward mapped reaction and explicit template separate and covered by concrete mapped/SMARTS fixtures.
- Stop promoting MolBuilder reaction names to templates; preserve those names in annotations.
- Document the contract in concepts, schema rationale, and the 0.8.2 changelog.

## risk

The behavioral change is limited to reaction provenance fields. Existing planner metadata remains available in annotations, so source fidelity is retained. AiZynthFinder mapped reactions intentionally change direction; consumers that previously compensated for the backwards value should remove that workaround.

## verification

- `uv run pytest -q tests/adapters` — 238 passed
- `uv run ruff check src/retrocast/adapters tests/adapters` — passed
- `cargo fmt --all --check` — passed
- `cargo test --workspace --locked` — all workspace suites passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- commit hooks: Ruff lint/format and ty — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787804278&installation_model_id=19379&pr_number=146&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F146&signature=6427a6643cb88af495fe3ba0bbd9bb3f649f70a95ff4ec436e181b97f5053abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized atom-mapped reaction data to use `reactants>>product` direction.
  * Preserved planner-reported reaction templates separately from concrete mapped reactions.
  * Prevented reaction names and rendered actions from being incorrectly treated as templates.

* **Documentation**
  * Clarified reaction field definitions, provenance, and annotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns reaction provenance fields across planner adapters.
- Reorients AiZynthFinder mapped reactions into forward `reactants>>product` form while retaining source metadata in annotations.
- Stops treating MolBuilder reaction names as templates in both Python and Rust.
- Adds realistic ASKCOS, AiZynthFinder, and MolBuilder contract fixtures and documents the shared provenance semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the documented reaction provenance contract consistently implemented in the affected Python and Rust adapters.

The changed adapter paths preserve source metadata, agree across language implementations, and are covered with concrete mapped-reaction and template fixtures; no actionable failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/retrocast-py/src/retrocast/adapters/aizynth.py | Reverses source-reported retrosynthetic mapped reactions while preserving the untouched source metadata. |
| packages/retrocast-py/src/retrocast/adapters/molbuilder.py | Keeps MolBuilder reaction names in annotations instead of promoting them to the canonical template field. |
| packages/retrocast-rs/crates/retrocast-core/src/route.rs | Mirrors AiZynthFinder mapped-reaction orientation normalization in the Rust adapter path. |
| packages/retrocast-rs/crates/retrocast-core/src/adapters/molbuilder.rs | Mirrors MolBuilder reaction provenance semantics in Rust. |
| packages/retrocast-rs/crates/retrocast-core/src/adapters/askcos.rs | Adds concrete coverage confirming ASKCOS keeps forward mapped reactions separate from explicit templates. |

<sub>Reviews (1): Last reviewed commit: ["fix: align template reaction provenance"](https://github.com/ischemist/project-procrustes/commit/f757bb0f563162b8c34b89cc604384ebad700d2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47830559)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Adapters](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/adapters.md)
- Knowledge Base — [Models Schema (`retrocast.models`)](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/models-schema.md)
- Knowledge Base — [Rust Core (retrocast-rs)](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/rust-core.md)
</details>

<!-- /greptile_comment -->