### PR TITLE
fix: preserve malformed bipartite candidate slots

### DIFF
--- a/packages/retrocast-rs/crates/retrocast-core/src/adapt.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapt.rs
@@ -497,7 +497,11 @@ mod tests {
 
     use super::{ingest, ingest_file};
     use crate::{
-        adapters::AiZynthFinderAdapter, error::EngineError, io, model::Task, route::AdaptMode,
+        adapters::{AiZynthFinderAdapter, SynPlannerAdapter},
+        error::EngineError,
+        io,
+        model::Task,
+        route::AdaptMode,
     };
 
     static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
@@ -597,6 +601,45 @@ mod tests {
 
         assert_eq!(predictions["ethanol"].len(), 1);
         assert!(predictions["methanol"].is_empty());
+    }
+
+    #[test]
+    fn ingest_keeps_an_all_invalid_synplanner_target_as_ranked_failures() {
+        let task = streamed_task();
+        let raw = json!({
+            "ethanol": [
+                {
+                    "type": "mol",
+                    "smiles": "CCO",
+                    "children": [{
+                        "type": "reaction",
+                        "smiles": "C>>CCO",
+                        "children": [true]
+                    }]
+                },
+                {"type": "mol", "smiles": "CCO", "children": [null]}
+            ],
+            "methanol": [{"type": "mol", "smiles": "CO"}]
+        });
+
+        let predictions =
+            ingest(raw, &SynPlannerAdapter, &task, AdaptMode::Strict, None, 2).unwrap();
+
+        assert_eq!(predictions["ethanol"].len(), 2);
+        assert_eq!(
+            predictions["ethanol"]
+                .iter()
+                .map(|candidate| candidate.rank)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert!(predictions["ethanol"].iter().all(|candidate| {
+            candidate.failure.as_ref().is_some_and(|failure| {
+                failure.code == "adapter.schema_invalid"
+                    && failure.target_id.as_deref() == Some("ethanol")
+            })
+        }));
+        assert!(predictions["methanol"][0].route.is_some());
     }
 
     #[test]

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/bipartite.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/bipartite.rs
@@ -17,19 +17,6 @@ pub struct SyntheseusAdapter;
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SynPlannerAdapter;
 
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct SynPlannerSkippedRoute {
-    pub source_index: usize,
-    pub source_order: usize,
-    pub error: String,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct SynPlannerEntryBatch {
-    pub entries: Vec<RawRouteEntry>,
-    pub skipped: Vec<SynPlannerSkippedRoute>,
-}
-
 #[derive(Clone, Copy)]
 enum Flavor {
     Syntheseus,
@@ -68,36 +55,6 @@ impl Adapter for SynPlannerAdapter {
     fn cast(&self, raw_route: Value, mode: AdaptMode, target: Option<&Target>) -> Result<Route> {
         cast_bipartite(raw_route, mode, target, self.name(), Flavor::SynPlanner)
     }
-}
-
-pub fn extract_synplanner_entries(
-    payload: Value,
-    source_key: Option<&str>,
-) -> Result<SynPlannerEntryBatch> {
-    let routes = payload
-        .as_array()
-        .ok_or_else(|| common::schema("synplanner", "route payload must be a list"))?;
-    let mut entries = Vec::new();
-    let mut skipped = Vec::new();
-    for (index, route) in routes.iter().enumerate() {
-        match validate_node(route, "mol", "synplanner", "route root") {
-            Ok(()) => entries.push(RawRouteEntry {
-                payload: route.clone(),
-                source_key: source_key.map(str::to_owned),
-                source_row_index: None,
-                source_record_id: None,
-                target_hint_id: None,
-                target_hint_smiles: None,
-                source_order: Some(index + 1),
-            }),
-            Err(error) => skipped.push(SynPlannerSkippedRoute {
-                source_index: index,
-                source_order: index + 1,
-                error: error.to_string(),
-            }),
-        }
-    }
-    Ok(SynPlannerEntryBatch { entries, skipped })
 }
 
 fn make_entries(routes: &[Value], source_key: Option<&str>) -> Vec<RawRouteEntry> {
@@ -321,13 +278,125 @@ fn build_molecule(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{Value, json};
 
-    use super::{SynPlannerAdapter, SyntheseusAdapter, extract_synplanner_entries};
+    use super::{SynPlannerAdapter, SyntheseusAdapter};
     use crate::{
         adapters::{Adapter, adapt_candidates},
+        model::Target,
         route::AdaptMode,
     };
+
+    struct CandidateCase {
+        name: &'static str,
+        payload: Value,
+        mode: AdaptMode,
+        max_candidates: Option<usize>,
+        expected_failure_codes: Vec<Option<&'static str>>,
+    }
+
+    fn candidate_cases() -> Vec<CandidateCase> {
+        let valid = json!([
+            {"type": "mol", "smiles": "CCO"},
+            {"type": "mol", "smiles": "OCC"}
+        ]);
+        let mixed = json!([
+            {"type": "mol", "smiles": "CCO"},
+            {"type": "mol", "smiles": "CCO", "children": [null]},
+            {"type": "mol", "smiles": "not-smiles"}
+        ]);
+        let all_invalid = json!([
+            {"type": "mol", "smiles": "CCO", "children": [true]},
+            {"type": "mol", "smiles": "not-smiles"}
+        ]);
+        let truncated = json!([
+            {"type": "mol", "smiles": "CCO", "children": [null]},
+            {"type": "mol", "smiles": "OCC"},
+            {"type": "mol", "smiles": "not-smiles"}
+        ]);
+
+        vec![
+            CandidateCase {
+                name: "all-valid strict",
+                payload: valid.clone(),
+                mode: AdaptMode::Strict,
+                max_candidates: None,
+                expected_failure_codes: vec![None, None],
+            },
+            CandidateCase {
+                name: "all-valid prune",
+                payload: valid,
+                mode: AdaptMode::Prune,
+                max_candidates: None,
+                expected_failure_codes: vec![None, None],
+            },
+            CandidateCase {
+                name: "mixed strict",
+                payload: mixed.clone(),
+                mode: AdaptMode::Strict,
+                max_candidates: None,
+                expected_failure_codes: vec![
+                    None,
+                    Some("adapter.schema_invalid"),
+                    Some("chem.invalid_smiles"),
+                ],
+            },
+            CandidateCase {
+                name: "mixed prune",
+                payload: mixed,
+                mode: AdaptMode::Prune,
+                max_candidates: None,
+                expected_failure_codes: vec![
+                    None,
+                    Some("adapter.schema_invalid"),
+                    Some("adapter.target_pruned"),
+                ],
+            },
+            CandidateCase {
+                name: "all-invalid strict",
+                payload: all_invalid.clone(),
+                mode: AdaptMode::Strict,
+                max_candidates: None,
+                expected_failure_codes: vec![
+                    Some("adapter.schema_invalid"),
+                    Some("chem.invalid_smiles"),
+                ],
+            },
+            CandidateCase {
+                name: "all-invalid prune",
+                payload: all_invalid,
+                mode: AdaptMode::Prune,
+                max_candidates: None,
+                expected_failure_codes: vec![
+                    Some("adapter.schema_invalid"),
+                    Some("adapter.target_pruned"),
+                ],
+            },
+            CandidateCase {
+                name: "max-candidates strict",
+                payload: truncated.clone(),
+                mode: AdaptMode::Strict,
+                max_candidates: Some(2),
+                expected_failure_codes: vec![Some("adapter.schema_invalid"), None],
+            },
+            CandidateCase {
+                name: "max-candidates prune",
+                payload: truncated,
+                mode: AdaptMode::Prune,
+                max_candidates: Some(2),
+                expected_failure_codes: vec![Some("adapter.schema_invalid"), None],
+            },
+        ]
+    }
+
+    fn fixture_target() -> Target {
+        serde_json::from_value(json!({
+            "id": "target-ethanol",
+            "smiles": "CCO",
+            "inchikey": "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"
+        }))
+        .unwrap()
+    }
 
     #[test]
     fn syntheseus_preserves_reaction_metadata() {
@@ -350,82 +419,71 @@ mod tests {
     }
 
     #[test]
-    fn synplanner_preserves_invalid_routes_as_ranked_failures() {
-        let candidates = adapt_candidates(
-            json!([
-                {"type": "mol", "smiles": "CCO", "children": [{"type": "reaction", "smiles": "C>>CCO", "children": [null]}]},
-                {"type": "mol", "smiles": "CCC"}
-            ]),
-            &SynPlannerAdapter,
-            AdaptMode::Strict,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+    fn bipartite_candidate_slot_matrix() {
+        let target = fixture_target();
+        for adapter in [&SynPlannerAdapter as &dyn Adapter, &SyntheseusAdapter] {
+            for case in candidate_cases() {
+                let candidates = adapt_candidates(
+                    case.payload,
+                    adapter,
+                    case.mode,
+                    Some(&target),
+                    Some("source-ethanol"),
+                    case.max_candidates,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{} / {} failed: {error}", adapter.name(), case.name)
+                });
 
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].rank, 1);
-        assert!(candidates[0].route.is_none());
-        assert_eq!(
-            candidates[0].failure.as_ref().unwrap().code,
-            "adapter.schema_invalid"
-        );
-        assert_eq!(candidates[1].rank, 2);
-        assert!(candidates[1].route.is_some());
-        assert!(candidates[1].failure.is_none());
-    }
-
-    #[test]
-    fn synplanner_all_invalid_routes_remain_candidate_failures() {
-        let candidates = adapt_candidates(
-            json!([
-                {"type": "mol", "smiles": "CCO", "children": [true]},
-                {"type": "mol", "smiles": "CCC", "children": [null]}
-            ]),
-            &SynPlannerAdapter,
-            AdaptMode::Strict,
-            None,
-            Some("target-1"),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(
-            candidates
-                .iter()
-                .map(|candidate| candidate.rank)
-                .collect::<Vec<_>>(),
-            vec![1, 2]
-        );
-        assert!(candidates.iter().all(|candidate| candidate.route.is_none()));
-        assert!(candidates.iter().all(|candidate| {
-            candidate.failure.as_ref().is_some_and(|failure| {
-                failure.code == "adapter.schema_invalid"
-                    && failure
-                        .message
-                        .as_deref()
-                        .is_some_and(|message| message.contains("node must be an object"))
-            })
-        }));
-    }
-
-    #[test]
-    fn synplanner_all_invalid_entry_inspection_reports_every_skip() {
-        let batch = extract_synplanner_entries(
-            json!([
-                {"type": "mol", "smiles": "CCO", "children": [true]},
-                {"type": "mol", "smiles": "CCC", "children": [null]}
-            ]),
-            Some("target-1"),
-        )
-        .unwrap();
-
-        assert!(batch.entries.is_empty());
-        assert_eq!(batch.skipped.len(), 2);
-        assert_eq!(batch.skipped[0].source_order, 1);
-        assert_eq!(batch.skipped[1].source_order, 2);
+                assert_eq!(
+                    candidates.len(),
+                    case.expected_failure_codes.len(),
+                    "{} / {} candidate count",
+                    adapter.name(),
+                    case.name
+                );
+                for (index, (candidate, expected_failure_code)) in candidates
+                    .iter()
+                    .zip(&case.expected_failure_codes)
+                    .enumerate()
+                {
+                    assert_eq!(
+                        candidate.rank,
+                        index + 1,
+                        "{} / {} rank",
+                        adapter.name(),
+                        case.name
+                    );
+                    match expected_failure_code {
+                        None => {
+                            let route = candidate.route.as_ref().unwrap_or_else(|| {
+                                panic!(
+                                    "{} / {} rank {} should be a route",
+                                    adapter.name(),
+                                    case.name,
+                                    candidate.rank
+                                )
+                            });
+                            assert_eq!(route.target.smiles, "CCO");
+                            assert!(candidate.failure.is_none());
+                        }
+                        Some(expected_code) => {
+                            let failure = candidate.failure.as_ref().unwrap_or_else(|| {
+                                panic!(
+                                    "{} / {} rank {} should be a failure",
+                                    adapter.name(),
+                                    case.name,
+                                    candidate.rank
+                                )
+                            });
+                            assert_eq!(failure.code, *expected_code);
+                            assert_eq!(failure.target_id.as_deref(), Some("target-ethanol"));
+                            assert!(candidate.route.is_none());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -442,26 +500,6 @@ mod tests {
             .unwrap_err();
             assert!(error.to_string().contains("route payload must be a list"));
         }
-    }
-
-    #[test]
-    fn syntheseus_invalid_routes_are_candidate_failures() {
-        let candidates = adapt_candidates(
-            json!([
-                {"type": "mol", "smiles": "CCO", "children": [null]},
-                {"type": "mol", "smiles": "CCC"}
-            ]),
-            &SyntheseusAdapter,
-            AdaptMode::Strict,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(candidates.len(), 2);
-        assert!(candidates[0].failure.is_some());
-        assert!(candidates[1].route.is_some());
     }
 
     #[test]

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/bipartite.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/bipartite.rs
@@ -45,9 +45,6 @@ impl Adapter for SyntheseusAdapter {
         let routes = payload
             .as_array()
             .ok_or_else(|| common::schema(self.name(), "route payload must be a list"))?;
-        for route in routes {
-            validate_node(route, "mol", self.name(), "route root")?;
-        }
         Ok(make_entries(routes, source_key))
     }
 
@@ -62,7 +59,10 @@ impl Adapter for SynPlannerAdapter {
     }
 
     fn entries(&self, payload: Value, source_key: Option<&str>) -> Result<Vec<RawRouteEntry>> {
-        Ok(extract_synplanner_entries(payload, source_key)?.entries)
+        let routes = payload
+            .as_array()
+            .ok_or_else(|| common::schema(self.name(), "route payload must be a list"))?;
+        Ok(make_entries(routes, source_key))
     }
 
     fn cast(&self, raw_route: Value, mode: AdaptMode, target: Option<&Target>) -> Result<Route> {
@@ -96,38 +96,6 @@ pub fn extract_synplanner_entries(
                 error: error.to_string(),
             }),
         }
-    }
-    if entries.is_empty() && !skipped.is_empty() {
-        let first = &skipped[0];
-        let message = format!(
-            "no valid routes; skipped {} invalid route(s), first invalid route source_index={} source_order={}: {}",
-            skipped.len(),
-            first.source_index,
-            first.source_order,
-            first.error
-        );
-        let context = Map::from_iter([
-            ("adapter".to_owned(), json!("synplanner")),
-            (
-                "target_id".to_owned(),
-                json!(source_key.unwrap_or("<unknown>")),
-            ),
-            ("skipped_routes".to_owned(), json!(skipped.len())),
-            (
-                "first_invalid_source_index".to_owned(),
-                json!(first.source_index),
-            ),
-            (
-                "first_invalid_source_order".to_owned(),
-                json!(first.source_order),
-            ),
-            ("first_validation_error".to_owned(), json!(first.error)),
-        ]);
-        return Err(crate::error::EngineError::AdapterSchemaContext {
-            adapter: "synplanner",
-            message,
-            context,
-        });
     }
     Ok(SynPlannerEntryBatch { entries, skipped })
 }
@@ -355,8 +323,11 @@ fn build_molecule(
 mod tests {
     use serde_json::json;
 
-    use super::{SynPlannerAdapter, SyntheseusAdapter};
-    use crate::{adapters::Adapter, route::AdaptMode};
+    use super::{SynPlannerAdapter, SyntheseusAdapter, extract_synplanner_entries};
+    use crate::{
+        adapters::{Adapter, adapt_candidates},
+        route::AdaptMode,
+    };
 
     #[test]
     fn syntheseus_preserves_reaction_metadata() {
@@ -379,18 +350,118 @@ mod tests {
     }
 
     #[test]
-    fn synplanner_skips_invalid_routes_but_keeps_source_rank() {
-        let routes = SynPlannerAdapter
-            .entries(
-                json!([
-                    {"type": "mol", "smiles": "CCO", "children": [{"type": "reaction", "smiles": "C>>CCO", "children": [null]}]},
-                    {"type": "mol", "smiles": "CCC"}
-                ]),
+    fn synplanner_preserves_invalid_routes_as_ranked_failures() {
+        let candidates = adapt_candidates(
+            json!([
+                {"type": "mol", "smiles": "CCO", "children": [{"type": "reaction", "smiles": "C>>CCO", "children": [null]}]},
+                {"type": "mol", "smiles": "CCC"}
+            ]),
+            &SynPlannerAdapter,
+            AdaptMode::Strict,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].rank, 1);
+        assert!(candidates[0].route.is_none());
+        assert_eq!(
+            candidates[0].failure.as_ref().unwrap().code,
+            "adapter.schema_invalid"
+        );
+        assert_eq!(candidates[1].rank, 2);
+        assert!(candidates[1].route.is_some());
+        assert!(candidates[1].failure.is_none());
+    }
+
+    #[test]
+    fn synplanner_all_invalid_routes_remain_candidate_failures() {
+        let candidates = adapt_candidates(
+            json!([
+                {"type": "mol", "smiles": "CCO", "children": [true]},
+                {"type": "mol", "smiles": "CCC", "children": [null]}
+            ]),
+            &SynPlannerAdapter,
+            AdaptMode::Strict,
+            None,
+            Some("target-1"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.rank)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert!(candidates.iter().all(|candidate| candidate.route.is_none()));
+        assert!(candidates.iter().all(|candidate| {
+            candidate.failure.as_ref().is_some_and(|failure| {
+                failure.code == "adapter.schema_invalid"
+                    && failure
+                        .message
+                        .as_deref()
+                        .is_some_and(|message| message.contains("node must be an object"))
+            })
+        }));
+    }
+
+    #[test]
+    fn synplanner_all_invalid_entry_inspection_reports_every_skip() {
+        let batch = extract_synplanner_entries(
+            json!([
+                {"type": "mol", "smiles": "CCO", "children": [true]},
+                {"type": "mol", "smiles": "CCC", "children": [null]}
+            ]),
+            Some("target-1"),
+        )
+        .unwrap();
+
+        assert!(batch.entries.is_empty());
+        assert_eq!(batch.skipped.len(), 2);
+        assert_eq!(batch.skipped[0].source_order, 1);
+        assert_eq!(batch.skipped[1].source_order, 2);
+    }
+
+    #[test]
+    fn bipartite_adapters_reject_non_list_envelopes() {
+        for adapter in [&SynPlannerAdapter as &dyn Adapter, &SyntheseusAdapter] {
+            let error = adapt_candidates(
+                json!({"not": "a route list"}),
+                adapter,
+                AdaptMode::Strict,
+                None,
+                None,
                 None,
             )
-            .unwrap();
-        assert_eq!(routes.len(), 1);
-        assert_eq!(routes[0].source_order, Some(2));
+            .unwrap_err();
+            assert!(error.to_string().contains("route payload must be a list"));
+        }
+    }
+
+    #[test]
+    fn syntheseus_invalid_routes_are_candidate_failures() {
+        let candidates = adapt_candidates(
+            json!([
+                {"type": "mol", "smiles": "CCO", "children": [null]},
+                {"type": "mol", "smiles": "CCC"}
+            ]),
+            &SyntheseusAdapter,
+            AdaptMode::Strict,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates[0].failure.is_some());
+        assert!(candidates[1].route.is_some());
     }
 
     #[test]

--- a/packages/retrocast-rs/crates/retrocast-core/src/adapters/mod.rs
+++ b/packages/retrocast-rs/crates/retrocast-core/src/adapters/mod.rs
@@ -14,10 +14,7 @@ use rayon::prelude::*;
 use serde_json::{Map, Value, json};
 
 pub use askcos::AskcosAdapter;
-pub use bipartite::{
-    SynPlannerAdapter, SynPlannerEntryBatch, SynPlannerSkippedRoute, SyntheseusAdapter,
-    extract_synplanner_entries,
-};
+pub use bipartite::{SynPlannerAdapter, SyntheseusAdapter};
 pub use dms::{DirectMultiStepAdapter, route_length as dms_route_length};
 pub use molbuilder::MolBuilderAdapter;
 pub use multistepttl::MultiStepTtlAdapter;

--- a/packages/retrocast-rs/crates/retrocast-python/src/lib.rs
+++ b/packages/retrocast-rs/crates/retrocast-python/src/lib.rs
@@ -528,17 +528,6 @@ fn reaction_string_parse_json(route_string: &str, adapter: &str, mode: &str) -> 
 }
 
 #[pyfunction]
-#[pyo3(signature = (raw_json, source_key=None))]
-fn synplanner_entries_json(raw_json: &str, source_key: Option<&str>) -> PyResult<String> {
-    let raw: Value = from_json(raw_json)?;
-    let result = match adapters::extract_synplanner_entries(raw, source_key) {
-        Ok(batch) => AdapterBoundaryResult::success(batch),
-        Err(error) => AdapterBoundaryResult::failure("synplanner", error, None),
-    };
-    to_json(&result)
-}
-
-#[pyfunction]
 fn paroutes_condition_stats_json(route_json: &str, statistics_json: &str) -> PyResult<String> {
     let route: Value = from_json(route_json)?;
     let mut statistics: adapters::ConditionSlotParseStatistics = from_json(statistics_json)?;
@@ -2289,7 +2278,6 @@ fn retrocast(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(dms_route_length_json, module)?)?;
     module.add_function(wrap_pyfunction!(synllama_precursor_map_json, module)?)?;
     module.add_function(wrap_pyfunction!(reaction_string_parse_json, module)?)?;
-    module.add_function(wrap_pyfunction!(synplanner_entries_json, module)?)?;
     module.add_function(wrap_pyfunction!(paroutes_condition_stats_json, module)?)?;
     module.add_function(wrap_pyfunction!(candidate_statistics_json, module)?)?;
     module.add_function(wrap_pyfunction!(

--- a/packages/retrocast-rs/python-tests/test_bindings.py
+++ b/packages/retrocast-rs/python-tests/test_bindings.py
@@ -102,6 +102,118 @@ def test_adapt_accepts_plain_python_values() -> None:
     assert candidates[0]["route"]["target"]["smiles"] == "CCO"
 
 
+@pytest.mark.parametrize("adapter", ["synplanner", "syntheseus"])
+@pytest.mark.parametrize(
+    ("mode", "payload", "max_candidates", "expected_failure_codes"),
+    [
+        pytest.param(
+            "strict",
+            [{"type": "mol", "smiles": "CCO"}, {"type": "mol", "smiles": "OCC"}],
+            None,
+            [None, None],
+            id="all-valid-strict",
+        ),
+        pytest.param(
+            "prune",
+            [{"type": "mol", "smiles": "CCO"}, {"type": "mol", "smiles": "OCC"}],
+            None,
+            [None, None],
+            id="all-valid-prune",
+        ),
+        pytest.param(
+            "strict",
+            [
+                {"type": "mol", "smiles": "CCO"},
+                {"type": "mol", "smiles": "CCO", "children": [None]},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            None,
+            [None, "adapter.schema_invalid", "chem.invalid_smiles"],
+            id="mixed-strict",
+        ),
+        pytest.param(
+            "prune",
+            [
+                {"type": "mol", "smiles": "CCO"},
+                {"type": "mol", "smiles": "CCO", "children": [None]},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            None,
+            [None, "adapter.schema_invalid", "adapter.target_pruned"],
+            id="mixed-prune",
+        ),
+        pytest.param(
+            "strict",
+            [
+                {"type": "mol", "smiles": "CCO", "children": [True]},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            None,
+            ["adapter.schema_invalid", "chem.invalid_smiles"],
+            id="all-invalid-strict",
+        ),
+        pytest.param(
+            "prune",
+            [
+                {"type": "mol", "smiles": "CCO", "children": [True]},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            None,
+            ["adapter.schema_invalid", "adapter.target_pruned"],
+            id="all-invalid-prune",
+        ),
+        pytest.param(
+            "strict",
+            [
+                {"type": "mol", "smiles": "CCO", "children": [None]},
+                {"type": "mol", "smiles": "OCC"},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            2,
+            ["adapter.schema_invalid", None],
+            id="max-candidates-strict",
+        ),
+        pytest.param(
+            "prune",
+            [
+                {"type": "mol", "smiles": "CCO", "children": [None]},
+                {"type": "mol", "smiles": "OCC"},
+                {"type": "mol", "smiles": "not-smiles"},
+            ],
+            2,
+            ["adapter.schema_invalid", None],
+            id="max-candidates-prune",
+        ),
+    ],
+)
+def test_bipartite_candidate_slot_matrix(
+    adapter: str,
+    mode: str,
+    payload: list[dict[str, object]],
+    max_candidates: int | None,
+    expected_failure_codes: list[str | None],
+) -> None:
+    target = task()["targets"][TARGET_ID]
+    candidates = retrocast.adapt(
+        payload,
+        adapter,
+        mode=mode,
+        target=target,
+        source_key="source-ethanol",
+        max_candidates=max_candidates,
+    )
+
+    assert [candidate["rank"] for candidate in candidates] == list(range(1, len(expected_failure_codes) + 1))
+    for candidate, expected_failure_code in zip(candidates, expected_failure_codes, strict=True):
+        if expected_failure_code is None:
+            assert candidate["route"]["target"]["smiles"] == "CCO"
+            assert "failure" not in candidate
+        else:
+            assert candidate["failure"]["code"] == expected_failure_code
+            assert candidate["failure"]["target_id"] == TARGET_ID
+            assert "route" not in candidate
+
+
 def test_native_handles_keep_composed_state_in_rust(tmp_path: Path) -> None:
     predictions = retrocast.ingest(
         {TARGET_ID: raw()},

--- a/retrocast.pyi
+++ b/retrocast.pyi
@@ -3,6 +3,7 @@ from os import PathLike
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
 
 _StrPath: TypeAlias = str | PathLike[str]
+_AdaptMode: TypeAlias = Literal["strict", "prune"]
 _JSONScalar: TypeAlias = None | bool | int | float | str
 _JSONValue: TypeAlias = _JSONScalar | list["_JSONValue"] | dict[str, "_JSONValue"]
 
@@ -74,7 +75,7 @@ def adapt(
     raw: _JSONValue,
     adapter: str,
     *,
-    mode: Literal["strict", "lenient"] = "strict",
+    mode: _AdaptMode = "strict",
     target: _TargetInput | Mapping[str, _JSONValue] | None = None,
     source_key: str | None = None,
     max_candidates: int | None = None,
@@ -85,7 +86,7 @@ def ingest(
     adapter: str,
     task: _TaskInput | Mapping[str, _JSONValue],
     *,
-    mode: Literal["strict", "lenient"] = "strict",
+    mode: _AdaptMode = "strict",
     max_candidates: int | None = None,
     workers: int = 1,
 ) -> NativePredictions: ...
@@ -94,7 +95,7 @@ def ingest_file(
     adapter: str,
     task_path: _StrPath,
     *,
-    mode: Literal["strict", "lenient"] = "strict",
+    mode: _AdaptMode = "strict",
     max_candidates: int | None = None,
     workers: int = 1,
 ) -> NativePredictions: ...
@@ -137,7 +138,7 @@ def evaluate(
     execution_stats_path: _StrPath | None = None,
     adapter: str = "aizynthfinder",
     workers: int = 1,
-    mode: Literal["strict", "lenient"] = "strict",
+    mode: _AdaptMode = "strict",
     max_candidates: int | None = None,
     match_level: Literal["full", "no_stereo", "connectivity"] = "full",
     acceptable_route_match: Literal["prefix", "exact"] = "prefix",


### PR DESCRIPTION
## why

RetroCast 0.8.2 aborts an entire evaluation when a SynPlanner or Syntheseus payload contains no adaptable routes. The stored Pandora `ref-lin-600/synplanner-1.3.2-mcts-rollout` result hits this boundary: one target contains 19 malformed route slots, causing a 600-target benchmark evaluation to fail instead of preserving those ranked failures as Tier-0 evidence.

This also exposed two contradictory entry contracts. The production candidate path is rank-preserving, while a SynPlanner-specific helper filtered malformed slots before candidate construction.

## what changed

- Treat every bipartite planner list element as a ranked candidate slot and convert per-route adaptation errors into `Candidate.failure` records.
- Apply the same semantics to SynPlanner and Syntheseus, including all-invalid payloads.
- Remove the divergent SynPlanner-only extraction API and native-Python binding.
- Add table-driven Rust and public Python coverage for all-valid, mixed, all-invalid, strict, prune, target identity, rank, failure-code, and candidate-limit behavior.

## risk

This intentionally changes malformed-route handling: invalid entries now occupy their original ranks instead of being filtered or aborting the whole target. Top-level envelope errors still fail, and strict chemistry behavior remains unchanged. The main compatibility risk is a consumer of the removed low-level `synplanner_entries_json` helper; repository-wide search found no caller or documented facade use.

## verification

- `cargo test --workspace` — 114 tests passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `uv run maturin develop`
- native Python binding suite — 33 passed
- `uv run ruff check ...`
- `uv run ty check`
- Exact Pandora `ref-lin-600/synplanner-1.3.2-mcts-rollout` evaluation completed: 600 targets and 19,404 candidates; target `n5-04220` retained ranks 1–19 as `adapter.schema_invalid` failures with the correct target ID; strict manifest verification passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788414285&installation_model_id=19379&pr_number=148&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F148&signature=5675897a09c2d750d1358f066dcd0a6f2cf5d3e2be09becd99eafaf5631b1e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route ingestion so invalid candidates are consistently preserved as ranked validation failures in strict mode.
  * Ensured valid routes continue to be produced when other candidates are invalid.
  * Improved handling of mixed, malformed, and candidate-limited route inputs.
* **Tests**
  * Added comprehensive coverage across supported adapters, ingestion modes, ranking, failure codes, and target matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes SynPlanner and Syntheseus preserve every list element as a ranked candidate slot, representing malformed routes as candidate-level failures rather than discarding them or aborting an all-invalid target.
- Routes from both bipartite adapters now enter the shared candidate adaptation path without preliminary slot filtering.
- Rust and Python tests cover valid, mixed, all-invalid, strict, prune, and candidate-limit behavior.
- The obsolete SynPlanner extraction helper is removed, and public mode annotations are aligned with runtime behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/retrocast-rs/crates/retrocast-core/src/adapters/bipartite.rs | Unifies SynPlanner and Syntheseus entry extraction so malformed list elements remain ranked candidate slots. |
| packages/retrocast-rs/crates/retrocast-core/src/adapt.rs | Adds ingest coverage confirming an all-invalid SynPlanner target produces ranked failures without affecting sibling targets. |
| packages/retrocast-rs/crates/retrocast-core/src/adapters/mod.rs | Removes exports belonging to the obsolete SynPlanner-only extraction path. |
| packages/retrocast-rs/crates/retrocast-python/src/lib.rs | Removes the unused native SynPlanner entry-extraction function and its module registration. |
| packages/retrocast-rs/python-tests/test_bindings.py | Adds public binding coverage for candidate-slot preservation across both bipartite adapters and adaptation modes. |
| retrocast.pyi | Corrects mode annotations to match the runtime-supported strict and prune values. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Bipartite planner list] --> B[Create one raw entry per slot]
  B --> C{Adapt route}
  C -->|Valid| D[Candidate with route]
  C -->|Malformed| E[Candidate with failure record]
  D --> F[Preserve source rank]
  E --> F
  F --> G[Ingested target candidates]
```

<sub>Reviews (2): Last reviewed commit: ["fix: align Python adapt mode typing"](https://github.com/ischemist/project-procrustes/commit/50393036bae652d58abc98e0c504cc76a7c2c257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49950571)</sub>

**Context used:**

- Knowledge Base — [Rust Core (retrocast-rs)](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/rust-core.md)

<!-- /greptile_comment -->