### PR TITLE
fix: gate RetroCast v0.8.3 releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,8 +6,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  preflight:
+    name: Validate release version
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Match release tag to package versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: python3 scripts/check-release-version.py --tag="$RELEASE_TAG"
+
   wheels:
     name: ${{ matrix.platform }} wheel
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -139,6 +156,7 @@ jobs:
           if-no-files-found: error
 
   sdist:
+    needs: preflight
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,8 +9,23 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: Validate release version
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Match release tag to package versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: python3 scripts/check-release-version.py --tag="$RELEASE_TAG"
+
   cli:
     name: ${{ matrix.platform }} CLI
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -226,6 +241,7 @@ jobs:
             if gh release upload "$RELEASE_TAG" \
               dist/retrocast-* \
               dist/SHA256SUMS \
+              --repo "$GITHUB_REPOSITORY" \
               --clobber
             then
               exit 0

--- a/packages/retrocast-rs/Cargo.lock
+++ b/packages/retrocast-rs/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "retrocast-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "retrocast-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "csv",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "retrocast-python"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "pyo3",
  "retrocast-core",

--- a/packages/retrocast-rs/Cargo.toml
+++ b/packages/retrocast-rs/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 # This is the release workspace used by Rust users, Maturin, and CI so every
 # front end builds the same core from one lockfile.
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail a release before building when its tag and Rust packages disagree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tomllib
+from pathlib import Path
+
+RETROCAST_PACKAGES = frozenset(
+    {
+        "retrocast-cli",
+        "retrocast-core",
+        "retrocast-python",
+    }
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Release tag to validate, such as v0.8.3. Empty checks package consistency only.",
+    )
+    args = parser.parse_args()
+
+    repository_root = Path(__file__).resolve().parents[1]
+    manifest = repository_root / "packages" / "retrocast-rs" / "Cargo.toml"
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--locked",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            str(manifest),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = json.loads(result.stdout)
+    workspace_members = set(metadata["workspace_members"])
+    package_versions = {
+        package["name"]: package["version"]
+        for package in metadata["packages"]
+        if package["id"] in workspace_members and package["name"] in RETROCAST_PACKAGES
+    }
+
+    missing_packages = RETROCAST_PACKAGES - package_versions.keys()
+    if missing_packages:
+        names = ", ".join(sorted(missing_packages))
+        raise SystemExit(f"missing RetroCast workspace packages from cargo metadata: {names}")
+
+    versions = set(package_versions.values())
+    if len(versions) != 1:
+        details = ", ".join(f"{name}={version}" for name, version in sorted(package_versions.items()))
+        raise SystemExit(f"RetroCast workspace package versions disagree: {details}")
+
+    version = versions.pop()
+    lockfile = manifest.with_name("Cargo.lock")
+    lock_data = tomllib.loads(lockfile.read_text())
+    locked_versions = {
+        package["name"]: package["version"] for package in lock_data["package"] if package["name"] in RETROCAST_PACKAGES
+    }
+    if locked_versions != package_versions:
+        expected = ", ".join(f"{name}={value}" for name, value in sorted(package_versions.items()))
+        actual = ", ".join(f"{name}={value}" for name, value in sorted(locked_versions.items()))
+        raise SystemExit(f"Cargo.lock package versions disagree (expected {expected}; found {actual})")
+
+    if args.tag and args.tag != f"v{version}":
+        raise SystemExit(f"release tag {args.tag!r} does not match RetroCast workspace version {version!r}")
+
+    print(f"RetroCast workspace packages consistently report {version}")
+    if args.tag:
+        print(f"Release tag {args.tag} matches workspace version {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## why

The first v0.8.3 release attempt built artifacts from a Rust workspace that still declared 0.8.2. PyPI correctly rejected the resulting 0.8.2 filenames as already published, while the standalone CLI workflow produced archives labeled v0.8.3 whose binaries reported 0.8.2. Its publish job then failed separately because `gh release upload` ran without a checkout or explicit repository, so `gh` could not resolve its target.

A release tag must not be able to launch the expensive platform matrices unless the package and lockfile versions agree with that tag, and release jobs without repository context must name the repository explicitly.

## what changed

- Bump the native Rust workspace and its three lockfile package records to 0.8.3.
- Add a shared release-version preflight that resolves every RetroCast workspace package through locked Cargo metadata, checks the lockfile records, and requires an exact `v<package-version>` tag on release events.
- Gate both PyPI wheel/sdist builds and standalone CLI builds on that preflight.
- Pass `--repo "$GITHUB_REPOSITORY"` to the no-checkout CLI release upload. The release download already supplied the same explicit context.

## risk

This changes release packaging and publication only. A malformed or stale release version now fails before any platform build starts. Manual workflow dispatches still validate workspace and lockfile consistency but intentionally have no release tag to compare. No release, tag, PyPI file, or SynthArena deployment is created by this PR.

## verification

- `actionlint .github/workflows/publish-pypi.yml .github/workflows/publish-release.yml`
- `python3 scripts/check-release-version.py --tag=v0.8.3`
- Negative preflight with `--tag=v0.8.2` failed with the expected mismatch.
- `cargo test --locked --workspace --manifest-path packages/retrocast-rs/Cargo.toml` (114 passed)
- Release CLI build: `retrocast --version` reported `retrocast 0.8.3`.
- Root Maturin wheel built as `retrocast-0.8.3-...whl`; a clean venv reported distribution `0.8.3`, `retrocast.__version__ == "0.8.3"`, Rust engine, and `engine_info()[0] == "0.8.3"`.
- Pre-commit Ruff, Ruff format, and ty hooks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/project-procrustes/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788415967&installation_model_id=19379&pr_number=149&repository=ischemist%2Fproject-procrustes&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fproject-procrustes%2Fpull%2F149&signature=a1784e31ff48a13c176ad07af0a9baf00d2a1f83efae90ab2589b95e5f8746f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the RetroCast Rust workspace and lockfile at version 0.8.3 and adds an early consistency check to both release workflows.
- Validates Cargo metadata, lockfile package records, and release tags before starting platform builds.
- Gates PyPI wheel, sdist, and standalone CLI builds on the preflight.
- Supplies explicit repository context when uploading standalone CLI release assets.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the release matrices and publication paths consistently gated by the new version validation.

The workspace and lockfile versions agree, release events require the matching tag, manual runs retain consistency checks without publishing, and all affected build and publication jobs depend on the preflight.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check-release-version.py | Adds a coherent locked-metadata, lockfile, and release-tag consistency check for the three RetroCast workspace packages. |
| .github/workflows/publish-pypi.yml | Adds a preflight dependency that gates every wheel and sdist build before release publication. |
| .github/workflows/publish-release.yml | Gates standalone CLI builds on version validation and explicitly targets the repository during release upload. |
| packages/retrocast-rs/Cargo.toml | Updates the shared Rust workspace package version to 0.8.3. |
| packages/retrocast-rs/Cargo.lock | Updates all three corresponding workspace package records to 0.8.3. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E[Release published or manual dispatch] --> P[Version preflight]
  P --> M[Read locked Cargo metadata]
  M --> L[Compare workspace and Cargo.lock versions]
  L --> T{Release event?}
  T -->|Yes| V[Require tag v&lt;workspace version&gt;]
  T -->|No| B[Build matrices]
  V --> B
  B --> A[Wheel, sdist, and CLI artifacts]
  A --> R{Release event?}
  R -->|Yes| U[Publish to PyPI or GitHub Release]
  R -->|No| S[Stop after build]
```

<sub>Reviews (1): Last reviewed commit: ["fix: gate RetroCast v0.8.3 releases"](https://github.com/ischemist/project-procrustes/commit/ecf76e5841c6ffde1f9203e9fb52e77242eaf1e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49955252)</sub>

**Context used:**

- Knowledge Base — [Rust Core (retrocast-rs)](https://app.greptile.com/ischemist/-/custom-context/knowledge-base/ischemist/project-procrustes/-/docs/rust-core.md)

<!-- /greptile_comment -->